### PR TITLE
Add Web Channel for arbitrary Durable Objects

### DIFF
--- a/.changeset/bright-webs-chat.md
+++ b/.changeset/bright-webs-chat.md
@@ -1,0 +1,12 @@
+---
+"@cloudflare/channels": minor
+---
+
+Add a Web Channel for arbitrary Durable Objects. It speaks the AIChatAgent
+browser protocol using an owned WebSockets capability, dispatches incoming
+turns through `ChannelHost.onMessage`, and streams `ChannelChunk`s back as AI SDK
+UI message chunks.
+
+Push-based Channels can now bind live ingress to the Host's normal routing and
+dispatch path. `consumeChunks` also accepts an `AbortSignal` so transports can
+cancel active generation safely.

--- a/.changeset/pink-poems-brake.md
+++ b/.changeset/pink-poems-brake.md
@@ -1,0 +1,30 @@
+---
+"@cloudflare/channels": minor
+---
+
+Stream outbound messages.
+
+`host.stream(surface, chunks, options?)` takes a
+`ReadableStream<ChannelChunk>` and resolves one `DeliveryResult`. Channels that
+can stream consume the stream themselves; Channels that cannot never learn it
+was a stream, because the Host collects the answer and calls `deliver` once.
+
+- New `ChannelChunk` union covering `text`, `reasoning`, `tool`, and `source`,
+  plus an optional `stream` method on `Channel` and `OutboundResolver`.
+- New `consumeChunks` helper for Channel authors, which reads a stream to
+  completion and then finalizes exactly once, whether it closed or errored.
+- Slack streams through `chat.startStream` / `appendStream` / `stopStream`,
+  collecting into an ordinary message for top-level channels where Slack does
+  not support native streaming. Telegram previews with `sendMessageDraft`
+  before persisting the answer with `sendMessage`.
+- `fanout` tees the stream per destination; `fallback` buffers consumed chunks
+  and replays them to the next destination after a failure.
+- `toChannelChunks` maps an AI SDK `fullStream` onto `ChannelChunk`.
+- `DeliveryResult`'s `uncertain` arm gains an optional `reference`, and the
+  three statuses are now defined by what the reader received rather than by
+  what the transport accepted. A stream that ends before its answer is complete
+  is `uncertain`.
+
+Slack reply surfaces derived from ingress now carry `recipientUserId` and
+`recipientTeamId` for non-direct messages, which Slack requires to stream into
+a channel.

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -5,6 +5,7 @@
   "experimentalSortPackageJson": false,
   "ignorePatterns": [
     "packages/agents/CHANGELOG.md",
+    "packages/channels/live-tests/snapshots",
     "site/agents/.astro",
     "**/routeTree.gen.ts",
     "**/think.d.ts"

--- a/packages/channels/README.md
+++ b/packages/channels/README.md
@@ -147,6 +147,47 @@ export default {
 Each Channel authenticates its own input and declines what isn't its business,
 so the Host asks them in configuration order and the first to claim it wins.
 
+### Web chat from any Durable Object
+
+The Web Channel speaks the same browser protocol as `AIChatAgent` without
+requiring the Durable Object to extend `Agent`. It is an ordinary Channel that
+uses an owned WebSockets capability; install that capability into Lifecycle and
+handle its normalized messages through the Host:
+
+```typescript
+import { DurableObject } from "cloudflare:workers";
+import { Lifecycle } from "agents/lifecycle";
+import { ChannelHost, type ChannelInboundMessage } from "@cloudflare/channels";
+import { toChannelChunks } from "@cloudflare/channels/ai-sdk";
+import { web } from "@cloudflare/channels/web";
+import { streamText } from "ai";
+
+export class Chat extends DurableObject<Env> {
+  readonly web = web();
+  readonly channels = new ChannelHost({
+    channels: { web: this.web },
+    onMessage: ({ message }) => this.onMessage(message)
+  });
+  readonly lifecycle = Lifecycle.install(this).use(this.web.webSockets);
+
+  async onMessage(message: ChannelInboundMessage) {
+    const result = streamText({
+      model: this.env.MODEL,
+      prompt: message.message.text
+    });
+    await this.channels.stream(
+      message.replySurface!,
+      toChannelChunks(result.fullStream)
+    );
+  }
+}
+```
+
+The current compatibility layer converts neutral `ChannelChunk`s into AI SDK
+UI message chunks. Live cancellation is supported, while durable stream replay
+is intentionally not yet implemented; reconnecting clients receive an idle
+resume response.
+
 ### Routing
 
 A Channel's `route` turns one normalized event into an opaque application

--- a/packages/channels/README.md
+++ b/packages/channels/README.md
@@ -297,7 +297,7 @@ Durability is a property of how your application uses it.
 | ----------------------------------------------------------------------- | --------------------------------------------------------------------------- |
 | A `dispatchId` stable across redelivery and unaffected by routing       | Deduplicate on it before starting any side effect                           |
 | The Host awaits your callback before the provider is acknowledged       | Hand off durably before returning — a DO RPC, queue send, or workflow start |
-| One provider attempt per `deliver()`, reported honestly                 | Decide whether to retry; `uncertain` may duplicate a real delivery          |
+| One outbound attempt per `deliver()` or `stream()`, reported honestly   | Decide whether to retry; `uncertain` may duplicate a real delivery          |
 | Surfaces are plain JSON you can persist                                 | Keep configured channel keys stable                                         |
 | Decisions arrive as normalized events carrying your own `interactionId` | Own settlement; an interaction id is not an authorization credential        |
 
@@ -305,8 +305,10 @@ Durability is a property of how your application uses it.
 
 - [ ] Approval-link ingress: signing, verification, and a confirmation page, so
       link approvals return through the same normalized path as Slack buttons
-- [ ] Streaming output delivery — see
-      [`design/rfc-channel-streaming.md`](../../design/rfc-channel-streaming.md)
+- [ ] Reader-initiated stream cancellation: Slack's `message_stream_stopped`
+      and Telegram's `stopped_message_generation` should reach the running
+      generation as ordinary ingress, so aborting it errors the stream and
+      each Channel finalizes on the path it already has
 - [ ] More built-in channels
 - [ ] Rendering templates (pretty emails)
 - [ ] Automatic webhook registration

--- a/packages/channels/live-tests/README.md
+++ b/packages/channels/live-tests/README.md
@@ -1,8 +1,9 @@
 # Live delivery tests
 
-This local-only test calls the real `telegram()`, `slack()`, and `email()`
-adapters, then reads each destination through an independent provider API. It
-is not part of normal package tests, Nx affected tests, or CI.
+These local-only tests call the real `telegram()`, `slack()`, and `email()`
+adapters through `ChannelHost`, then read each destination through an independent
+provider API. They are not part of normal package tests, Nx affected tests, or
+CI.
 
 The configured destinations must be disposable. The test deletes their messages
 before and after delivery. Telegram's immutable chat/channel creation service
@@ -28,6 +29,16 @@ Telegram observation uses a non-bot Teleproto `StringSession`. Slack needs
 email sender needs Cloudflare Email Service access; Fastmail supplies independent
 JMAP observation and deletion.
 
+Slack live streaming posts a disposable anchor and streams its thread reply. It
+also needs the reader's user and team ids; the binding derives them from
+`auth.test` and the one channel member that is not this bot, so no extra
+configuration or scope is needed.
+
+Telegram only shows drafts in private chats. Point
+`CHANNELS_LIVE_TELEGRAM_CHAT_ID` at a private chat with the bot to exercise the
+draft path. A group still receives the terminal message, but cannot prove that
+streaming previews reached a reader.
+
 ## Run
 
 ```sh
@@ -39,7 +50,3 @@ Run one provider with Vitest's name filter:
 ```sh
 pnpm --filter @cloudflare/channels test:live -t telegram
 ```
-
-Each test sends `Cloudflare Channels live delivery smoke test.`, polls once per
-second for up to two minutes, waits five more seconds for duplicates, and
-snapshots the exact observed `[{ text }]` array.

--- a/packages/channels/live-tests/README.md
+++ b/packages/channels/live-tests/README.md
@@ -1,6 +1,6 @@
 # Live delivery tests
 
-These local-only tests call the real `telegram()`, `slack()`, and `email()`
+These local-only tests call the real `telegram()`, `slack()`, `email()`, and `web()`
 adapters through `ChannelHost`, then read each destination through an independent
 provider API. They are not part of normal package tests, Nx affected tests, or
 CI.
@@ -23,6 +23,8 @@ Set these variables in an uncommitted environment file or the shell:
   `CHANNELS_LIVE_FASTMAIL_API_TOKEN`,
   `CHANNELS_LIVE_CLOUDFLARE_ACCOUNT_ID`,
   `CHANNELS_LIVE_CLOUDFLARE_API_TOKEN`
+- Web: `CHANNELS_LIVE_WEB_URL` and, for a deployed fixture,
+  `CHANNELS_LIVE_WEB_TOKEN`
 
 Telegram observation uses a non-bot Teleproto `StringSession`. Slack needs
 `chat:write`, `channels:history`, and membership in the configured channel. The
@@ -39,6 +41,12 @@ Telegram only shows drafts in private chats. Point
 draft path. A group still receives the terminal message, but cannot prove that
 streaming previews reached a reader.
 
+The Web binding observes the destination through a real
+`WebSocketChatTransport`. A separate non-hibernating Cap'n Web session drives
+the fixture Durable Object's `ChannelHost`, keeping each streamed delivery on
+one live object instance. The fixture persists only the reply surface; each test
+uses a fresh object name and clears it afterward.
+
 ## Run
 
 ```sh
@@ -50,3 +58,27 @@ Run one provider with Vitest's name filter:
 ```sh
 pnpm --filter @cloudflare/channels test:live -t telegram
 ```
+
+For a local Web run, start the fixture and test it from separate terminals:
+
+```sh
+pnpm --filter @cloudflare/channels dev:live:web
+```
+
+```sh
+CHANNELS_LIVE_WEB_URL=http://127.0.0.1:8799 \
+  pnpm --filter @cloudflare/channels test:live -t web
+```
+
+To use a deployed fixture, configure its token and deploy the worker, then set
+the matching URL and token in the test environment:
+
+```sh
+pnpm exec wrangler secret put LIVE_TEST_TOKEN \
+  --config packages/channels/live-tests/web/wrangler.jsonc
+pnpm exec wrangler deploy \
+  --config packages/channels/live-tests/web/wrangler.jsonc
+```
+
+The worker accepts tokenless requests only on localhost. Do not commit the
+token or an environment file containing it.

--- a/packages/channels/live-tests/binding.ts
+++ b/packages/channels/live-tests/binding.ts
@@ -2,7 +2,13 @@ import type { ChannelChunk, DeliveryResult } from "../src/channel";
 import type { ChannelHost } from "../src/host";
 import type { ChannelMessageSurface } from "../src/surface";
 
-export type ObservedMessage = { text: string };
+export type ObservedMessage = {
+  text: string;
+  [key: string]: unknown;
+};
+
+/** The outbound Host surface exercised by every live delivery scenario. */
+export type LiveDeliveryHost = Pick<ChannelHost, "deliver" | "stream">;
 
 export type LiveStreamSession = {
   push(chunk: ChannelChunk): Promise<void>;
@@ -12,9 +18,9 @@ export type LiveStreamSession = {
 };
 
 export type LiveDeliveryBinding = {
-  name: "telegram" | "slack" | "slack-thread" | "email";
+  name: "telegram" | "slack" | "slack-thread" | "email" | "web";
   destination: string;
-  host: ChannelHost;
+  host: LiveDeliveryHost;
   surface: ChannelMessageSurface;
   /** Initialize the observer and start from an empty destination. */
   open(): Promise<void>;

--- a/packages/channels/live-tests/binding.ts
+++ b/packages/channels/live-tests/binding.ts
@@ -1,11 +1,26 @@
+import type { ChannelChunk, DeliveryResult } from "../src/channel";
+import type { ChannelHost } from "../src/host";
+import type { ChannelMessageSurface } from "../src/surface";
+
 export type ObservedMessage = { text: string };
 
+export type LiveStreamSession = {
+  push(chunk: ChannelChunk): Promise<void>;
+  finish(): Promise<DeliveryResult>;
+  /** End the stream the way a failed generation does. */
+  fail(reason: string): Promise<DeliveryResult>;
+};
+
 export type LiveDeliveryBinding = {
-  name: "telegram" | "slack" | "email";
+  name: "telegram" | "slack" | "slack-thread" | "email";
   destination: string;
-  open?(): Promise<void>;
+  host: ChannelHost;
+  surface: ChannelMessageSurface;
+  /** Initialize the observer and start from an empty destination. */
+  open(): Promise<void>;
   clear(): Promise<void>;
-  deliver(text: string): Promise<unknown>;
+  /** Provider-side evidence that an ephemeral preview reached the reader. */
+  previews?(): number;
   read(): Promise<ObservedMessage[]>;
   close?(): Promise<void>;
 };

--- a/packages/channels/live-tests/bindings/email.ts
+++ b/packages/channels/live-tests/bindings/email.ts
@@ -1,9 +1,11 @@
+import { execFileSync } from "node:child_process";
 import {
   email,
   type ChannelEmailMessage,
   type EmailSendBinding
 } from "../../src/adapters/email/email";
 import type { ChannelMessageSurface } from "../../src/surface";
+import { ChannelHost } from "../../src/host";
 import {
   requiredEnv,
   type LiveDeliveryBinding,
@@ -12,6 +14,26 @@ import {
 
 const CORE = "urn:ietf:params:jmap:core";
 const MAIL = "urn:ietf:params:jmap:mail";
+
+function wranglerAuthToken(): string {
+  try {
+    const output = execFileSync("pnpm", ["exec", "wrangler", "auth", "token"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"]
+    });
+    const token = output
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .at(-1);
+    if (!token) throw new Error("Wrangler returned an empty token");
+    return token;
+  } catch {
+    throw new Error(
+      "Could not obtain a Cloudflare API token from Wrangler. Run `pnpm exec wrangler login` before the email live tests."
+    );
+  }
+}
 
 type FastmailSession = { apiUrl: string; accountId: string };
 type FastmailEmail = {
@@ -94,9 +116,10 @@ export function emailBinding(): LiveDeliveryBinding {
     from,
     binding: cloudflareBinding(
       requiredEnv("CHANNELS_LIVE_CLOUDFLARE_ACCOUNT_ID"),
-      requiredEnv("CHANNELS_LIVE_CLOUDFLARE_API_TOKEN")
+      wranglerAuthToken()
     )
   });
+  const host = new ChannelHost({ channels: { email: channel } });
   const surface: ChannelMessageSurface = {
     channelKey: "email",
     version: 1,
@@ -113,6 +136,16 @@ export function emailBinding(): LiveDeliveryBinding {
         limit: 100
       })
     ).ids;
+  }
+
+  async function clear(): Promise<void> {
+    const emailIds = await ids();
+    if (emailIds.length > 0) {
+      await jmap(fastmailToken, session, "Email/set", {
+        accountId: session.accountId,
+        destroy: emailIds
+      });
+    }
   }
 
   async function messages(): Promise<FastmailEmail[]> {
@@ -135,22 +168,15 @@ export function emailBinding(): LiveDeliveryBinding {
 
   return {
     name: "email",
+    host,
+    surface,
     destination: `email inbox ${to}`,
     async open() {
       session = await openFastmail(fastmailToken);
+      await clear();
     },
-    async clear() {
-      const emailIds = await ids();
-      if (emailIds.length > 0) {
-        await jmap(fastmailToken, session, "Email/set", {
-          accountId: session.accountId,
-          destroy: emailIds
-        });
-      }
-    },
-    async deliver(text) {
-      return await channel.deliver!(surface, { markdown: text });
-    },
+    clear,
+
     async read(): Promise<ObservedMessage[]> {
       return (await messages()).map((message) => {
         const partId = message.textBody[0].partId;

--- a/packages/channels/live-tests/bindings/slack.ts
+++ b/packages/channels/live-tests/bindings/slack.ts
@@ -1,4 +1,5 @@
 import { slack } from "../../src/adapters/slack";
+import { ChannelHost } from "../../src/host";
 import type { ChannelMessageSurface } from "../../src/surface";
 import {
   requiredEnv,
@@ -6,10 +7,19 @@ import {
   type ObservedMessage
 } from "../binding";
 
-type SlackMessage = { ts: string; text: string };
+type SlackMessage = {
+  ts: string;
+  text: string;
+  reply_count?: number;
+  subtype?: string;
+};
 type SlackResponse = {
   ok: boolean;
   error?: string;
+  ts?: string;
+  team_id?: string;
+  user_id?: string;
+  members?: string[];
   messages?: SlackMessage[];
 };
 
@@ -31,11 +41,13 @@ async function slackApi(
   return payload;
 }
 
-export function slackBinding(): LiveDeliveryBinding {
+function createSlackBinding(threaded: boolean): LiveDeliveryBinding {
   const token = requiredEnv("CHANNELS_LIVE_SLACK_BOT_TOKEN");
   const channelId = requiredEnv("CHANNELS_LIVE_SLACK_CHANNEL_ID");
   const channel = slack({ botToken: token });
-  const surface: ChannelMessageSurface = {
+  const host = new ChannelHost({ channels: { slack: channel } });
+  let anchorTs: string | undefined;
+  let surface: ChannelMessageSurface = {
     channelKey: "slack",
     version: 1,
     address: { channelId },
@@ -47,25 +59,102 @@ export function slackBinding(): LiveDeliveryBinding {
       channel: channelId,
       limit: "100"
     });
-    return result.messages ?? [];
+    const history = result.messages ?? [];
+    const observed: SlackMessage[] = [];
+    for (const message of history) {
+      observed.push(message);
+      if (!message.reply_count) continue;
+      const thread = await slackApi(token, "conversations.replies", {
+        channel: channelId,
+        ts: message.ts,
+        limit: "100"
+      });
+      observed.push(
+        ...(thread.messages ?? []).filter((reply) => reply.ts !== message.ts)
+      );
+    }
+    return observed;
   }
 
-  return {
-    name: "slack",
-    destination: `Slack channel ${channelId}`,
-    async clear() {
-      for (const message of await messages()) {
+  async function clear(): Promise<void> {
+    // Replies must be deleted before their parent. Slack may retain thread
+    // tombstones after deletion; those are not messages the bot can delete.
+    for (const message of (await messages()).reverse()) {
+      if (message.subtype === "message_deleted") continue;
+      try {
         await slackApi(token, "chat.delete", {
           channel: channelId,
           ts: message.ts
         });
+      } catch (error) {
+        if (
+          error instanceof Error &&
+          error.message.includes("message_not_found")
+        ) {
+          continue;
+        }
+        throw error;
       }
+    }
+  }
+
+  return {
+    name: threaded ? "slack-thread" : "slack",
+    host,
+    get surface() {
+      return surface;
     },
-    async deliver(text) {
-      return await channel.deliver!(surface, { markdown: text });
+    destination: threaded
+      ? `Slack thread in channel ${channelId}`
+      : `Slack channel ${channelId}`,
+    async open() {
+      await clear();
+      if (!threaded) return;
+
+      // Native channel streaming needs a thread and the intended reader.
+      const identity = await slackApi(token, "auth.test", {});
+      const members = await slackApi(token, "conversations.members", {
+        channel: channelId,
+        limit: "100"
+      });
+      const recipientUserId = (members.members ?? []).find(
+        (member) => member !== identity.user_id
+      );
+      if (!recipientUserId) {
+        throw new Error(
+          `Slack channel ${channelId} has no member besides this bot to stream to`
+        );
+      }
+      const anchor = await slackApi(token, "chat.postMessage", {
+        channel: channelId,
+        text: "Cloudflare Channels live streaming thread."
+      });
+      anchorTs = anchor.ts;
+      surface = {
+        ...surface,
+        address: {
+          channelId,
+          threadTs: anchorTs!,
+          recipientUserId,
+          recipientTeamId: identity.team_id!
+        }
+      };
     },
+    clear,
     async read(): Promise<ObservedMessage[]> {
-      return (await messages()).map(({ text }) => ({ text }));
+      return (await messages())
+        .filter((message) => message.ts !== anchorTs)
+        .map(({ text }) => ({ text }));
     }
   };
+}
+
+/** A top-level Slack channel destination. Streams collect and deliver once. */
+export function slackBinding(): LiveDeliveryBinding {
+  return createSlackBinding(false);
+}
+
+/** A Slack thread destination that exercises Slack's native streaming API. */
+export function slackThreadBinding(): LiveDeliveryBinding {
+  return createSlackBinding(true);
 }

--- a/packages/channels/live-tests/bindings/telegram.ts
+++ b/packages/channels/live-tests/bindings/telegram.ts
@@ -2,6 +2,7 @@ import { TelegramClient } from "teleproto";
 import { StringSession } from "teleproto/sessions";
 import { telegram } from "../../src/adapters/telegram";
 import type { ChannelMessageSurface } from "../../src/surface";
+import { ChannelHost } from "../../src/host";
 import {
   requiredEnv,
   type LiveDeliveryBinding,
@@ -13,18 +14,55 @@ const creationActions = new Set([
   "MessageActionChatCreate"
 ]);
 
+/** The raw MTProto update that carries a bot's draft to the reader's client. */
+type TypingUpdate = {
+  className?: string;
+  userId?: unknown;
+  action?: { className?: string };
+};
+
+/** Recover the bot's own user id from its BotFather token prefix. */
+function botUserId(botToken: string): number {
+  const id = Number(botToken.match(/^(\d+):/)?.[1]);
+  if (!Number.isSafeInteger(id) || id <= 0) {
+    throw new Error("Could not read a bot user id from the Telegram bot token");
+  }
+  return id;
+}
+
 export function telegramBinding(): LiveDeliveryBinding {
   const chatId = requiredEnv("CHANNELS_LIVE_TELEGRAM_CHAT_ID");
   const numericChatId = Number(chatId);
+  if (!Number.isSafeInteger(numericChatId) || numericChatId <= 0) {
+    throw new Error(
+      "Telegram streaming live tests require a private-chat user ID; groups and channels discard sendMessageDraft previews"
+    );
+  }
+  const botToken = requiredEnv("CHANNELS_LIVE_TELEGRAM_BOT_TOKEN");
+  /**
+   * The two sides of a direct message address it by different ids: the bot
+   * sends to the user's id, while the observing user session reads the chat
+   * named by the bot's id. They coincide only for groups and channels.
+   *
+   * Getting this wrong is destructive rather than merely wrong, because the
+   * user's own id names Saved Messages, and `clear()` revokes everything it
+   * finds. `open()` refuses to proceed unless the target is the intended one.
+   */
+  const observedChatId = botUserId(botToken);
   const client = new TelegramClient(
     new StringSession(requiredEnv("CHANNELS_LIVE_TELEGRAM_SESSION")),
     Number(requiredEnv("CHANNELS_LIVE_TELEGRAM_API_ID")),
     requiredEnv("CHANNELS_LIVE_TELEGRAM_API_HASH"),
     { connectionRetries: 3 }
   );
-  const channel = telegram({
-    botToken: requiredEnv("CHANNELS_LIVE_TELEGRAM_BOT_TOKEN")
-  });
+  const channel = telegram({ botToken });
+  const botId = botUserId(botToken);
+  // Telegram surfaces a bot's draft to the recipient's client as a typing
+  // update with its own action, distinct from an ordinary typing indicator.
+  // Counting those is the only positive evidence available that a preview
+  // reached the reader, since the Bot API cannot read back its own draft.
+  let previews = 0;
+  const host = new ChannelHost({ channels: { telegram: channel } });
   const surface: ChannelMessageSurface = {
     channelKey: "telegram",
     version: 1,
@@ -34,7 +72,7 @@ export function telegramBinding(): LiveDeliveryBinding {
 
   async function messages() {
     return Array.from(
-      await client.getMessages(numericChatId, { limit: undefined })
+      await client.getMessages(observedChatId, { limit: undefined })
     );
   }
 
@@ -44,25 +82,51 @@ export function telegramBinding(): LiveDeliveryBinding {
     return creationActions.has(message.action?.className ?? "");
   }
 
+  async function clear(): Promise<void> {
+    const deletable = (await messages()).filter(
+      (message) => !isCreationMessage(message)
+    );
+    if (deletable.length > 0) {
+      await client.deleteMessages(observedChatId, deletable, {
+        revoke: true
+      });
+    }
+  }
+
   return {
     name: "telegram",
+    host,
+    surface,
     destination: `Telegram chat ${chatId}`,
     async open() {
       await client.connect();
+      client.addEventHandler((update: TypingUpdate) => {
+        if (
+          update?.className === "UpdateUserTyping" &&
+          update.action?.className === "SendMessageTextDraftAction" &&
+          Number(update.userId) === botId
+        ) {
+          previews += 1;
+        }
+      });
       await client.getDialogs({ folder: 0 });
-      await client.getEntity(numericChatId);
-    },
-    async clear() {
-      const deletable = (await messages()).filter(
-        (message) => !isCreationMessage(message)
-      );
-      if (deletable.length > 0) {
-        await client.deleteMessages(numericChatId, deletable, { revoke: true });
+      const sessionUserId = Number((await client.getMe()).id);
+      if (observedChatId === sessionUserId) {
+        throw new Error(
+          "Refusing to run: the observed chat is this account's Saved Messages, whose contents clear() would revoke"
+        );
       }
+      if (numericChatId !== sessionUserId) {
+        throw new Error(
+          `Refusing to run: the bot would send to user ${numericChatId}, but the observing session is user ${sessionUserId}, so the test would read a different conversation`
+        );
+      }
+      await client.getEntity(observedChatId);
+      await clear();
+      previews = 0;
     },
-    async deliver(text) {
-      return await channel.deliver!(surface, { markdown: text });
-    },
+    clear,
+    previews: () => previews,
     async read(): Promise<ObservedMessage[]> {
       return (await messages()).flatMap((message) =>
         typeof message.message === "string" ? [{ text: message.message }] : []

--- a/packages/channels/live-tests/bindings/web.ts
+++ b/packages/channels/live-tests/bindings/web.ts
@@ -1,0 +1,246 @@
+import type { UIMessageChunk } from "ai";
+import { WebSocketChatTransport } from "agents/chat/transport";
+import { newWebSocketRpcSession, type RpcStub } from "capnweb";
+import type {
+  ChannelChunk,
+  ChannelDeliveryOptions,
+  ChannelMessage,
+  ChannelStreamOptions,
+  DeliveryResult
+} from "../../src/channel";
+import type { ChannelMessageSurface } from "../../src/surface";
+import {
+  requiredEnv,
+  type LiveDeliveryBinding,
+  type LiveDeliveryHost,
+  type ObservedMessage
+} from "../binding";
+
+type WebObservation = {
+  text: string;
+  reasoning: string[];
+  sources: Array<{ url: string; title?: string }>;
+  error?: string;
+};
+
+type StreamHandle = { id: string };
+
+type WebLiveControl = {
+  surface(): Promise<ChannelMessageSurface | null>;
+  deliver(
+    surface: ChannelMessageSurface,
+    message: ChannelMessage,
+    options?: ChannelDeliveryOptions
+  ): Promise<DeliveryResult>;
+  startStream(
+    surface: ChannelMessageSurface,
+    options?: ChannelStreamOptions
+  ): Promise<StreamHandle>;
+  push(id: string, chunk: ChannelChunk): Promise<void>;
+  finish(id: string): Promise<DeliveryResult>;
+  fail(id: string, reason: string): Promise<DeliveryResult>;
+  clear(): Promise<void>;
+};
+
+function webSocketUrl(url: URL): string {
+  const socket = new URL(url);
+  socket.protocol = socket.protocol === "https:" ? "wss:" : "ws:";
+  return socket.toString();
+}
+
+function callablesUrl(url: URL): string {
+  const socket = new URL(webSocketUrl(url));
+  socket.searchParams.set("__agents_rpc", "capnweb");
+  return socket.toString();
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function waitForOpen(socket: WebSocket): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(
+      () => reject(new Error("Timed out opening the Web live-test socket")),
+      30_000
+    );
+    socket.addEventListener(
+      "open",
+      () => {
+        clearTimeout(timeout);
+        resolve();
+      },
+      { once: true }
+    );
+    socket.addEventListener(
+      "error",
+      () => {
+        clearTimeout(timeout);
+        reject(new Error("Failed to open the Web live-test socket"));
+      },
+      { once: true }
+    );
+  });
+}
+
+/** Apply the AI SDK chunks observed by the real browser transport. */
+function observeChunk(
+  observation: WebObservation,
+  chunk: UIMessageChunk
+): void {
+  switch (chunk.type) {
+    case "text-delta":
+      observation.text += chunk.delta;
+      return;
+    case "reasoning-delta": {
+      const index = observation.reasoning.length - 1;
+      if (index < 0) observation.reasoning.push(chunk.delta);
+      else observation.reasoning[index] += chunk.delta;
+      return;
+    }
+    case "reasoning-start":
+      observation.reasoning.push("");
+      return;
+    case "source-url":
+      observation.sources.push({
+        url: chunk.url,
+        ...(chunk.title !== undefined && { title: chunk.title })
+      });
+      return;
+    default:
+      return;
+  }
+}
+
+/**
+ * A live Web destination backed by a deployed bare Durable Object fixture.
+ * The chat socket is the independent observer; a non-hibernating Cap'n Web
+ * session makes the fixture's real ChannelHost perform each operation.
+ */
+export function webBinding(): LiveDeliveryBinding {
+  const fixtureUrl = new URL(requiredEnv("CHANNELS_LIVE_WEB_URL"));
+  const token = process.env.CHANNELS_LIVE_WEB_TOKEN;
+  const objectName = `channels-live-${crypto.randomUUID()}`;
+  let surface: ChannelMessageSurface | undefined;
+  let socket: WebSocket | undefined;
+  let control: RpcStub<WebLiveControl> | undefined;
+  let observation: WebObservation | undefined;
+  let observing: Promise<void> | undefined;
+
+  function url(path: string): URL {
+    const result = new URL(fixtureUrl);
+    result.pathname = `${result.pathname.replace(/\/$/, "")}${path}`;
+    result.searchParams.set("name", objectName);
+    if (token) result.searchParams.set("token", token);
+    return result;
+  }
+
+  function rpc(): RpcStub<WebLiveControl> {
+    if (!control) throw new Error("Web live-test control plane is not open");
+    return control;
+  }
+
+  const host: LiveDeliveryHost = {
+    deliver(
+      destination: ChannelMessageSurface,
+      message: ChannelMessage,
+      options?: ChannelDeliveryOptions
+    ) {
+      return rpc().deliver(destination, message, options);
+    },
+
+    async stream(
+      destination: ChannelMessageSurface,
+      chunks: ReadableStream<ChannelChunk>,
+      options?: ChannelStreamOptions
+    ): Promise<DeliveryResult> {
+      const handle = await rpc().startStream(destination, options);
+      const reader = chunks.getReader();
+      try {
+        while (true) {
+          const next = await reader.read();
+          if (next.done) break;
+          await rpc().push(handle.id, next.value);
+        }
+      } catch (error) {
+        return rpc().fail(handle.id, errorText(error));
+      } finally {
+        reader.releaseLock();
+      }
+      return rpc().finish(handle.id);
+    }
+  };
+
+  return {
+    name: "web",
+    destination: fixtureUrl.toString(),
+    host,
+    get surface() {
+      if (!surface) throw new Error("Web live-test destination is not open");
+      return surface;
+    },
+    async open() {
+      const chatUrl = url("/chat");
+      control = newWebSocketRpcSession<WebLiveControl>(callablesUrl(chatUrl));
+      socket = new WebSocket(webSocketUrl(chatUrl));
+      await waitForOpen(socket);
+      const transport = new WebSocketChatTransport({ agent: socket });
+      const chunks = await transport.sendMessages({
+        chatId: objectName,
+        messages: [
+          {
+            id: crypto.randomUUID(),
+            role: "user",
+            parts: [{ type: "text", text: "Open live-test destination" }]
+          }
+        ],
+        abortSignal: undefined,
+        trigger: "submit-message"
+      });
+
+      observation = { text: "", reasoning: [], sources: [] };
+      observing = (async () => {
+        try {
+          for await (const chunk of chunks) {
+            observeChunk(observation!, chunk);
+          }
+        } catch (error) {
+          observation!.error = errorText(error);
+        }
+      })();
+
+      const deadline = Date.now() + 30_000;
+      while (Date.now() < deadline) {
+        const captured = await rpc().surface();
+        if (captured) {
+          surface = captured;
+          return;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      }
+      throw new Error("Web live-test fixture did not capture a reply surface");
+    },
+    async clear() {
+      await rpc().clear();
+      observation = undefined;
+      surface = undefined;
+    },
+    async read(): Promise<ObservedMessage[]> {
+      if (!observation) return [];
+      const message: ObservedMessage = { text: observation.text };
+      if (observation.reasoning.some(Boolean)) {
+        message.reasoning = observation.reasoning.filter(Boolean);
+      }
+      if (observation.sources.length > 0) {
+        message.sources = observation.sources;
+      }
+      if (observation.error !== undefined) message.error = observation.error;
+      return message.text || Object.keys(message).length > 1 ? [message] : [];
+    },
+    async close() {
+      socket?.close(1000, "live test complete");
+      control?.[Symbol.dispose]();
+      await observing?.catch(() => {});
+    }
+  };
+}

--- a/packages/channels/live-tests/delivery.test.ts
+++ b/packages/channels/live-tests/delivery.test.ts
@@ -1,52 +1,35 @@
-import { describe, expect, test } from "vitest";
-import { emailBinding } from "./bindings/email";
-import { slackBinding } from "./bindings/slack";
-import { telegramBinding } from "./bindings/telegram";
+import { expect, test } from "vitest";
+import { readUntil, uniqueText, withDestination } from "./helpers";
+import { providers } from "./providers";
 
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
-const providers = [
-  ["telegram", telegramBinding],
-  ["slack", slackBinding],
-  ["email", emailBinding]
-] as const;
-
-describe("live channel delivery", () => {
-  test.each(providers)("delivers through %s", async (_name, create) => {
-    const channel = create();
-    console.info(`[${channel.name}] clearing ${channel.destination}`);
-    await channel.open?.();
-
-    try {
-      await channel.clear();
-      expect(await channel.read()).toEqual([]);
-
-      const result = await channel.deliver(
-        "Cloudflare Channels live delivery smoke test."
-      );
-      console.info(`[${channel.name}] ${JSON.stringify(result)}`);
-
-      let messages = [];
-      const deadline = Date.now() + 120_000;
-      while (messages.length === 0 && Date.now() < deadline) {
-        await sleep(1_000);
-        messages = await channel.read();
-      }
-      expect(messages.length).toBeGreaterThan(0);
-
-      await sleep(5_000);
-      messages = await channel.read();
-      console.info(`[${channel.name}] observed ${JSON.stringify(messages)}`);
-      await expect(
-        `${JSON.stringify(messages, null, 2)}\n`
-      ).toMatchFileSnapshot(`./snapshots/${channel.name}.json`);
-    } finally {
-      try {
-        await channel.clear();
-        expect(await channel.read()).toEqual([]);
-      } finally {
-        await channel.close?.();
-      }
-    }
+test.each(providers)("delivers through %s", async (_name, create) => {
+  await withDestination(create, async (channel) => {
+    const text = "Cloudflare Channels live delivery smoke test.";
+    const result = await channel.host.deliver(channel.surface, {
+      markdown: uniqueText(text)
+    });
+    console.info(`[${channel.name}] ${JSON.stringify(result)}`);
+    expect(result.status).toBe("delivered");
+    await expect(
+      `${JSON.stringify(await readUntil(channel, text), null, 2)}\n`
+    ).toMatchFileSnapshot(`./snapshots/${channel.name}.json`);
   });
 });
+
+test.each(providers)(
+  "delivers rich content through %s",
+  async (_name, create) => {
+    await withDestination(create, async (channel) => {
+      const result = await channel.host.deliver(channel.surface, {
+        title: "Live rich delivery",
+        markdown: uniqueText(
+          "Rich delivery with **bold text**, [a link](https://example.com), and `code`."
+        )
+      });
+      expect(result.status).toBe("delivered");
+      await expect(
+        `${JSON.stringify(await readUntil(channel, "Rich delivery"), null, 2)}\n`
+      ).toMatchFileSnapshot(`./snapshots/${channel.name}-rich.json`);
+    });
+  }
+);

--- a/packages/channels/live-tests/helpers.ts
+++ b/packages/channels/live-tests/helpers.ts
@@ -18,8 +18,9 @@ export function uniqueText(text: string): string {
 export async function readObserved(
   channel: LiveDeliveryBinding
 ): Promise<ObservedMessage[]> {
-  return (await channel.read()).map((message) => ({
-    text: message.text.replaceAll(RUN_MARKER, "")
+  return (await channel.read()).map(({ text, ...observation }) => ({
+    text: text.replaceAll(RUN_MARKER, ""),
+    ...observation
   }));
 }
 

--- a/packages/channels/live-tests/helpers.ts
+++ b/packages/channels/live-tests/helpers.ts
@@ -1,0 +1,110 @@
+import { expect } from "vitest";
+import type { ChannelChunk, DeliveryResult } from "../src/channel";
+import type {
+  LiveDeliveryBinding,
+  LiveStreamSession,
+  ObservedMessage
+} from "./binding";
+
+const SETTLE_MS = 3_000;
+const OBSERVATION_TIMEOUT_MS = 240_000;
+const RUN_MARKER = `[channels-live:${crypto.randomUUID()}] `;
+
+/** Keep repeated live runs distinct to providers that deduplicate traffic. */
+export function uniqueText(text: string): string {
+  return `${RUN_MARKER}${text}`;
+}
+
+export async function readObserved(
+  channel: LiveDeliveryBinding
+): Promise<ObservedMessage[]> {
+  return (await channel.read()).map((message) => ({
+    text: message.text.replaceAll(RUN_MARKER, "")
+  }));
+}
+
+/** Run one scenario against an empty destination and leave it empty. */
+export async function withDestination(
+  create: () => LiveDeliveryBinding,
+  run: (channel: LiveDeliveryBinding) => Promise<void>
+): Promise<void> {
+  const channel = create();
+  await channel.open();
+  try {
+    expect(await readObserved(channel)).toEqual([]);
+    await run(channel);
+  } finally {
+    try {
+      await channel.clear();
+      expect(await readObserved(channel)).toEqual([]);
+    } finally {
+      await channel.close?.();
+    }
+  }
+}
+
+/** Poll the destination until the expected text lands, or give up loudly. */
+export async function readUntil(
+  channel: LiveDeliveryBinding,
+  expected: string
+): Promise<ObservedMessage[]> {
+  const deadline = Date.now() + OBSERVATION_TIMEOUT_MS;
+  let messages: ObservedMessage[] = [];
+  while (Date.now() < deadline) {
+    messages = await readObserved(channel);
+    if (messages.some((message) => message.text.includes(expected))) break;
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+  expect(
+    messages.some((message) => message.text.includes(expected)),
+    `${channel.name} never showed ${JSON.stringify(expected)}`
+  ).toBe(true);
+  // Settle, so a duplicate or a late edit shows up in the snapshot. Return
+  // only this scenario's messages: Email Service may finish an earlier send
+  // after that scenario's cleanup has already run.
+  await new Promise((resolve) => setTimeout(resolve, 5_000));
+  return (await readObserved(channel)).filter((message) =>
+    message.text.includes(expected)
+  );
+}
+
+export async function snapshot(
+  channel: LiveDeliveryBinding,
+  scenario: string,
+  observed: unknown
+): Promise<void> {
+  console.info(`[${channel.name}] ${scenario} ${JSON.stringify(observed)}`);
+  await expect(`${JSON.stringify(observed, null, 2)}\n`).toMatchFileSnapshot(
+    `./snapshots/${channel.name}-${scenario}.json`
+  );
+}
+
+/** Drive one outbound stream by hand so tests can inspect intermediate state. */
+export function chunkPump(
+  run: (chunks: ReadableStream<ChannelChunk>) => Promise<DeliveryResult>
+): LiveStreamSession {
+  let controller!: ReadableStreamDefaultController<ChannelChunk>;
+  const chunks = new ReadableStream<ChannelChunk>({
+    start(streamController) {
+      controller = streamController;
+    }
+  });
+  const delivery = run(chunks);
+  // Keep an early rejection from surfacing before the test calls finish/fail.
+  delivery.catch(() => {});
+
+  return {
+    async push(chunk) {
+      controller.enqueue(chunk);
+      await new Promise((resolve) => setTimeout(resolve, SETTLE_MS));
+    },
+    finish() {
+      controller.close();
+      return delivery;
+    },
+    fail(reason) {
+      controller.error(new Error(reason));
+      return delivery;
+    }
+  };
+}

--- a/packages/channels/live-tests/providers.ts
+++ b/packages/channels/live-tests/providers.ts
@@ -1,0 +1,12 @@
+import type { LiveDeliveryBinding } from "./binding";
+import { emailBinding } from "./bindings/email";
+import { slackBinding, slackThreadBinding } from "./bindings/slack";
+import { telegramBinding } from "./bindings/telegram";
+
+/** Every destination shape must support both finished and streamed delivery. */
+export const providers = [
+  ["telegram", telegramBinding],
+  ["slack", slackBinding],
+  ["slack-thread", slackThreadBinding],
+  ["email", emailBinding]
+] as const satisfies readonly [string, () => LiveDeliveryBinding][];

--- a/packages/channels/live-tests/providers.ts
+++ b/packages/channels/live-tests/providers.ts
@@ -2,11 +2,13 @@ import type { LiveDeliveryBinding } from "./binding";
 import { emailBinding } from "./bindings/email";
 import { slackBinding, slackThreadBinding } from "./bindings/slack";
 import { telegramBinding } from "./bindings/telegram";
+import { webBinding } from "./bindings/web";
 
 /** Every destination shape must support both finished and streamed delivery. */
 export const providers = [
   ["telegram", telegramBinding],
   ["slack", slackBinding],
   ["slack-thread", slackThreadBinding],
-  ["email", emailBinding]
+  ["email", emailBinding],
+  ["web", webBinding]
 ] as const satisfies readonly [string, () => LiveDeliveryBinding][];

--- a/packages/channels/live-tests/snapshots/email-rich.json
+++ b/packages/channels/live-tests/snapshots/email-rich.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "Rich delivery with **bold text**, [a link](https://example.com), and `code`.\n\n"
+  }
+]

--- a/packages/channels/live-tests/snapshots/email-stream-interrupted.json
+++ b/packages/channels/live-tests/snapshots/email-stream-interrupted.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "The model started answering and then \n\n"
+  }
+]

--- a/packages/channels/live-tests/snapshots/email-stream-rich.json
+++ b/packages/channels/live-tests/snapshots/email-stream-rich.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "Rich streaming smoke test.\n\n"
+  }
+]

--- a/packages/channels/live-tests/snapshots/email-stream.json
+++ b/packages/channels/live-tests/snapshots/email-stream.json
@@ -1,0 +1,12 @@
+{
+  "duringStream": [
+    [],
+    [],
+    []
+  ],
+  "afterStream": [
+    {
+      "text": "Cloudflare Channels live streaming smoke test.\n\n"
+    }
+  ]
+}

--- a/packages/channels/live-tests/snapshots/slack-rich.json
+++ b/packages/channels/live-tests/snapshots/slack-rich.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "Live rich delivery\n\nRich delivery with **bold text**, [a link](<https://example.com>), and `code`."
+  }
+]

--- a/packages/channels/live-tests/snapshots/slack-stream-interrupted.json
+++ b/packages/channels/live-tests/snapshots/slack-stream-interrupted.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "The model started answering and then "
+  }
+]

--- a/packages/channels/live-tests/snapshots/slack-stream-rich.json
+++ b/packages/channels/live-tests/snapshots/slack-stream-rich.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "Live rich stream\n\nRich streaming smoke test."
+  }
+]

--- a/packages/channels/live-tests/snapshots/slack-stream.json
+++ b/packages/channels/live-tests/snapshots/slack-stream.json
@@ -1,0 +1,12 @@
+{
+  "duringStream": [
+    [],
+    [],
+    []
+  ],
+  "afterStream": [
+    {
+      "text": "Cloudflare Channels live streaming smoke test."
+    }
+  ]
+}

--- a/packages/channels/live-tests/snapshots/slack-thread-rich.json
+++ b/packages/channels/live-tests/snapshots/slack-thread-rich.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "Live rich delivery\n\nRich delivery with **bold text**, [a link](<https://example.com>), and `code`."
+  }
+]

--- a/packages/channels/live-tests/snapshots/slack-thread-stream-interrupted.json
+++ b/packages/channels/live-tests/snapshots/slack-thread-stream-interrupted.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "The model started answering and then"
+  }
+]

--- a/packages/channels/live-tests/snapshots/slack-thread-stream-rich.json
+++ b/packages/channels/live-tests/snapshots/slack-thread-stream-rich.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "Live rich stream\n\n Rich streaming smoke test. <https://example.com|Example>, with interactive elements"
+  }
+]

--- a/packages/channels/live-tests/snapshots/slack-thread-stream.json
+++ b/packages/channels/live-tests/snapshots/slack-thread-stream.json
@@ -1,0 +1,24 @@
+{
+  "duringStream": [
+    [
+      {
+        "text": "Cloudflare Channels"
+      }
+    ],
+    [
+      {
+        "text": "Cloudflare Channels live streaming"
+      }
+    ],
+    [
+      {
+        "text": "Cloudflare Channels live streaming smoke test."
+      }
+    ]
+  ],
+  "afterStream": [
+    {
+      "text": "Cloudflare Channels live streaming smoke test."
+    }
+  ]
+}

--- a/packages/channels/live-tests/snapshots/slack-thread.json
+++ b/packages/channels/live-tests/snapshots/slack-thread.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "Cloudflare Channels live delivery smoke test."
+  }
+]

--- a/packages/channels/live-tests/snapshots/telegram-rich.json
+++ b/packages/channels/live-tests/snapshots/telegram-rich.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "Live rich delivery\n\nRich delivery with **bold text**, [a link](https://example.com), and `code`."
+  }
+]

--- a/packages/channels/live-tests/snapshots/telegram-stream-interrupted.json
+++ b/packages/channels/live-tests/snapshots/telegram-stream-interrupted.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "The model started answering and then"
+  }
+]

--- a/packages/channels/live-tests/snapshots/telegram-stream-rich.json
+++ b/packages/channels/live-tests/snapshots/telegram-stream-rich.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "Live rich stream\n\nRich streaming smoke test."
+  }
+]

--- a/packages/channels/live-tests/snapshots/telegram-stream.json
+++ b/packages/channels/live-tests/snapshots/telegram-stream.json
@@ -1,0 +1,13 @@
+{
+  "duringStream": [
+    [],
+    [],
+    []
+  ],
+  "afterStream": [
+    {
+      "text": "Cloudflare Channels live streaming smoke test."
+    }
+  ],
+  "previews": 3
+}

--- a/packages/channels/live-tests/snapshots/web-rich.json
+++ b/packages/channels/live-tests/snapshots/web-rich.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "Live rich delivery\n\nRich delivery with **bold text**, [a link](https://example.com), and `code`."
+  }
+]

--- a/packages/channels/live-tests/snapshots/web-stream-interrupted.json
+++ b/packages/channels/live-tests/snapshots/web-stream-interrupted.json
@@ -1,0 +1,6 @@
+[
+  {
+    "text": "The model started answering and then ",
+    "error": "model failed mid-generation"
+  }
+]

--- a/packages/channels/live-tests/snapshots/web-stream-rich.json
+++ b/packages/channels/live-tests/snapshots/web-stream-rich.json
@@ -1,0 +1,14 @@
+[
+  {
+    "text": "Rich streaming smoke test.",
+    "reasoning": [
+      "every Channel may ignore this"
+    ],
+    "sources": [
+      {
+        "url": "https://example.com",
+        "title": "Example"
+      }
+    ]
+  }
+]

--- a/packages/channels/live-tests/snapshots/web-stream.json
+++ b/packages/channels/live-tests/snapshots/web-stream.json
@@ -1,0 +1,24 @@
+{
+  "duringStream": [
+    [
+      {
+        "text": "Cloudflare Channels "
+      }
+    ],
+    [
+      {
+        "text": "Cloudflare Channels live streaming "
+      }
+    ],
+    [
+      {
+        "text": "Cloudflare Channels live streaming smoke test."
+      }
+    ]
+  ],
+  "afterStream": [
+    {
+      "text": "Cloudflare Channels live streaming smoke test."
+    }
+  ]
+}

--- a/packages/channels/live-tests/snapshots/web.json
+++ b/packages/channels/live-tests/snapshots/web.json
@@ -1,0 +1,5 @@
+[
+  {
+    "text": "Cloudflare Channels live delivery smoke test."
+  }
+]

--- a/packages/channels/live-tests/streaming.test.ts
+++ b/packages/channels/live-tests/streaming.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "vitest";
+import type { ChannelChunk } from "../src/channel";
+import type { ObservedMessage } from "./binding";
+import {
+  chunkPump,
+  readObserved,
+  readUntil,
+  snapshot,
+  uniqueText,
+  withDestination
+} from "./helpers";
+import { providers } from "./providers";
+
+const STREAM_CHUNKS: readonly ChannelChunk[] = [
+  { type: "text", text: uniqueText("Cloudflare Channels ") },
+  { type: "text", text: "live streaming " },
+  { type: "text", text: "smoke test." }
+];
+
+/**
+ * Every chunk variant and the title, none of which the text-only smoke test
+ * can produce. This is a request-shape test: Slack rejected an earlier title
+ * with `streaming_mode_mismatch`, which no mock could catch.
+ */
+const RICH_CHUNKS: readonly ChannelChunk[] = [
+  {
+    type: "tool",
+    name: "search",
+    status: "started",
+    title: "Searching docs",
+    detail: "query: streaming"
+  },
+  { type: "text", text: uniqueText("Rich streaming ") },
+  { type: "reasoning", text: "every Channel may ignore this" },
+  {
+    type: "tool",
+    name: "search",
+    status: "completed",
+    title: "Searching docs"
+  },
+  { type: "text", text: "smoke test." },
+  { type: "source", url: "https://example.com", title: "Example" }
+];
+
+describe("live channel streaming", () => {
+  test.each(providers)("streams through %s", async (_name, create) => {
+    await withDestination(create, async (channel) => {
+      const session = chunkPump((chunks) =>
+        channel.host.stream(channel.surface, chunks)
+      );
+      const duringStream: ObservedMessage[][] = [];
+      for (const chunk of STREAM_CHUNKS) {
+        await session.push(chunk);
+        duringStream.push(await readObserved(channel));
+      }
+      const result = await session.finish();
+      expect(result.status).toBe("delivered");
+
+      const complete = "Cloudflare Channels live streaming smoke test.";
+      await snapshot(channel, "stream", {
+        duringStream,
+        afterStream: await readUntil(channel, complete),
+        ...(channel.previews && { previews: channel.previews() })
+      });
+    });
+  });
+
+  test.each(providers)(
+    "streams every chunk variant through %s",
+    async (_name, create) => {
+      await withDestination(create, async (channel) => {
+        const session = chunkPump((chunks) =>
+          channel.host.stream(channel.surface, chunks, {
+            title: "Live rich stream"
+          })
+        );
+        for (const chunk of RICH_CHUNKS) await session.push(chunk);
+        expect((await session.finish()).status).toBe("delivered");
+
+        await snapshot(
+          channel,
+          "stream-rich",
+          await readUntil(channel, "Rich streaming smoke test.")
+        );
+      });
+    }
+  );
+
+  /**
+   * A Channel must finalize after an abnormal ending too. Telegram is the
+   * sharp case: its draft is not the message, so omitting the terminal
+   * `sendMessage` leaves the chat empty when the draft expires.
+   */
+  test.each(providers)(
+    "persists a partial answer when the generation fails through %s",
+    async (_name, create) => {
+      await withDestination(create, async (channel) => {
+        const session = chunkPump((chunks) =>
+          channel.host.stream(channel.surface, chunks)
+        );
+        await session.push({
+          type: "text",
+          text: uniqueText("The model started ")
+        });
+        await session.push({ type: "text", text: "answering and then " });
+        const result = await session.fail("model failed mid-generation");
+
+        expect(result.status).toBe("uncertain");
+        expect(result).toHaveProperty("reference");
+        await snapshot(
+          channel,
+          "stream-interrupted",
+          await readUntil(channel, "The model started answering and then")
+        );
+      });
+    }
+  );
+});

--- a/packages/channels/live-tests/tsconfig.json
+++ b/packages/channels/live-tests/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
-    "types": ["node"]
+    "types": ["node", "@cloudflare/workers-types"]
   },
   "include": ["./**/*.ts"],
   "exclude": []

--- a/packages/channels/live-tests/web/worker.ts
+++ b/packages/channels/live-tests/web/worker.ts
@@ -1,0 +1,147 @@
+import { DurableObject, RpcTarget } from "cloudflare:workers";
+import { Lifecycle } from "agents/lifecycle";
+import type {
+  ChannelChunk,
+  ChannelDeliveryOptions,
+  ChannelMessage,
+  ChannelStreamOptions,
+  DeliveryResult
+} from "../../src/channel";
+import { ChannelHost } from "../../src/host";
+import type { ChannelMessageSurface } from "../../src/surface";
+import { web } from "../../src/adapters/web";
+
+type Env = {
+  WEB_CHANNEL_LIVE: DurableObjectNamespace<WebChannelLiveObject>;
+  LIVE_TEST_TOKEN?: string;
+};
+
+type StreamSession = {
+  controller: ReadableStreamDefaultController<ChannelChunk>;
+  delivery: Promise<DeliveryResult>;
+};
+
+class WebLiveControl extends RpcTarget {
+  readonly #streams = new Map<string, StreamSession>();
+  readonly #storage: DurableObjectStorage;
+  readonly #host: () => ChannelHost;
+
+  constructor(storage: DurableObjectStorage, host: () => ChannelHost) {
+    super();
+    this.#storage = storage;
+    this.#host = host;
+  }
+
+  async surface(): Promise<ChannelMessageSurface | null> {
+    return (await this.#storage.get<ChannelMessageSurface>("surface")) ?? null;
+  }
+
+  deliver(
+    surface: ChannelMessageSurface,
+    message: ChannelMessage,
+    options?: ChannelDeliveryOptions
+  ): Promise<DeliveryResult> {
+    return this.#host().deliver(surface, message, options);
+  }
+
+  startStream(
+    surface: ChannelMessageSurface,
+    options?: ChannelStreamOptions
+  ): { id: string } {
+    const id = crypto.randomUUID();
+    let controller!: ReadableStreamDefaultController<ChannelChunk>;
+    const chunks = new ReadableStream<ChannelChunk>({
+      start(streamController) {
+        controller = streamController;
+      }
+    });
+    const delivery = this.#host().stream(surface, chunks, options);
+    this.#streams.set(id, { controller, delivery });
+    return { id };
+  }
+
+  push(id: string, chunk: ChannelChunk): void {
+    this.#session(id).controller.enqueue(chunk);
+  }
+
+  async finish(id: string): Promise<DeliveryResult> {
+    const session = this.#session(id);
+    session.controller.close();
+    try {
+      return await session.delivery;
+    } finally {
+      this.#streams.delete(id);
+    }
+  }
+
+  async fail(id: string, reason: string): Promise<DeliveryResult> {
+    const session = this.#session(id);
+    session.controller.error(new Error(reason));
+    try {
+      return await session.delivery;
+    } finally {
+      this.#streams.delete(id);
+    }
+  }
+
+  async clear(): Promise<void> {
+    const deliveries: Promise<DeliveryResult>[] = [];
+    for (const session of this.#streams.values()) {
+      session.controller.error(new Error("Live-test destination cleared"));
+      deliveries.push(session.delivery);
+    }
+    this.#streams.clear();
+    await this.#storage.delete("surface");
+    await Promise.allSettled(deliveries);
+  }
+
+  #session(id: string): StreamSession {
+    const session = this.#streams.get(id);
+    if (!session) throw new Error(`Unknown Web live-test stream ${id}`);
+    return session;
+  }
+}
+
+/** Bare Durable Object serving the live Web Channel contract fixture. */
+export class WebChannelLiveObject extends DurableObject<Env> {
+  readonly #control = new WebLiveControl(this.ctx.storage, () => this.#host);
+  readonly #web = web({ webSockets: { callables: this.#control } });
+  readonly #host = new ChannelHost({
+    channels: { web: this.#web },
+    onMessage: async ({ message }) => {
+      if (!message.replySurface) {
+        throw new Error(
+          "Web live-test message did not include a reply surface"
+        );
+      }
+      await this.ctx.storage.put("surface", message.replySurface);
+    }
+  });
+
+  readonly lifecycle = Lifecycle.install(this).use(this.#web.webSockets);
+}
+
+function localRequest(url: URL): boolean {
+  return url.hostname === "127.0.0.1" || url.hostname === "localhost";
+}
+
+export default {
+  fetch(request, env) {
+    const url = new URL(request.url);
+    if (url.pathname === "/") return new Response("Web Channel live fixture");
+
+    const suppliedToken = url.searchParams.get("token");
+    if (env.LIVE_TEST_TOKEN) {
+      if (suppliedToken !== env.LIVE_TEST_TOKEN) {
+        return new Response("Unauthorized", { status: 401 });
+      }
+    } else if (!localRequest(url)) {
+      return new Response("LIVE_TEST_TOKEN is not configured", { status: 503 });
+    }
+
+    const name = url.searchParams.get("name");
+    if (!name) return new Response("Missing object name", { status: 400 });
+    const id = env.WEB_CHANNEL_LIVE.idFromName(name);
+    return env.WEB_CHANNEL_LIVE.get(id).fetch(request);
+  }
+} satisfies ExportedHandler<Env>;

--- a/packages/channels/live-tests/web/wrangler.jsonc
+++ b/packages/channels/live-tests/web/wrangler.jsonc
@@ -1,0 +1,21 @@
+{
+  "$schema": "../../../../node_modules/wrangler/config-schema.json",
+  "name": "channels-web-live-test",
+  "main": "worker.ts",
+  "compatibility_date": "2026-06-11",
+  "compatibility_flags": ["nodejs_compat"],
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "WEB_CHANNEL_LIVE",
+        "class_name": "WebChannelLiveObject"
+      }
+    ]
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["WebChannelLiveObject"]
+    }
+  ]
+}

--- a/packages/channels/package.json
+++ b/packages/channels/package.json
@@ -43,6 +43,11 @@
       "import": "./dist/tanstack-ai.js",
       "require": "./dist/tanstack-ai.js"
     },
+    "./web": {
+      "types": "./dist/web.d.ts",
+      "import": "./dist/web.js",
+      "require": "./dist/web.js"
+    },
     "./voice": {
       "types": "./dist/voice.d.ts",
       "import": "./dist/voice.js",

--- a/packages/channels/package.json
+++ b/packages/channels/package.json
@@ -60,6 +60,7 @@
   },
   "dependencies": {
     "@cloudflare/voice": "workspace:*",
+    "agents": "workspace:*",
     "postal-mime": "^2.7.5"
   },
   "peerDependencies": {

--- a/packages/channels/package.json
+++ b/packages/channels/package.json
@@ -60,6 +60,7 @@
   ],
   "scripts": {
     "build": "tsx ./scripts/build.ts",
+    "dev:live:web": "wrangler dev --config live-tests/web/wrangler.jsonc --port 8799 --inspector-port 0",
     "test": "vitest --run",
     "test:live": "vitest --run -c vitest.live.config.ts"
   },
@@ -83,6 +84,7 @@
   "devDependencies": {
     "@tanstack/ai": "0.38.0",
     "ai": "^7.0.0",
+    "capnweb": "^0.12.0",
     "teleproto": "^1.228.5",
     "vitest": "4.1.10"
   },

--- a/packages/channels/scripts/build.ts
+++ b/packages/channels/scripts/build.ts
@@ -11,6 +11,7 @@ async function main() {
       "ai-sdk": "src/ai-sdk.ts",
       slack: "src/adapters/slack.ts",
       "tanstack-ai": "src/tanstack-ai.ts",
+      web: "src/adapters/web.ts",
       voice: "src/adapters/voice.ts"
     },
     deps: {

--- a/packages/channels/src/__tests__/ai-sdk.test.ts
+++ b/packages/channels/src/__tests__/ai-sdk.test.ts
@@ -6,7 +6,7 @@ import {
   type ChannelMessage,
   type DeliveryResult
 } from "..";
-import { createSendMessageTool } from "../ai-sdk";
+import { createSendMessageTool, toChannelChunks } from "../ai-sdk";
 
 function executable(tool: ReturnType<typeof createSendMessageTool>) {
   return tool.execute as unknown as (
@@ -86,5 +86,75 @@ describe("AI SDK message adapter", () => {
       success: true,
       value: { markdown: "Ready" }
     });
+  });
+});
+
+describe("AI SDK stream adapter", () => {
+  async function collect(parts: unknown[]) {
+    const chunks: unknown[] = [];
+    const stream = toChannelChunks(
+      (async function* () {
+        for (const part of parts) yield part as never;
+      })()
+    );
+    for await (const chunk of stream) chunks.push(chunk);
+    return chunks;
+  }
+
+  it("keeps the parts a Channel can express and drops the rest", async () => {
+    await expect(
+      collect([
+        { type: "start" },
+        { type: "text-start", id: "1" },
+        { type: "text-delta", id: "1", text: "Hello" },
+        { type: "reasoning-delta", id: "2", text: "thinking" },
+        { type: "tool-call", toolCallId: "t1", toolName: "search", input: {} },
+        {
+          type: "tool-result",
+          toolCallId: "t1",
+          toolName: "search",
+          input: {},
+          output: "ok"
+        },
+        { type: "tool-error", toolCallId: "t2", toolName: "fetch", error: "x" },
+        {
+          type: "source",
+          sourceType: "url",
+          id: "s1",
+          url: "https://example.com",
+          title: "Example"
+        },
+        {
+          type: "source",
+          sourceType: "document",
+          id: "s2",
+          mediaType: "application/pdf",
+          title: "Report"
+        },
+        { type: "finish", finishReason: "stop" }
+      ])
+    ).resolves.toEqual([
+      { type: "text", text: "Hello" },
+      { type: "reasoning", text: "thinking" },
+      { type: "tool", name: "search", status: "started" },
+      { type: "tool", name: "search", status: "completed" },
+      { type: "tool", name: "fetch", status: "failed" },
+      { type: "source", url: "https://example.com", title: "Example" }
+    ]);
+  });
+
+  it("errors the stream when the generation fails, so Channels finalize", async () => {
+    await expect(
+      collect([
+        { type: "text-delta", id: "1", text: "Half an " },
+        { type: "error", error: new Error("model failed") }
+      ])
+    ).rejects.toThrow("model failed");
+  });
+
+  it("errors the stream when the generation is aborted", async () => {
+    await expect(
+      collect([{ type: "abort", reason: "stopped by the reader" }])
+    ).rejects.toThrow("stopped by the reader");
   });
 });

--- a/packages/channels/src/__tests__/fallback.test.ts
+++ b/packages/channels/src/__tests__/fallback.test.ts
@@ -4,9 +4,64 @@ import {
   fallback,
   fallbackChannel,
   type Channel,
+  type ChannelChunk,
   type DeliveryResult,
   type OutboundResolver
 } from "..";
+
+function streamOf<T>(values: readonly T[], error?: unknown): ReadableStream<T> {
+  let index = 0;
+  return new ReadableStream<T>({
+    pull(controller) {
+      if (index < values.length) {
+        controller.enqueue(values[index]!);
+        index += 1;
+        return;
+      }
+      if (error !== undefined) controller.error(error);
+      else controller.close();
+    }
+  });
+}
+
+function text(...parts: string[]): ChannelChunk[] {
+  return parts.map((part) => ({ type: "text", text: part }));
+}
+
+/** A Channel that records what it read, then reports a fixed outcome. */
+function streamingChannel(
+  result: DeliveryResult,
+  options: { readAtMost?: number; available?: boolean } = {}
+): Channel & { seen: ChannelChunk[]; calls: number } {
+  const channel = {
+    seen: [] as ChannelChunk[],
+    calls: 0,
+    ...(options.available === undefined
+      ? {}
+      : { isAvailable: () => options.available! }),
+    async stream(_surface: unknown, chunks: ReadableStream<ChannelChunk>) {
+      channel.calls += 1;
+      const reader = chunks.getReader();
+      let read = 0;
+      for (;;) {
+        if (read === options.readAtMost) break;
+        const next = await reader.read();
+        if (next.done) break;
+        channel.seen.push(next.value);
+        read += 1;
+      }
+      reader.releaseLock();
+      return result;
+    }
+  };
+  return channel as Channel & { seen: ChannelChunk[]; calls: number };
+}
+
+const rejected: DeliveryResult = {
+  status: "failed",
+  retryable: false,
+  error: { code: "DELIVERY_FAILED", message: "Not delivered" }
+};
 
 function surface(channelKey: string) {
   return {
@@ -104,14 +159,14 @@ describe("fallback surfaces", () => {
     const first = channel({ status: "delivered" });
     const channelHost = host({ first });
     const message = { markdown: "Hello" };
-    const context = { deliveryId: "notice-1" };
+    const options = { delivery: { deliveryId: "notice-1" } };
 
-    await channelHost.deliver(fallback([surface("first")]), message, context);
+    await channelHost.deliver(fallback([surface("first")]), message, options);
 
     expect(first.deliver).toHaveBeenCalledWith(
       surface("first"),
       message,
-      context
+      options
     );
   });
 
@@ -181,5 +236,143 @@ describe("fallback surfaces", () => {
       address: { surfaces: [surface("Slack"), surface("email")] },
       label: "Slack, then email"
     });
+  });
+});
+
+describe("fallback streaming", () => {
+  it("replays what a failed destination consumed to the next one", async () => {
+    const first = streamingChannel(rejected);
+    const second = streamingChannel({ status: "delivered", reference: "s-1" });
+    const channelHost = host({ first, second });
+
+    await expect(
+      channelHost.stream(
+        fallback([surface("first"), surface("second")]),
+        streamOf(text("Hello ", "world"))
+      )
+    ).resolves.toEqual({ status: "delivered", reference: "s-1" });
+    expect(second.seen).toEqual([
+      { type: "text", text: "Hello " },
+      { type: "text", text: "world" }
+    ]);
+    expect(second.seen).toEqual(first.seen);
+  });
+
+  it("replays the consumed prefix and streams the untouched remainder", async () => {
+    const first = streamingChannel(rejected, { readAtMost: 1 });
+    const second = streamingChannel({ status: "delivered" });
+    const channelHost = host({ first, second });
+
+    await channelHost.stream(
+      fallback([surface("first"), surface("second")]),
+      streamOf(text("one", "two", "three"))
+    );
+
+    expect(first.seen).toEqual([{ type: "text", text: "one" }]);
+    expect(second.seen).toEqual([
+      { type: "text", text: "one" },
+      { type: "text", text: "two" },
+      { type: "text", text: "three" }
+    ]);
+  });
+
+  it("skips an unavailable destination without consuming the stream", async () => {
+    const skipped = streamingChannel(
+      { status: "delivered" },
+      {
+        available: false
+      }
+    );
+    const final = streamingChannel({ status: "delivered", reference: "f-1" });
+    const channelHost = host({ skipped, final });
+
+    await expect(
+      channelHost.stream(
+        fallback([surface("skipped"), surface("final")]),
+        streamOf(text("Hello"))
+      )
+    ).resolves.toEqual({ status: "delivered", reference: "f-1" });
+    expect(skipped.calls).toBe(0);
+    expect(final.seen).toEqual([{ type: "text", text: "Hello" }]);
+  });
+
+  it("stops after an uncertain streaming outcome", async () => {
+    const first = streamingChannel({
+      status: "uncertain",
+      reference: "half-written",
+      error: { code: "STREAM_ERROR", message: "Partly sent" }
+    });
+    const second = streamingChannel({ status: "delivered" });
+    const channelHost = host({ first, second });
+
+    await expect(
+      channelHost.stream(
+        fallback([surface("first"), surface("second")]),
+        streamOf(text("Hello"))
+      )
+    ).resolves.toEqual({
+      status: "uncertain",
+      reference: "half-written",
+      error: { code: "STREAM_ERROR", message: "Partly sent" }
+    });
+    expect(second.calls).toBe(0);
+  });
+
+  it("attempts the final destination even after every earlier one failed", async () => {
+    const first = streamingChannel(rejected);
+    const second = streamingChannel(rejected);
+    const channelHost = host({ first, second });
+
+    await expect(
+      channelHost.stream(
+        fallback([surface("first"), surface("second")]),
+        streamOf(text("Hello"))
+      )
+    ).resolves.toEqual(rejected);
+    expect(second.seen).toEqual([{ type: "text", text: "Hello" }]);
+  });
+
+  it("replays into a destination that cannot stream", async () => {
+    const deliver = vi.fn(async () => ({ status: "delivered" as const }));
+    const first = streamingChannel(rejected);
+    const channelHost = host({ first, second: { deliver } });
+
+    await expect(
+      channelHost.stream(
+        fallback([surface("first"), surface("second")]),
+        streamOf(text("Hello ", "world")),
+        { title: "Update" }
+      )
+    ).resolves.toEqual({ status: "delivered" });
+    expect(deliver).toHaveBeenCalledWith(
+      surface("second"),
+      { title: "Update", markdown: "Hello world" },
+      undefined
+    );
+  });
+
+  it("passes an interrupted generation on to the destination", async () => {
+    const seen: ChannelChunk[] = [];
+    let interrupted = false;
+    const channelHost = host({
+      only: {
+        async stream(_surface, chunks) {
+          try {
+            for await (const chunk of chunks) seen.push(chunk);
+          } catch {
+            interrupted = true;
+          }
+          return { status: "uncertain", error: { code: "X", message: "y" } };
+        }
+      }
+    });
+
+    await channelHost.stream(
+      fallback([surface("only")]),
+      streamOf(text("Half an "), new Error("model failed"))
+    );
+
+    expect(seen).toEqual([{ type: "text", text: "Half an " }]);
+    expect(interrupted).toBe(true);
   });
 });

--- a/packages/channels/src/__tests__/fanout.test.ts
+++ b/packages/channels/src/__tests__/fanout.test.ts
@@ -5,9 +5,28 @@ import {
   fanout,
   fanoutChannel,
   type Channel,
+  type ChannelChunk,
   type DeliveryResult,
   type OutboundResolver
 } from "..";
+
+function streamOf<T>(values: readonly T[]): ReadableStream<T> {
+  let index = 0;
+  return new ReadableStream<T>({
+    pull(controller) {
+      if (index < values.length) {
+        controller.enqueue(values[index]!);
+        index += 1;
+      } else {
+        controller.close();
+      }
+    }
+  });
+}
+
+function text(...parts: string[]): ChannelChunk[] {
+  return parts.map((part) => ({ type: "text", text: part }));
+}
 
 function surface(channelKey: string) {
   return {
@@ -55,19 +74,19 @@ describe("fanout surfaces", () => {
     const second = channel({ status: "delivered", reference: "email-1" });
     const channelHost = host({ first, second });
     const message = { title: "Update", markdown: "Hello" };
-    const context = { deliveryId: "notice-1" };
+    const options = { delivery: { deliveryId: "notice-1" } };
 
     const delivery = channelHost.deliver(
       fanout([surface("first"), surface("second")]),
       message,
-      context
+      options
     );
     await vi.waitFor(() => {
       expect(started).toEqual(["first"]);
       expect(second.deliver).toHaveBeenCalledWith(
         surface("second"),
         message,
-        context
+        options
       );
     });
     release?.();
@@ -202,5 +221,113 @@ describe("fanout surfaces", () => {
     ).resolves.toEqual({ status: "delivered", reference: "final" });
     expect(first.deliver).not.toHaveBeenCalled();
     expect(unavailable.deliver).not.toHaveBeenCalled();
+  });
+});
+
+describe("fanout streaming", () => {
+  it("gives every destination its own branch of the stream", async () => {
+    const seen: Record<string, ChannelChunk[]> = { first: [], second: [] };
+    const streaming = (key: string): Channel => ({
+      async stream(_surface, chunks) {
+        for await (const chunk of chunks) seen[key]!.push(chunk);
+        return { status: "delivered" };
+      }
+    });
+    const channelHost = host({
+      first: streaming("first"),
+      second: streaming("second")
+    });
+
+    await expect(
+      channelHost.stream(
+        fanout([surface("first"), surface("second")]),
+        streamOf(text("Hello ", "world"))
+      )
+    ).resolves.toEqual({ status: "delivered" });
+    expect(seen.first).toEqual(seen.second);
+    expect(seen.first).toEqual([
+      { type: "text", text: "Hello " },
+      { type: "text", text: "world" }
+    ]);
+  });
+
+  it("lets a fast destination finish while a slow one is still reading", async () => {
+    let release: (() => void) | undefined;
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const order: string[] = [];
+    const channelHost = host({
+      slow: {
+        async stream(_surface, chunks) {
+          await blocked;
+          for await (const _chunk of chunks) order.push("slow");
+          return { status: "delivered" };
+        }
+      },
+      fast: {
+        async stream(_surface, chunks) {
+          for await (const _chunk of chunks) order.push("fast");
+          return { status: "delivered" };
+        }
+      }
+    });
+
+    const delivery = channelHost.stream(
+      fanout([surface("slow"), surface("fast")]),
+      streamOf(text("one", "two"))
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(order).toEqual(["fast", "fast"]);
+
+    release?.();
+    await expect(delivery).resolves.toEqual({ status: "delivered" });
+    expect(order).toEqual(["fast", "fast", "slow", "slow"]);
+  });
+
+  it("reports a partial streaming outcome as uncertain", async () => {
+    const channelHost = host({
+      first: { stream: async () => ({ status: "delivered" as const }) },
+      second: {
+        stream: async () => ({
+          status: "failed" as const,
+          retryable: false,
+          error: { code: "NOPE", message: "Rejected" }
+        })
+      }
+    });
+
+    await expect(
+      channelHost.stream(
+        fanout([surface("first"), surface("second")]),
+        streamOf(text("Hello"))
+      )
+    ).resolves.toMatchObject({
+      status: "uncertain",
+      error: { code: "FANOUT_DELIVERY_UNCERTAIN" }
+    });
+  });
+
+  it("collects for a destination that cannot stream and streams to one that can", async () => {
+    const deliver = vi.fn(async () => ({ status: "delivered" as const }));
+    const channelHost = host({
+      plain: { deliver },
+      streaming: {
+        stream: async () => ({ status: "delivered" as const })
+      }
+    });
+
+    await expect(
+      channelHost.stream(
+        fanout([surface("plain"), surface("streaming")]),
+        streamOf(text("Hello ", "world")),
+        { title: "Update" }
+      )
+    ).resolves.toEqual({ status: "delivered" });
+    expect(deliver).toHaveBeenCalledWith(
+      surface("plain"),
+      { title: "Update", markdown: "Hello world" },
+      undefined
+    );
   });
 });

--- a/packages/channels/src/__tests__/host.test.ts
+++ b/packages/channels/src/__tests__/host.test.ts
@@ -14,6 +14,7 @@ import {
   type ChannelRouteContext,
   type ChannelRouteEvent
 } from "..";
+import { bindChannelIngress, type BindableChannelIngress } from "../internal";
 
 const delivered = async () => ({ status: "delivered" as const });
 const surface = {
@@ -90,6 +91,41 @@ function host(
 }
 
 describe("stateless ChannelHost", () => {
+  it("routes push-based Channel ingress through onMessage", async () => {
+    let push:
+      | ((
+          envelope: ChannelIngressEnvelope<{ requestId: string }>
+        ) => Promise<void>)
+      | undefined;
+    const channel: Channel<{ requestId: string }> &
+      BindableChannelIngress<{ requestId: string }> = {
+      [bindChannelIngress](dispatch) {
+        push = dispatch;
+      },
+      route: vi.fn((_event, raw) => `request:${raw.requestId}`)
+    };
+    const onMessage = vi.fn();
+    host({ web: channel }, { onMessage });
+
+    await push?.({
+      event: message(),
+      raw: { requestId: "turn-1" }
+    });
+
+    expect(channel.route).toHaveBeenCalledWith(
+      expect.objectContaining({ eventId: "event-1" }),
+      { requestId: "turn-1" },
+      expect.objectContaining({ findUser: expect.any(Function) })
+    );
+    expect(onMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelKey: "web",
+        route: "request:turn-1",
+        message: expect.objectContaining({ type: "message" })
+      })
+    );
+  });
+
   it("allows an outbound-only Host without ingress callbacks", async () => {
     const deliver = vi.fn(delivered);
     const channelHost = new ChannelHost({

--- a/packages/channels/src/__tests__/slack-stream.test.ts
+++ b/packages/channels/src/__tests__/slack-stream.test.ts
@@ -1,0 +1,391 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ChannelChunk } from "..";
+import { slack } from "../adapters/slack";
+
+const BOT_TOKEN = "xoxb-secret-token";
+const CHANNEL_SURFACE = {
+  channelKey: "slack",
+  version: 1,
+  address: {
+    channelId: "CDEST",
+    threadTs: "1711000000.000100",
+    recipientUserId: "UHUMAN",
+    recipientTeamId: "TWORK"
+  },
+  label: "Slack · CDEST"
+} as const;
+
+type Call = { method: string; body: Record<string, unknown> };
+
+/** Record every Slack call, answering each stream method with ok. */
+function recorder(overrides: Record<string, () => Response> = {}): {
+  fetch: typeof globalThis.fetch;
+  calls: Call[];
+} {
+  const calls: Call[] = [];
+  const fetch = vi.fn<typeof globalThis.fetch>(async (input, init) => {
+    const method = String(input).split("/").pop()!;
+    calls.push({ method, body: JSON.parse(String(init?.body)) });
+    return (
+      overrides[method]?.() ??
+      Response.json({ ok: true, channel: "CDEST", ts: "1711000000.9" })
+    );
+  });
+  return { fetch, calls };
+}
+
+function streamOf<T>(values: readonly T[], error?: unknown): ReadableStream<T> {
+  let index = 0;
+  return new ReadableStream<T>({
+    pull(controller) {
+      if (index < values.length) {
+        controller.enqueue(values[index]!);
+        index += 1;
+        return;
+      }
+      if (error !== undefined) controller.error(error);
+      else controller.close();
+    }
+  });
+}
+
+function chunks(...parts: string[]): ReadableStream<ChannelChunk> {
+  return streamOf(parts.map((text) => ({ type: "text", text }) as const));
+}
+
+describe("Slack streaming", () => {
+  it("collects a top-level channel stream and posts it once", async () => {
+    const { fetch, calls } = recorder();
+    const channel = slack({ botToken: BOT_TOKEN, fetch });
+
+    await expect(
+      channel.stream!(
+        {
+          ...CHANNEL_SURFACE,
+          address: { channelId: "CDEST" }
+        },
+        chunks("Hello", " world"),
+        { title: "Update" }
+      )
+    ).resolves.toEqual({
+      status: "delivered",
+      reference: "slack:channel:CDEST:message:1711000000.9"
+    });
+    expect(calls).toEqual([
+      {
+        method: "chat.postMessage",
+        body: {
+          channel: "CDEST",
+          text: "Update\n\nHello world",
+          mrkdwn: true
+        }
+      }
+    ]);
+  });
+
+  it("starts, appends, and stops one streaming message", async () => {
+    const { fetch, calls } = recorder();
+    const channel = slack({ botToken: BOT_TOKEN, fetch, streamIntervalMs: 0 });
+
+    await expect(
+      channel.stream!(CHANNEL_SURFACE, chunks("Hello ", "world"), {})
+    ).resolves.toEqual({
+      status: "delivered",
+      reference: "slack:channel:CDEST:message:1711000000.9"
+    });
+    expect(calls.map((call) => call.method)).toEqual([
+      "chat.startStream",
+      "chat.appendStream",
+      "chat.appendStream",
+      "chat.stopStream"
+    ]);
+    expect(calls[0]?.body).toEqual({
+      channel: "CDEST",
+      thread_ts: "1711000000.000100",
+      recipient_user_id: "UHUMAN",
+      recipient_team_id: "TWORK"
+    });
+    expect(calls[1]?.body).toEqual({
+      channel: "CDEST",
+      ts: "1711000000.9",
+      chunks: [{ type: "markdown_text", text: "Hello " }]
+    });
+    expect(calls[3]?.body).toEqual({
+      channel: "CDEST",
+      ts: "1711000000.9"
+    });
+  });
+
+  it("opens the stream with the title, which is known before the first token", async () => {
+    const { fetch, calls } = recorder();
+    const channel = slack({ botToken: BOT_TOKEN, fetch, streamIntervalMs: 0 });
+
+    await channel.stream!(CHANNEL_SURFACE, chunks("Body"), {
+      title: "Deploy status"
+    });
+
+    // The title must travel as a chunk, not as `markdown_text`. Slack locks a
+    // stream into the mode it was opened in and rejects every later append
+    // with `streaming_mode_mismatch`, which loses the entire answer.
+    expect(calls[0]?.body).toMatchObject({
+      chunks: [{ type: "markdown_text", text: "Deploy status\n\n" }]
+    });
+    expect(calls[0]?.body.markdown_text).toBeUndefined();
+    expect(calls.every((call) => call.body.markdown_text === undefined)).toBe(
+      true
+    );
+  });
+
+  it("appends every chunk produced inside one interval together", async () => {
+    vi.useFakeTimers();
+    const { fetch, calls } = recorder();
+    const channel = slack({
+      botToken: BOT_TOKEN,
+      fetch,
+      streamIntervalMs: 1000
+    });
+
+    await channel.stream!(CHANNEL_SURFACE, chunks("a", "b", "c"), {});
+
+    expect(
+      calls
+        .filter((call) => call.method === "chat.appendStream")
+        .map((call) => call.body.chunks)
+    ).toEqual([[{ type: "markdown_text", text: "a" }]]);
+    // Whatever the interval withheld rides on the terminal call rather than
+    // costing another round trip, so nothing is dropped.
+    expect(calls.at(-1)).toEqual({
+      method: "chat.stopStream",
+      body: {
+        channel: "CDEST",
+        ts: "1711000000.9",
+        chunks: [
+          { type: "markdown_text", text: "b" },
+          { type: "markdown_text", text: "c" }
+        ]
+      }
+    });
+    vi.useRealTimers();
+  });
+
+  it("renders tool progress as task updates and sources beneath the answer", async () => {
+    const { fetch, calls } = recorder();
+    const channel = slack({ botToken: BOT_TOKEN, fetch, streamIntervalMs: 0 });
+    const parts: ChannelChunk[] = [
+      { type: "reasoning", text: "dropped" },
+      {
+        type: "tool",
+        name: "search",
+        status: "started",
+        title: "Searching",
+        detail: "query"
+      },
+      { type: "tool", name: "search", status: "completed" },
+      { type: "source", url: "https://example.com", title: "Example" },
+      { type: "text", text: "Answer" }
+    ];
+
+    await channel.stream!(CHANNEL_SURFACE, streamOf(parts), {});
+
+    const appended = calls
+      .filter((call) => call.method === "chat.appendStream")
+      .flatMap((call) => call.body.chunks as unknown[]);
+    expect(appended).toEqual([
+      {
+        type: "task_update",
+        id: "search",
+        title: "Searching",
+        status: "in_progress",
+        details: "query"
+      },
+      {
+        type: "task_update",
+        id: "search",
+        title: "search",
+        status: "complete"
+      },
+      { type: "markdown_text", text: "Answer" }
+    ]);
+    expect(calls.at(-1)?.body.blocks).toEqual([
+      {
+        type: "context",
+        elements: [
+          {
+            type: "mrkdwn",
+            text: "<https://example.com|Example>"
+          }
+        ]
+      }
+    ]);
+  });
+
+  it("splits text past Slack's append limit", async () => {
+    const { fetch, calls } = recorder();
+    const channel = slack({ botToken: BOT_TOKEN, fetch, streamIntervalMs: 0 });
+
+    await channel.stream!(CHANNEL_SURFACE, chunks("x".repeat(12_001)), {});
+
+    const appended = calls.filter(
+      (call) => call.method === "chat.appendStream"
+    );
+    expect(
+      (appended[0]!.body.chunks as { text: string }[]).map(
+        (chunk) => chunk.text.length
+      )
+    ).toEqual([12_000, 1]);
+  });
+
+  it("stops the stream and reports uncertain when the generation fails", async () => {
+    const { fetch, calls } = recorder();
+    const channel = slack({ botToken: BOT_TOKEN, fetch, streamIntervalMs: 0 });
+    const interrupted = streamOf(
+      [{ type: "text", text: "Half an " } as const],
+      new Error("model failed")
+    );
+
+    await expect(
+      channel.stream!(CHANNEL_SURFACE, interrupted, {})
+    ).resolves.toEqual({
+      status: "uncertain",
+      reference: "slack:channel:CDEST:message:1711000000.9",
+      error: {
+        code: "SLACK_STREAM_INTERRUPTED",
+        message: "The answer ended early, so the Slack message is incomplete"
+      }
+    });
+    expect(calls.at(-1)?.method).toBe("chat.stopStream");
+  });
+
+  it("stops the stream even after an append is rejected", async () => {
+    const { fetch, calls } = recorder({
+      "chat.appendStream": () => Response.json({ ok: false, error: "no_text" })
+    });
+    const channel = slack({ botToken: BOT_TOKEN, fetch, streamIntervalMs: 0 });
+
+    await expect(
+      channel.stream!(CHANNEL_SURFACE, chunks("a", "b"), {})
+    ).resolves.toEqual({
+      status: "uncertain",
+      reference: "slack:channel:CDEST:message:1711000000.9",
+      error: {
+        code: "SLACK_API_ERROR_NO_TEXT",
+        message: "Slack rejected the message: no_text"
+      }
+    });
+    expect(calls.map((call) => call.method)).toEqual([
+      "chat.startStream",
+      "chat.appendStream",
+      "chat.stopStream"
+    ]);
+  });
+
+  it("reports a rejected stop as uncertain, since the message exists", async () => {
+    const { fetch } = recorder({
+      "chat.stopStream": () =>
+        Response.json({ ok: false, error: "internal_error" }, { status: 500 })
+    });
+    const channel = slack({ botToken: BOT_TOKEN, fetch, streamIntervalMs: 0 });
+
+    await expect(
+      channel.stream!(CHANNEL_SURFACE, chunks("a"), {})
+    ).resolves.toMatchObject({
+      status: "uncertain",
+      reference: "slack:channel:CDEST:message:1711000000.9",
+      error: { code: "SLACK_API_ERROR_INTERNAL_ERROR" }
+    });
+  });
+
+  it("never reads the stream when Slack refuses to start one", async () => {
+    const { fetch, calls } = recorder({
+      "chat.startStream": () =>
+        Response.json({ ok: false, error: "not_in_channel" })
+    });
+    const channel = slack({ botToken: BOT_TOKEN, fetch, streamIntervalMs: 0 });
+    const source = chunks("a");
+
+    await expect(channel.stream!(CHANNEL_SURFACE, source, {})).resolves.toEqual(
+      {
+        status: "failed",
+        retryable: false,
+        error: {
+          code: "SLACK_API_ERROR_NOT_IN_CHANNEL",
+          message: "Slack rejected the message: not_in_channel"
+        }
+      }
+    );
+    expect(calls).toHaveLength(1);
+    expect(source.locked).toBe(false);
+  });
+
+  it("rejects a malformed surface without calling Slack", async () => {
+    const { fetch, calls } = recorder();
+    const channel = slack({ botToken: BOT_TOKEN, fetch });
+
+    await expect(
+      channel.stream!(
+        { channelKey: "slack", version: 1, address: null, label: "bad" },
+        chunks("a"),
+        {}
+      )
+    ).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "SLACK_SURFACE_INVALID" }
+    });
+    expect(calls).toEqual([]);
+  });
+
+  it("opens a direct message and streams to the resolved conversation", async () => {
+    const { fetch, calls } = recorder({
+      "conversations.open": () =>
+        Response.json({ ok: true, channel: { id: "DADA" } })
+    });
+    const channel = slack({ botToken: BOT_TOKEN, fetch, streamIntervalMs: 0 });
+
+    await channel.stream!(
+      {
+        channelKey: "slack",
+        version: 1,
+        address: { teamId: "TWORK", userId: "UADA" },
+        label: "Slack · user UADA"
+      },
+      chunks("Hi"),
+      {}
+    );
+
+    expect(calls[1]).toEqual({
+      method: "chat.startStream",
+      body: {
+        channel: "DADA",
+        recipient_user_id: "UADA",
+        recipient_team_id: "TWORK"
+      }
+    });
+  });
+
+  it("falls back to delivery when a top-level surface has an incomplete recipient pair", async () => {
+    const { fetch, calls } = recorder();
+    const channel = slack({ botToken: BOT_TOKEN, fetch, streamIntervalMs: 0 });
+
+    await channel.stream!(
+      {
+        channelKey: "slack",
+        version: 1,
+        address: { channelId: "CDEST", recipientUserId: "UHUMAN" },
+        label: "Slack · CDEST"
+      },
+      chunks("Hi"),
+      {}
+    );
+
+    expect(calls[0]).toEqual({
+      method: "chat.postMessage",
+      body: { channel: "CDEST", text: "Hi", mrkdwn: true }
+    });
+  });
+
+  it("rejects a nonsensical stream interval when the Channel is created", () => {
+    expect(() => slack({ botToken: BOT_TOKEN, streamIntervalMs: -1 })).toThrow(
+      "streamIntervalMs must be a non-negative integer"
+    );
+  });
+});

--- a/packages/channels/src/__tests__/slack.test.ts
+++ b/packages/channels/src/__tests__/slack.test.ts
@@ -152,7 +152,9 @@ describe("Slack signed ingress", () => {
         address: {
           teamId: "TWORK",
           channelId: "CGENERAL",
-          threadTs: "1710000000.000100"
+          threadTs: "1710000000.000100",
+          recipientUserId: "UHUMAN",
+          recipientTeamId: "TWORK"
         },
         label: "Slack · CGENERAL · thread 1710000000.000100"
       },
@@ -711,7 +713,7 @@ describe("Slack interactions and delivery outcomes", () => {
     const result = await channel.deliver(
       threadSurface,
       { title: "Build blocked", markdown: "Please **help**" },
-      { deliveryId: "caller-delivery-1" }
+      { delivery: { deliveryId: "caller-delivery-1" } }
     );
 
     expect(result).toEqual({

--- a/packages/channels/src/__tests__/stream.test.ts
+++ b/packages/channels/src/__tests__/stream.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  ChannelHost,
+  consumeChunks,
+  type Channel,
+  type ChannelChunk,
+  type DeliveryResult
+} from "..";
+import { collectText, createPacer } from "../stream";
+
+const surface = {
+  channelKey: "test",
+  version: 1,
+  address: null,
+  label: "Test destination"
+} as const;
+
+function streamOf<T>(values: readonly T[], error?: unknown): ReadableStream<T> {
+  let index = 0;
+  return new ReadableStream<T>({
+    pull(controller) {
+      if (index < values.length) {
+        controller.enqueue(values[index]!);
+        index += 1;
+        return;
+      }
+      if (error !== undefined) controller.error(error);
+      else controller.close();
+    }
+  });
+}
+
+function text(...parts: string[]): ChannelChunk[] {
+  return parts.map((part) => ({ type: "text", text: part }));
+}
+
+async function drain<T>(stream: ReadableStream<T>): Promise<T[]> {
+  const values: T[] = [];
+  for await (const value of stream) values.push(value);
+  return values;
+}
+
+function host(channels: Record<string, Channel>) {
+  return new ChannelHost({ channels, onMessage() {} });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("collectText", () => {
+  it("joins every text chunk and ignores the other variants", async () => {
+    const chunks: ChannelChunk[] = [
+      { type: "reasoning", text: "thinking" },
+      { type: "text", text: "Hello " },
+      { type: "tool", name: "search", status: "started" },
+      { type: "text", text: "world" },
+      { type: "source", url: "https://example.com" }
+    ];
+
+    await expect(collectText(streamOf(chunks))).resolves.toEqual({
+      text: "Hello world",
+      interrupted: false
+    });
+  });
+
+  it("separates text segments divided by a semantic chunk", async () => {
+    const chunks: ChannelChunk[] = [
+      { type: "text", text: "Hello" },
+      { type: "tool", name: "search", status: "completed" },
+      { type: "text", text: "world" }
+    ];
+
+    await expect(collectText(streamOf(chunks))).resolves.toEqual({
+      text: "Hello world",
+      interrupted: false
+    });
+  });
+
+  it("does not separate adjacent text deltas", async () => {
+    await expect(
+      collectText(streamOf(text("Half an", "swer")))
+    ).resolves.toEqual({
+      text: "Half answer",
+      interrupted: false
+    });
+  });
+
+  it("reports interruption instead of losing the partial answer", async () => {
+    const chunks = streamOf(text("Half an "), new Error("model failed"));
+
+    await expect(collectText(chunks)).resolves.toEqual({
+      text: "Half an ",
+      interrupted: true
+    });
+  });
+});
+
+describe("consumeChunks", () => {
+  it("finalizes once when the stream closes normally", async () => {
+    const onFinish = vi.fn(() => "done");
+
+    await expect(
+      consumeChunks(streamOf(text("a", "b")), { onChunk() {}, onFinish })
+    ).resolves.toBe("done");
+    expect(onFinish).toHaveBeenCalledExactlyOnceWith({ interrupted: false });
+  });
+
+  it("finalizes with the cause when the generation fails", async () => {
+    const error = new Error("model failed");
+    const seen: ChannelChunk[] = [];
+
+    const outcome = await consumeChunks(streamOf(text("a"), error), {
+      onChunk: (chunk) => void seen.push(chunk),
+      onFinish: (result) => result
+    });
+
+    expect(seen).toEqual(text("a"));
+    expect(outcome).toEqual({ interrupted: true, error });
+  });
+
+  it("finalizes and stops the producer when the handler throws", async () => {
+    const cancel = vi.fn();
+    const chunks = new ReadableStream<ChannelChunk>({
+      pull: (controller) => controller.enqueue({ type: "text", text: "a" }),
+      cancel
+    });
+    const error = new Error("provider rejected the append");
+
+    const outcome = await consumeChunks(chunks, {
+      onChunk() {
+        throw error;
+      },
+      onFinish: (result) => result
+    });
+
+    expect(outcome).toEqual({ interrupted: true, error });
+    expect(cancel).toHaveBeenCalledOnce();
+  });
+});
+
+describe("createPacer", () => {
+  it("allows the first flush immediately", () => {
+    expect(createPacer(1000)()).toBe(true);
+  });
+
+  it("withholds a flush until the interval has passed", () => {
+    vi.useFakeTimers();
+    const shouldFlush = createPacer(1000);
+
+    expect([shouldFlush(), shouldFlush(), shouldFlush()]).toEqual([
+      true,
+      false,
+      false
+    ]);
+
+    vi.setSystemTime(Date.now() + 1000);
+    expect(shouldFlush()).toBe(true);
+  });
+
+  it("never withholds when the interval is zero", () => {
+    vi.useFakeTimers();
+    const shouldFlush = createPacer(0);
+
+    expect([shouldFlush(), shouldFlush()]).toEqual([true, true]);
+  });
+});
+
+describe("ChannelHost.stream", () => {
+  it("hands a streaming Channel the normalized stream", async () => {
+    const seen: ChannelChunk[] = [];
+    const stream = vi.fn(
+      async (
+        _surface,
+        chunks: ReadableStream<ChannelChunk>
+      ): Promise<DeliveryResult> => {
+        seen.push(...(await drain(chunks)));
+        return { status: "delivered", reference: "message-1" };
+      }
+    );
+
+    await expect(
+      host({ test: { stream } }).stream(
+        surface,
+        streamOf(text("Hello ", "world")),
+        { title: "Update" }
+      )
+    ).resolves.toEqual({ status: "delivered", reference: "message-1" });
+    expect(seen).toEqual(text("Hello ", "world"));
+    expect(stream.mock.calls[0]?.[2]).toEqual({ title: "Update" });
+  });
+
+  it("accepts a plain string stream so textStream needs no adaptation", async () => {
+    const received: ChannelChunk[] = [];
+    const channelHost = host({
+      test: {
+        async stream(_surface, chunks) {
+          received.push(...(await drain(chunks)));
+          return { status: "delivered" };
+        }
+      }
+    });
+
+    await channelHost.stream(surface, streamOf(text("Hello ", "world")));
+
+    expect(received).toEqual(text("Hello ", "world"));
+  });
+
+  it("accepts an async iterable", async () => {
+    async function* generate() {
+      yield* text("Hello ", "world");
+    }
+    const received: ChannelChunk[] = [];
+    const channelHost = host({
+      test: {
+        async stream(_surface, chunks) {
+          received.push(...(await drain(chunks)));
+          return { status: "delivered" };
+        }
+      }
+    });
+
+    await channelHost.stream(surface, generate());
+
+    expect(received).toEqual(text("Hello ", "world"));
+  });
+
+  it("collects the answer for a Channel that cannot stream", async () => {
+    const deliver = vi.fn(async () => ({ status: "delivered" as const }));
+
+    await expect(
+      host({ test: { deliver } }).stream(surface, streamOf(text("a", "b")), {
+        title: "Update",
+        delivery: { deliveryId: "notice-1" }
+      })
+    ).resolves.toEqual({ status: "delivered" });
+    expect(deliver).toHaveBeenCalledWith(
+      surface,
+      { title: "Update", markdown: "ab" },
+      { delivery: { deliveryId: "notice-1" } }
+    );
+  });
+
+  it("delivers a partial answer as uncertain when the generation fails", async () => {
+    const deliver = vi.fn(async () => ({
+      status: "delivered" as const,
+      reference: "message-1"
+    }));
+
+    await expect(
+      host({ test: { deliver } }).stream(
+        surface,
+        streamOf(text("Half an "), new Error("model failed"))
+      )
+    ).resolves.toEqual({
+      status: "uncertain",
+      reference: "message-1",
+      error: {
+        code: "CHANNEL_STREAM_INTERRUPTED",
+        message:
+          "An incomplete answer was delivered because the stream ended early"
+      }
+    });
+    expect(deliver).toHaveBeenCalledWith(
+      surface,
+      { markdown: "Half an " },
+      undefined
+    );
+  });
+
+  it("does not call a Channel when a failed generation produced nothing", async () => {
+    const deliver = vi.fn(async () => ({ status: "delivered" as const }));
+
+    await expect(
+      host({ test: { deliver } }).stream(
+        surface,
+        streamOf<ChannelChunk>([], new Error("model failed"))
+      )
+    ).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "CHANNEL_STREAM_INTERRUPTED" }
+    });
+    expect(deliver).not.toHaveBeenCalled();
+  });
+
+  it("releases the stream when the Channel cannot deliver at all", async () => {
+    const chunks = streamOf(text("a"));
+
+    await expect(
+      host({ test: {} }).stream(surface, chunks)
+    ).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "CHANNEL_DELIVERY_UNSUPPORTED" }
+    });
+    expect(chunks.locked).toBe(false);
+    await expect(drain(chunks)).resolves.toEqual([]);
+  });
+});

--- a/packages/channels/src/__tests__/stream.test.ts
+++ b/packages/channels/src/__tests__/stream.test.ts
@@ -137,6 +137,28 @@ describe("consumeChunks", () => {
     expect(outcome).toEqual({ interrupted: true, error });
     expect(cancel).toHaveBeenCalledOnce();
   });
+
+  it("finalizes and stops the producer when aborted", async () => {
+    const cancel = vi.fn();
+    const chunks = new ReadableStream<ChannelChunk>({ cancel });
+    const abort = new AbortController();
+    const consuming = consumeChunks(
+      chunks,
+      {
+        onChunk() {},
+        onFinish: (result) => result
+      },
+      { signal: abort.signal }
+    );
+
+    abort.abort("cancelled");
+
+    await expect(consuming).resolves.toEqual({
+      interrupted: true,
+      error: "cancelled"
+    });
+    expect(cancel).toHaveBeenCalledExactlyOnceWith("cancelled");
+  });
 });
 
 describe("createPacer", () => {

--- a/packages/channels/src/__tests__/telegram-stream.test.ts
+++ b/packages/channels/src/__tests__/telegram-stream.test.ts
@@ -1,0 +1,323 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ChannelChunk } from "..";
+import { telegram } from "../adapters/telegram";
+
+const BOT_TOKEN = "4242:bot-secret";
+const PRIVATE_SURFACE = {
+  channelKey: "telegram",
+  version: 1,
+  address: { chatId: "99" },
+  label: "Telegram · 99"
+} as const;
+
+type Call = { method: string; body: Record<string, unknown> };
+
+function recorder(overrides: Record<string, () => Response> = {}): {
+  fetch: typeof globalThis.fetch;
+  calls: Call[];
+} {
+  const calls: Call[] = [];
+  let messageId = 500;
+  const fetch = vi.fn<typeof globalThis.fetch>(async (input, init) => {
+    const method = String(input).split("/").pop()!;
+    calls.push({ method, body: JSON.parse(String(init?.body)) });
+    if (overrides[method]) return overrides[method]!();
+    if (method !== "sendMessage")
+      return Response.json({ ok: true, result: true });
+    messageId += 1;
+    return Response.json({ ok: true, result: { message_id: messageId } });
+  });
+  return { fetch, calls };
+}
+
+function streamOf<T>(values: readonly T[], error?: unknown): ReadableStream<T> {
+  let index = 0;
+  return new ReadableStream<T>({
+    pull(controller) {
+      if (index < values.length) {
+        controller.enqueue(values[index]!);
+        index += 1;
+        return;
+      }
+      if (error !== undefined) controller.error(error);
+      else controller.close();
+    }
+  });
+}
+
+function chunks(...parts: string[]): ReadableStream<ChannelChunk> {
+  return streamOf(parts.map((text) => ({ type: "text", text }) as const));
+}
+
+function of(calls: Call[], method: string): Call[] {
+  return calls.filter((call) => call.method === method);
+}
+
+describe("Telegram streaming", () => {
+  it("previews cumulative drafts, then persists the whole answer", async () => {
+    const { fetch, calls } = recorder();
+    const channel = telegram({
+      botToken: BOT_TOKEN,
+      fetch,
+      streamIntervalMs: 0
+    });
+
+    await expect(
+      channel.stream!(PRIVATE_SURFACE, chunks("Hello ", "world"), {})
+    ).resolves.toEqual({ status: "delivered", reference: "501" });
+
+    const drafts = of(calls, "sendMessageDraft");
+    expect(drafts.map((call) => call.body.text)).toEqual([
+      "Hello ",
+      "Hello world"
+    ]);
+    // One draft id, so Telegram animates between the snapshots.
+    expect(new Set(drafts.map((call) => call.body.draft_id)).size).toBe(1);
+    expect(drafts[0]?.body.chat_id).toBe(99);
+    expect(calls.at(-1)).toEqual({
+      method: "sendMessage",
+      body: { chat_id: "99", text: "Hello world" }
+    });
+  });
+
+  it("previews at most once per interval, then persists everything", async () => {
+    vi.useFakeTimers();
+    const { fetch, calls } = recorder();
+    const channel = telegram({
+      botToken: BOT_TOKEN,
+      fetch,
+      streamIntervalMs: 1000
+    });
+
+    await channel.stream!(PRIVATE_SURFACE, chunks("a", "b", "c"), {});
+
+    // No trailing preview: the message that replaces it lands immediately
+    // after, so drafting the tail would only flicker.
+    expect(of(calls, "sendMessageDraft").map((call) => call.body.text)).toEqual(
+      ["a"]
+    );
+    expect(calls.at(-1)?.body.text).toBe("abc");
+    vi.useRealTimers();
+  });
+
+  it("prefixes the title on both the preview and the message", async () => {
+    const { fetch, calls } = recorder();
+    const channel = telegram({
+      botToken: BOT_TOKEN,
+      fetch,
+      streamIntervalMs: 0
+    });
+
+    await channel.stream!(PRIVATE_SURFACE, chunks("Body"), {
+      title: "Deploy status"
+    });
+
+    expect(of(calls, "sendMessageDraft")[0]?.body.text).toBe(
+      "Deploy status\n\nBody"
+    );
+    expect(calls.at(-1)?.body.text).toBe("Deploy status\n\nBody");
+  });
+
+  it("never applies a parse mode to a draft, whose markup is unbalanced", async () => {
+    const { fetch, calls } = recorder();
+    const channel = telegram({
+      botToken: BOT_TOKEN,
+      fetch,
+      parseMode: "MarkdownV2",
+      streamIntervalMs: 0
+    });
+
+    await channel.stream!(PRIVATE_SURFACE, chunks("*bold", "*"), {});
+
+    expect(of(calls, "sendMessageDraft")[0]?.body.parse_mode).toBeUndefined();
+    expect(calls.at(-1)?.body.parse_mode).toBe("MarkdownV2");
+  });
+
+  it("sends the real message even when the generation failed part-way", async () => {
+    const { fetch, calls } = recorder();
+    const channel = telegram({
+      botToken: BOT_TOKEN,
+      fetch,
+      streamIntervalMs: 0
+    });
+    const interrupted = streamOf(
+      [{ type: "text", text: "Half an " } as const],
+      new Error("model failed")
+    );
+
+    await expect(
+      channel.stream!(PRIVATE_SURFACE, interrupted, {})
+    ).resolves.toEqual({
+      status: "uncertain",
+      reference: "501",
+      error: {
+        code: "TELEGRAM_STREAM_INTERRUPTED",
+        message: "An incomplete answer was sent because the stream ended early"
+      }
+    });
+    expect(calls.at(-1)).toEqual({
+      method: "sendMessage",
+      body: { chat_id: "99", text: "Half an " }
+    });
+  });
+
+  it("sends the real message even when every draft was rejected", async () => {
+    const { fetch, calls } = recorder({
+      sendMessageDraft: () =>
+        Response.json({ ok: false, error_code: 400, description: "nope" })
+    });
+    const channel = telegram({
+      botToken: BOT_TOKEN,
+      fetch,
+      streamIntervalMs: 0
+    });
+
+    await expect(
+      channel.stream!(PRIVATE_SURFACE, chunks("a", "b"), {})
+    ).resolves.toEqual({ status: "delivered", reference: "501" });
+    // Drafting stops after the first refusal rather than retrying per chunk.
+    expect(of(calls, "sendMessageDraft")).toHaveLength(1);
+    expect(of(calls, "sendMessage")).toHaveLength(1);
+  });
+
+  it("skips drafts in a group, where Telegram does not support them", async () => {
+    const { fetch, calls } = recorder();
+    const channel = telegram({
+      botToken: BOT_TOKEN,
+      fetch,
+      streamIntervalMs: 0
+    });
+
+    await expect(
+      channel.stream!(
+        {
+          channelKey: "telegram",
+          version: 1,
+          address: { chatId: "-100200" },
+          label: "Telegram · group"
+        },
+        chunks("Hello"),
+        {}
+      )
+    ).resolves.toEqual({ status: "delivered", reference: "501" });
+    expect(of(calls, "sendMessageDraft")).toEqual([]);
+    expect(calls.at(-1)?.body).toEqual({ chat_id: "-100200", text: "Hello" });
+  });
+
+  it("splits an answer that outgrows one Telegram message", async () => {
+    const { fetch, calls } = recorder();
+    const channel = telegram({
+      botToken: BOT_TOKEN,
+      fetch,
+      maxLength: 10,
+      streamIntervalMs: 0
+    });
+
+    await expect(
+      channel.stream!(PRIVATE_SURFACE, chunks("0123456789abc"), {})
+    ).resolves.toEqual({ status: "delivered", reference: "501" });
+    expect(of(calls, "sendMessage").map((call) => call.body.text)).toEqual([
+      "0123456789",
+      "abc"
+    ]);
+    // The preview cannot outgrow the limit either.
+    expect(of(calls, "sendMessageDraft")[0]?.body.text).toBe("0123456789");
+  });
+
+  it("reports a partly accepted split answer as uncertain", async () => {
+    let sends = 0;
+    const { fetch } = recorder({
+      sendMessage: () => {
+        sends += 1;
+        return sends === 1
+          ? Response.json({ ok: true, result: { message_id: 501 } })
+          : Response.json({ ok: false, error_code: 400, description: "no" });
+      }
+    });
+    const channel = telegram({
+      botToken: BOT_TOKEN,
+      fetch,
+      maxLength: 10,
+      streamIntervalMs: 0
+    });
+
+    await expect(
+      channel.stream!(PRIVATE_SURFACE, chunks("0123456789abc"), {})
+    ).resolves.toEqual({
+      status: "uncertain",
+      reference: "501",
+      error: {
+        code: "TELEGRAM_STREAM_PARTIAL",
+        message: "Telegram accepted only part of a split answer"
+      }
+    });
+  });
+
+  it("refuses a stream that carried no text", async () => {
+    const { fetch, calls } = recorder();
+    const channel = telegram({
+      botToken: BOT_TOKEN,
+      fetch,
+      streamIntervalMs: 0
+    });
+
+    await expect(
+      channel.stream!(
+        PRIVATE_SURFACE,
+        streamOf([{ type: "reasoning", text: "quiet" } as const]),
+        {}
+      )
+    ).resolves.toEqual({
+      status: "failed",
+      retryable: false,
+      error: {
+        code: "TELEGRAM_STREAM_EMPTY",
+        message: "The stream carried no text to send"
+      }
+    });
+    expect(calls).toEqual([]);
+  });
+
+  it("distinguishes an empty stream from one that died before its first token", async () => {
+    const { fetch } = recorder();
+    const channel = telegram({
+      botToken: BOT_TOKEN,
+      fetch,
+      streamIntervalMs: 0
+    });
+
+    await expect(
+      channel.stream!(
+        PRIVATE_SURFACE,
+        streamOf<ChannelChunk>([], new Error("model failed")),
+        {}
+      )
+    ).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "TELEGRAM_STREAM_INTERRUPTED" }
+    });
+  });
+
+  it("rejects a malformed surface without calling Telegram", async () => {
+    const { fetch, calls } = recorder();
+    const channel = telegram({ botToken: BOT_TOKEN, fetch });
+
+    await expect(
+      channel.stream!(
+        { channelKey: "telegram", version: 1, address: null, label: "bad" },
+        chunks("a"),
+        {}
+      )
+    ).resolves.toMatchObject({
+      status: "failed",
+      error: { code: "TELEGRAM_SURFACE_INVALID" }
+    });
+    expect(calls).toEqual([]);
+  });
+
+  it("rejects a nonsensical stream interval when the Channel is created", () => {
+    expect(() =>
+      telegram({ botToken: BOT_TOKEN, streamIntervalMs: 1.5 })
+    ).toThrow("streamIntervalMs must be a non-negative integer");
+  });
+});

--- a/packages/channels/src/__tests__/web-protocol.test.ts
+++ b/packages/channels/src/__tests__/web-protocol.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeWebChatRequest,
+  WebChatChunkEncoder
+} from "../adapters/web-protocol";
+
+describe("normalizeWebChatRequest", () => {
+  it("normalizes the latest user message from an AI SDK request", () => {
+    expect(
+      normalizeWebChatRequest({
+        model: "example",
+        messages: [
+          {
+            id: "user-1",
+            role: "user",
+            parts: [{ type: "text", text: "First" }]
+          },
+          {
+            id: "assistant-1",
+            role: "assistant",
+            parts: [{ type: "text", text: "Answer" }]
+          },
+          {
+            id: "user-2",
+            role: "user",
+            parts: [
+              { type: "text", text: "Hello " },
+              { type: "file", url: "https://example.com/file" },
+              { type: "text", text: "world" }
+            ]
+          }
+        ]
+      })
+    ).toMatchObject({
+      message: { id: "user-2", text: "Hello world" },
+      body: { model: "example" }
+    });
+  });
+
+  it("rejects bodies without a user message", () => {
+    expect(normalizeWebChatRequest({ messages: [] })).toBeNull();
+  });
+});
+
+describe("WebChatChunkEncoder", () => {
+  it("projects text, reasoning, and sources into AI SDK UI chunks", () => {
+    const encoder = new WebChatChunkEncoder("turn-1");
+
+    expect([
+      ...encoder.push({ type: "reasoning", text: "Think" }),
+      ...encoder.push({ type: "reasoning", text: "ing" }),
+      ...encoder.push({
+        type: "tool",
+        name: "search",
+        status: "completed"
+      }),
+      ...encoder.push({ type: "text", text: "Answer" }),
+      ...encoder.push({
+        type: "source",
+        url: "https://example.com",
+        title: "Example"
+      }),
+      ...encoder.finishPart()
+    ]).toEqual([
+      { type: "reasoning-start", id: "turn-1:reasoning:1" },
+      {
+        type: "reasoning-delta",
+        id: "turn-1:reasoning:1",
+        delta: "Think"
+      },
+      {
+        type: "reasoning-delta",
+        id: "turn-1:reasoning:1",
+        delta: "ing"
+      },
+      { type: "reasoning-end", id: "turn-1:reasoning:1" },
+      { type: "text-start", id: "turn-1:text:2" },
+      { type: "text-delta", id: "turn-1:text:2", delta: "Answer" },
+      { type: "text-end", id: "turn-1:text:2" },
+      {
+        type: "source-url",
+        sourceId: "turn-1:source:1",
+        url: "https://example.com",
+        title: "Example"
+      }
+    ]);
+  });
+});

--- a/packages/channels/src/__tests__/web.test.ts
+++ b/packages/channels/src/__tests__/web.test.ts
@@ -20,7 +20,7 @@ const mocks = vi.hoisted(() => {
 
 vi.mock("agents/websockets", () => ({ WebSockets: mocks.FakeWebSockets }));
 
-import { ChannelHost, type ChannelChunk } from "..";
+import { ChannelHost, type ChannelChunk, type DeliveryResult } from "..";
 import { web } from "../adapters/web";
 
 function streamOf(...chunks: ChannelChunk[]): ReadableStream<ChannelChunk> {
@@ -44,12 +44,13 @@ describe("web Channel", () => {
     const connection = { id: "browser-1", send };
     capability.connections.set(connection.id, connection);
     const onMessage = vi.fn();
+    let result: DeliveryResult | undefined;
     let host!: ChannelHost;
     host = new ChannelHost({
       channels: { browser: channel },
       async onMessage(event) {
         onMessage(event);
-        await host.stream(
+        result = await host.stream(
           event.message.replySurface!,
           streamOf(
             { type: "reasoning", text: "Brief thought" },
@@ -94,6 +95,10 @@ describe("web Channel", () => {
         })
       })
     );
+    expect(result).toEqual({
+      status: "delivered",
+      reference: "web:browser-1:request:turn-1"
+    });
     expect(send.mock.calls.map(([frame]) => JSON.parse(frame))).toEqual([
       {
         body: JSON.stringify({

--- a/packages/channels/src/__tests__/web.test.ts
+++ b/packages/channels/src/__tests__/web.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  class FakeWebSockets {
+    readonly handlers: Record<string, (...args: never[]) => unknown>;
+    readonly connections = new Map<string, unknown>();
+
+    constructor(options: {
+      handlers: Record<string, (...args: never[]) => unknown>;
+    }) {
+      this.handlers = options.handlers;
+    }
+
+    getConnection(id: string) {
+      return this.connections.get(id);
+    }
+  }
+  return { FakeWebSockets };
+});
+
+vi.mock("agents/websockets", () => ({ WebSockets: mocks.FakeWebSockets }));
+
+import { ChannelHost, type ChannelChunk } from "..";
+import { web } from "../adapters/web";
+
+function streamOf(...chunks: ChannelChunk[]): ReadableStream<ChannelChunk> {
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    }
+  });
+}
+
+describe("web Channel", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("dispatches browser turns through ChannelHost and streams the reply", async () => {
+    const channel = web();
+    const capability = channel.webSockets as unknown as InstanceType<
+      typeof mocks.FakeWebSockets
+    >;
+    const send = vi.fn();
+    const connection = { id: "browser-1", send };
+    capability.connections.set(connection.id, connection);
+    const onMessage = vi.fn();
+    let host!: ChannelHost;
+    host = new ChannelHost({
+      channels: { browser: channel },
+      async onMessage(event) {
+        onMessage(event);
+        await host.stream(
+          event.message.replySurface!,
+          streamOf(
+            { type: "reasoning", text: "Brief thought" },
+            { type: "text", text: "Hello" }
+          )
+        );
+      }
+    });
+
+    await capability.handlers.onMessage!(
+      connection as never,
+      JSON.stringify({
+        type: "cf_agent_use_chat_request",
+        id: "turn-1",
+        init: {
+          method: "POST",
+          body: JSON.stringify({
+            messages: [
+              {
+                id: "message-1",
+                role: "user",
+                parts: [{ type: "text", text: "Hi" }]
+              }
+            ]
+          })
+        }
+      }) as never
+    );
+
+    expect(onMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelKey: "browser",
+        route: "browser-1",
+        message: expect.objectContaining({
+          message: { id: "message-1", text: "Hi" },
+          replySurface: {
+            channelKey: "browser",
+            version: 1,
+            address: { connectionId: "browser-1", requestId: "turn-1" },
+            label: "Web chat"
+          }
+        })
+      })
+    );
+    expect(send.mock.calls.map(([frame]) => JSON.parse(frame))).toEqual([
+      {
+        body: JSON.stringify({
+          type: "reasoning-start",
+          id: "turn-1:reasoning:1"
+        }),
+        done: false,
+        id: "turn-1",
+        type: "cf_agent_use_chat_response"
+      },
+      {
+        body: JSON.stringify({
+          type: "reasoning-delta",
+          id: "turn-1:reasoning:1",
+          delta: "Brief thought"
+        }),
+        done: false,
+        id: "turn-1",
+        type: "cf_agent_use_chat_response"
+      },
+      {
+        body: JSON.stringify({
+          type: "reasoning-end",
+          id: "turn-1:reasoning:1"
+        }),
+        done: false,
+        id: "turn-1",
+        type: "cf_agent_use_chat_response"
+      },
+      {
+        body: JSON.stringify({ type: "text-start", id: "turn-1:text:2" }),
+        done: false,
+        id: "turn-1",
+        type: "cf_agent_use_chat_response"
+      },
+      {
+        body: JSON.stringify({
+          type: "text-delta",
+          id: "turn-1:text:2",
+          delta: "Hello"
+        }),
+        done: false,
+        id: "turn-1",
+        type: "cf_agent_use_chat_response"
+      },
+      {
+        body: JSON.stringify({ type: "text-end", id: "turn-1:text:2" }),
+        done: false,
+        id: "turn-1",
+        type: "cf_agent_use_chat_response"
+      },
+      {
+        body: "",
+        done: true,
+        id: "turn-1",
+        type: "cf_agent_use_chat_response"
+      }
+    ]);
+  });
+
+  it("answers resume probes without inventing durable replay", async () => {
+    const channel = web();
+    const capability = channel.webSockets as unknown as InstanceType<
+      typeof mocks.FakeWebSockets
+    >;
+    const send = vi.fn();
+
+    await capability.handlers.onMessage!(
+      { id: "browser-1", send } as never,
+      JSON.stringify({
+        type: "cf_agent_stream_resume_request",
+        probeId: "probe-1"
+      }) as never
+    );
+
+    expect(JSON.parse(send.mock.calls[0]![0])).toEqual({
+      type: "cf_agent_stream_resume_none",
+      reason: "idle",
+      probeId: "probe-1"
+    });
+  });
+});

--- a/packages/channels/src/adapters/slack.ts
+++ b/packages/channels/src/adapters/slack.ts
@@ -1,10 +1,13 @@
 import type {
   Channel,
   ChannelApprovalRequest,
+  ChannelChunk,
   ChannelMessage,
   ChannelRoute,
+  ChannelStreamOptions,
   DeliveryResult
 } from "../channel";
+import { collectText, consumeChunks, createPacer } from "../stream";
 import type { ChannelIdentity } from "../identity";
 import {
   isChannelMessageSurface,
@@ -116,7 +119,14 @@ export type SlackWebhookOptions = {
 
 export type SlackMessageSurface = ChannelMessageSurface<
   string,
-  { channelId: string; threadTs?: string } | { teamId: string; userId: string }
+  | {
+      channelId: string;
+      threadTs?: string;
+      /** The reader a channel stream is rendered for. Slack requires it. */
+      recipientUserId?: string;
+      recipientTeamId?: string;
+    }
+  | { teamId: string; userId: string }
 >;
 
 /** Configuration for a Slack Channel. */
@@ -127,6 +137,11 @@ export type SlackChannelOptions = {
   apiBaseUrl?: string;
   /** Project canonical Channel Markdown into Slack mrkdwn text. */
   toText?: (message: ChannelMessage) => string;
+  /**
+   * Smallest gap between `chat.appendStream` calls. Chunks produced inside
+   * one interval are appended together. @default 500
+   */
+  streamIntervalMs?: number;
   /** Add signed Slack HTTP ingress to the returned Channel. */
   webhook?: SlackWebhookOptions;
   /** Select an application route from the event, exact payload, and Host context. */
@@ -158,6 +173,10 @@ const DEFAULT_SLACK_WEBHOOK_PATH = "/webhooks/slack";
 const DEFAULT_MAX_SKEW_SECONDS = 5 * 60;
 const APPROVE_ACTION_ID = "cloudflare_channels_approve_v1";
 const REJECT_ACTION_ID = "cloudflare_channels_reject_v1";
+const DEFAULT_STREAM_INTERVAL_MS = 500;
+const SLACK_APPEND_LIMIT = 12_000;
+const SLACK_TASK_FIELD_LIMIT = 256;
+const SLACK_CONTEXT_LIMIT = 3000;
 const AMBIGUOUS_SLACK_ERRORS = new Set([
   "fatal_error",
   "internal_error",
@@ -305,6 +324,12 @@ function normalizedEvent(
         channelId,
         ...((threadTimestamp || !isDirectMessage) && {
           threadTs: threadTimestamp ?? timestamp
+        }),
+        // Slack renders a channel stream for one reader, and requires both
+        // ids to do it. A direct message already has a single reader.
+        ...(!isDirectMessage && {
+          recipientUserId: actorId,
+          recipientTeamId: teamId
         })
       },
       label: replySurfaceLabel(
@@ -431,7 +456,11 @@ async function normalizedInteractions(
         address: {
           teamId,
           channelId,
-          threadTs: threadTimestamp ?? timestamp
+          threadTs: threadTimestamp ?? timestamp,
+          ...(!isDirectMessage && {
+            recipientUserId: actorId,
+            recipientTeamId: teamId
+          })
         },
         label: replySurfaceLabel(channelId, threadTimestamp ?? timestamp)
       },
@@ -602,7 +631,7 @@ function failed(
   code: string,
   message: string,
   retryable: boolean
-): DeliveryResult {
+): Extract<DeliveryResult, { status: "failed" }> {
   return {
     status: "failed",
     retryable,
@@ -614,23 +643,10 @@ function slackErrorCode(error: string): string {
   return `SLACK_API_ERROR_${error.toUpperCase().replace(/[^A-Z0-9]+/g, "_")}`;
 }
 
-function classifyApiResponse(
+function classifyApiFailure(
   response: Response,
   payload: SlackApiResponse
-): DeliveryResult {
-  if (payload.ok === true) {
-    if (typeof payload.channel === "string" && typeof payload.ts === "string") {
-      return {
-        status: "delivered",
-        reference: outboundReference(payload.channel, payload.ts)
-      };
-    }
-    return uncertain(
-      "SLACK_DELIVERY_ERROR",
-      "Slack returned an invalid delivery response"
-    );
-  }
-
+): Exclude<DeliveryResult, { status: "delivered" }> {
   if (payload.ok === false) {
     const error =
       typeof payload.error === "string" ? payload.error : "unknown_error";
@@ -681,9 +697,19 @@ function approvalValue(
   } satisfies ApprovalValue);
 }
 
-type SlackTarget =
-  | { teamId?: string; channelId: string; threadTs?: string }
-  | { teamId: string; userId: string };
+/** A resolved conversation, with the reader a stream should be rendered for. */
+type SlackDestination = {
+  channelId: string;
+  threadTs?: string;
+  recipientUserId?: string;
+  recipientTeamId?: string;
+};
+
+type SlackTarget = SlackDestination | { teamId: string; userId: string };
+
+function optionalId(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
 
 function slackTarget(surface: ChannelMessageSurface): SlackTarget | undefined {
   if (
@@ -712,11 +738,94 @@ function slackTarget(surface: ChannelMessageSurface): SlackTarget | undefined {
   ) {
     return undefined;
   }
+  const recipientUserId = optionalId(address.recipientUserId);
+  const recipientTeamId = optionalId(address.recipientTeamId);
   return {
     channelId: address.channelId,
     ...(typeof address.threadTs === "string" && {
       threadTs: address.threadTs
-    })
+    }),
+    // Slack rejects one without the other, so only carry a complete pair.
+    ...(recipientUserId &&
+      recipientTeamId && { recipientUserId, recipientTeamId })
+  };
+}
+
+type SlackStreamChunk =
+  | { type: "markdown_text"; text: string }
+  | {
+      type: "task_update";
+      id: string;
+      title: string;
+      status: "in_progress" | "complete" | "error";
+      details?: string;
+    };
+
+const SLACK_TASK_STATUS = {
+  started: "in_progress",
+  completed: "complete",
+  failed: "error"
+} as const;
+
+function clamp(value: string, limit: number): string {
+  return value.length <= limit ? value : `${value.slice(0, limit - 1)}\u2026`;
+}
+
+function splitText(text: string, limit: number): string[] {
+  if (text.length <= limit) return text.length > 0 ? [text] : [];
+  const pieces: string[] = [];
+  for (let index = 0; index < text.length; index += limit) {
+    pieces.push(text.slice(index, index + limit));
+  }
+  return pieces;
+}
+
+/**
+ * Render a neutral chunk as Slack stream content.
+ *
+ * `reasoning` has no Slack rendering and is dropped. A `source` is collected
+ * rather than appended, so it can be rendered once beneath the finished
+ * message instead of interrupting the text.
+ */
+function toStreamChunks(
+  chunk: ChannelChunk,
+  sources: { url: string; title?: string }[]
+): SlackStreamChunk[] {
+  switch (chunk.type) {
+    case "text":
+      return splitText(chunk.text, SLACK_APPEND_LIMIT).map((text) => ({
+        type: "markdown_text",
+        text
+      }));
+    case "tool":
+      return [
+        {
+          type: "task_update",
+          id: chunk.name,
+          title: clamp(chunk.title ?? chunk.name, SLACK_TASK_FIELD_LIMIT),
+          status: SLACK_TASK_STATUS[chunk.status],
+          ...(chunk.detail !== undefined && {
+            details: clamp(chunk.detail, SLACK_TASK_FIELD_LIMIT)
+          })
+        }
+      ];
+    case "source":
+      sources.push(chunk);
+      return [];
+    case "reasoning":
+      return [];
+  }
+}
+
+function sourcesBlock(
+  sources: readonly { url: string; title?: string }[]
+): Record<string, unknown> {
+  const text = sources
+    .map((source) => `<${source.url}|${source.title ?? source.url}>`)
+    .join(" \u00b7 ");
+  return {
+    type: "context",
+    elements: [{ type: "mrkdwn", text: clamp(text, SLACK_CONTEXT_LIMIT) }]
   };
 }
 
@@ -733,11 +842,16 @@ export function slack(
     ""
   );
   const toText = options.toText ?? defaultText;
+  const streamIntervalMs =
+    options.streamIntervalMs ?? DEFAULT_STREAM_INTERVAL_MS;
+  if (!Number.isInteger(streamIntervalMs) || streamIntervalMs < 0) {
+    throw new Error("streamIntervalMs must be a non-negative integer");
+  }
   const ingress = options.webhook ? slackWebhook(options.webhook) : undefined;
 
   async function resolveTarget(
     target: SlackTarget
-  ): Promise<{ channelId: string; threadTs?: string } | DeliveryResult> {
+  ): Promise<SlackDestination | DeliveryResult> {
     if (!("userId" in target)) return target;
 
     let response: Response;
@@ -772,7 +886,11 @@ export function slack(
       ? (payload as SlackOpenConversationResponse)
       : undefined;
     if (result?.ok === true && typeof result.channel?.id === "string") {
-      return { channelId: result.channel.id };
+      return {
+        channelId: result.channel.id,
+        recipientUserId: target.userId,
+        recipientTeamId: target.teamId
+      };
     }
     const error = typeof result?.error === "string" ? result.error : "unknown";
     return failed(
@@ -801,21 +919,44 @@ export function slack(
     const target = await resolveTarget(unresolvedTarget);
     if ("status" in target) return target;
 
+    const sent = await callSlack("chat.postMessage", {
+      channel: target.channelId,
+      text,
+      mrkdwn: true,
+      ...(target.threadTs && { thread_ts: target.threadTs }),
+      ...(blocks && { blocks })
+    });
+    return "status" in sent
+      ? sent
+      : {
+          status: "delivered",
+          reference: outboundReference(sent.channelId, sent.ts)
+        };
+  }
+
+  /**
+   * One transport path for every Slack method this Channel calls.
+   *
+   * Each of them answers with the conversation and timestamp on success, and
+   * every failure mode is classified the same way, so posting and streaming
+   * cannot drift apart.
+   */
+  async function callSlack(
+    method: string,
+    body: Record<string, unknown>
+  ): Promise<
+    | { channelId: string; ts: string }
+    | Exclude<DeliveryResult, { status: "delivered" }>
+  > {
     let response: Response;
     try {
-      response = await fetch(`${apiBaseUrl}/chat.postMessage`, {
+      response = await fetch(`${apiBaseUrl}/${method}`, {
         method: "POST",
         headers: {
           authorization: `Bearer ${options.botToken}`,
           "content-type": "application/json; charset=utf-8"
         },
-        body: JSON.stringify({
-          channel: target.channelId,
-          text,
-          mrkdwn: true,
-          ...(target.threadTs && { thread_ts: target.threadTs }),
-          ...(blocks && { blocks })
-        })
+        body: JSON.stringify(body)
       });
     } catch {
       return uncertain(
@@ -828,33 +969,152 @@ export function slack(
     try {
       payload = await response.json();
     } catch {
-      if (response.status === 429) {
-        return failed(
-          "SLACK_HTTP_ERROR_429",
-          "Slack rate limited the message",
-          true
-        );
-      }
-      if (response.status >= 400 && response.status < 500) {
-        return failed(
-          `SLACK_HTTP_ERROR_${response.status}`,
-          `Slack rejected the message with HTTP ${response.status}`,
-          false
-        );
-      }
-      return uncertain(
-        "SLACK_DELIVERY_ERROR",
-        "Slack returned an invalid delivery response"
+      payload = undefined;
+    }
+    const apiResponse = asApiResponse(payload);
+    if (
+      apiResponse?.ok === true &&
+      typeof apiResponse.channel === "string" &&
+      typeof apiResponse.ts === "string"
+    ) {
+      return { channelId: apiResponse.channel, ts: apiResponse.ts };
+    }
+    return apiResponse?.ok === true
+      ? uncertain(
+          "SLACK_DELIVERY_ERROR",
+          "Slack returned an invalid delivery response"
+        )
+      : classifyApiFailure(response, apiResponse ?? {});
+  }
+
+  async function streamMessage(
+    destination: ChannelMessageSurface,
+    chunks: ReadableStream<ChannelChunk>,
+    streamOptions: ChannelStreamOptions
+  ): Promise<DeliveryResult> {
+    const unresolvedTarget = slackTarget(destination);
+    if (!unresolvedTarget) {
+      await chunks.cancel().catch(() => {});
+      return failed(
+        "SLACK_SURFACE_INVALID",
+        `Slack cannot parse the address for Channel "${destination.channelKey}"`,
+        false
       );
     }
 
-    const apiResponse = asApiResponse(payload);
-    return apiResponse
-      ? classifyApiResponse(response, apiResponse)
-      : uncertain(
-          "SLACK_DELIVERY_ERROR",
-          "Slack returned an invalid delivery response"
+    // Slack only permits native channel streaming in a thread. Preserve the
+    // simpler top-level application API by collecting and posting one ordinary
+    // message; direct-message targets still use native streaming.
+    if (!("userId" in unresolvedTarget) && !unresolvedTarget.threadTs) {
+      const collected = await collectText(chunks);
+      if (collected.interrupted && collected.text.length === 0) {
+        return failed(
+          "SLACK_STREAM_INTERRUPTED",
+          "The stream ended before producing any content to deliver",
+          false
         );
+      }
+      const delivered = await postMessage(
+        destination,
+        toText({
+          ...(streamOptions.title && { title: streamOptions.title }),
+          markdown: collected.text
+        })
+      );
+      if (!collected.interrupted || delivered.status !== "delivered") {
+        return delivered;
+      }
+      return uncertain(
+        "SLACK_STREAM_INTERRUPTED",
+        "An incomplete answer was delivered because the stream ended early",
+        delivered.reference
+      );
+    }
+
+    const target = await resolveTarget(unresolvedTarget);
+    if ("status" in target) {
+      await chunks.cancel().catch(() => {});
+      return target;
+    }
+
+    const started = await callSlack("chat.startStream", {
+      channel: target.channelId,
+      ...(target.threadTs && { thread_ts: target.threadTs }),
+      ...(target.recipientUserId && {
+        recipient_user_id: target.recipientUserId,
+        recipient_team_id: target.recipientTeamId
+      }),
+      // Every call in a stream must use the mode the stream was opened in,
+      // so the title goes in a chunk rather than `markdown_text`. Opening
+      // with `markdown_text` makes Slack reject each later append with
+      // `streaming_mode_mismatch`, losing the whole answer.
+      ...(streamOptions.title && {
+        chunks: [{ type: "markdown_text", text: `${streamOptions.title}\n\n` }]
+      })
+    });
+    if ("status" in started) {
+      await chunks.cancel().catch(() => {});
+      return started;
+    }
+
+    const reference = outboundReference(started.channelId, started.ts);
+    const sources: { url: string; title?: string }[] = [];
+    const shouldFlush = createPacer(streamIntervalMs);
+    let pending: SlackStreamChunk[] = [];
+    let appendFailure:
+      | Exclude<DeliveryResult, { status: "delivered" }>
+      | undefined;
+
+    return consumeChunks(chunks, {
+      async onChunk(chunk) {
+        pending.push(...toStreamChunks(chunk, sources));
+        if (pending.length === 0 || !shouldFlush()) return;
+        const appended = await callSlack("chat.appendStream", {
+          channel: started.channelId,
+          ts: started.ts,
+          chunks: pending
+        });
+        pending = [];
+        if ("status" in appended) {
+          appendFailure = appended;
+          // Stop reading, but still stop the stream: Slack leaves a message
+          // stuck in its streaming state otherwise.
+          throw new Error(appended.error.message);
+        }
+      },
+      async onFinish(outcome) {
+        // Whatever the pacer withheld rides along on the terminal call, so an
+        // interrupted answer keeps its tail without an extra round trip.
+        const stopped = await callSlack("chat.stopStream", {
+          channel: started.channelId,
+          ts: started.ts,
+          ...(pending.length > 0 && !appendFailure && { chunks: pending }),
+          ...(sources.length > 0 && { blocks: [sourcesBlock(sources)] })
+        });
+        if ("status" in stopped) {
+          return uncertain(
+            stopped.error.code,
+            `Slack could not stop the stream: ${stopped.error.message}`,
+            reference
+          );
+        }
+        if (appendFailure) {
+          return uncertain(
+            appendFailure.error.code,
+            appendFailure.error.message,
+            reference
+          );
+        }
+        if (outcome.interrupted) {
+          return uncertain(
+            "SLACK_STREAM_INTERRUPTED",
+            "The answer ended early, so the Slack message is incomplete",
+            reference
+          );
+        }
+        return { status: "delivered", reference };
+      }
+    });
   }
 
   return {
@@ -870,6 +1130,9 @@ export function slack(
     },
     deliver(destination, message) {
       return postMessage(destination, toText(message));
+    },
+    stream(destination, chunks, streamOptions) {
+      return streamMessage(destination, chunks, streamOptions);
     },
     requestApproval(destination, { interactionId, request }) {
       if (interactionId.length === 0) {

--- a/packages/channels/src/adapters/telegram.ts
+++ b/packages/channels/src/adapters/telegram.ts
@@ -1,10 +1,13 @@
 import type {
   Channel,
   ChannelApprovalRequest,
+  ChannelChunk,
   ChannelMessage,
   ChannelRoute,
+  ChannelStreamOptions,
   DeliveryResult
 } from "../channel";
+import { consumeChunks, createPacer } from "../stream";
 import type { ChannelIdentity } from "../identity";
 import {
   isChannelMessageSurface,
@@ -89,6 +92,11 @@ export type TelegramChannelOptions = {
   toText?: (message: ChannelMessage) => string;
   /** Parse mode for caller-formatted delivery text. */
   parseMode?: "HTML" | "MarkdownV2";
+  /**
+   * Smallest gap between `sendMessageDraft` previews. Snapshots produced
+   * inside one interval are replaced rather than sent. @default 500
+   */
+  streamIntervalMs?: number;
   /** Select an application route from the event, raw update, and Host context. */
   route?: ChannelRoute<TelegramUpdate>;
   /** Add secret-verified Telegram webhook ingress to the returned Channel. */
@@ -109,6 +117,7 @@ type TelegramApiResponse = {
 };
 
 const TELEGRAM_MESSAGE_LIMIT = 4096;
+const DEFAULT_STREAM_INTERVAL_MS = 500;
 const DEFAULT_TELEGRAM_WEBHOOK_PATH = "/webhooks/telegram";
 const APPROVAL_INSTRUCTIONS = "Reply YES to approve or NO to reject.";
 const INTERACTION_FOOTER =
@@ -498,6 +507,31 @@ function telegramSurface(
   return surface as TelegramMessageSurface;
 }
 
+/**
+ * Whether a chat can show an animated draft.
+ *
+ * `sendMessageDraft` is private chats only, and Telegram gives private chats
+ * positive ids. Anywhere else the answer is simply sent once at the end.
+ */
+function supportsDraft(chatId: string): boolean {
+  const numeric = Number(chatId);
+  return Number.isSafeInteger(numeric) && numeric > 0;
+}
+
+/** A non-zero draft identifier; reusing one animates between snapshots. */
+function newDraftId(): number {
+  const [random] = crypto.getRandomValues(new Uint32Array(1));
+  return ((random ?? 1) % 2_147_483_647) + 1;
+}
+
+function splitText(text: string, limit: number): string[] {
+  const pieces: string[] = [];
+  for (let index = 0; index < text.length; index += limit) {
+    pieces.push(text.slice(index, index + limit));
+  }
+  return pieces;
+}
+
 /** Create a configured Telegram Bot API Channel. */
 export function telegram(
   options: TelegramChannelOptions
@@ -521,6 +555,11 @@ export function telegram(
     );
   }
   const toText = options.toText ?? defaultText;
+  const streamIntervalMs =
+    options.streamIntervalMs ?? DEFAULT_STREAM_INTERVAL_MS;
+  if (!Number.isInteger(streamIntervalMs) || streamIntervalMs < 0) {
+    throw new Error("streamIntervalMs must be a non-negative integer");
+  }
   const botUserId = telegramBotUserId(options.botToken);
   const ingress = options.webhook
     ? telegramWebhook({ ...options.webhook, botUserId })
@@ -606,6 +645,138 @@ export function telegram(
         );
   }
 
+  /**
+   * Show one ephemeral preview. Failures are swallowed on purpose: a draft is
+   * a 30-second animation, and losing one must never cost the real message.
+   *
+   * The configured parse mode is deliberately not applied. A partial answer
+   * routinely holds unbalanced markup, which Telegram rejects outright.
+   */
+  async function sendDraft(
+    destination: TelegramMessageSurface,
+    draftId: number,
+    text: string
+  ): Promise<boolean> {
+    try {
+      const response = await fetch(
+        `${apiBaseUrl}/bot${options.botToken}/sendMessageDraft`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            chat_id: Number(destination.address.chatId),
+            draft_id: draftId,
+            text,
+            ...(destination.address.messageThreadId !== undefined && {
+              message_thread_id: destination.address.messageThreadId
+            })
+          })
+        }
+      );
+      return asApiResponse(await response.json())?.ok === true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Persist the answer, splitting it when it outgrows one Telegram message. */
+  async function sendComplete(
+    destination: ChannelMessageSurface,
+    text: string
+  ): Promise<DeliveryResult> {
+    const [head, ...tail] = splitText(text, maxLength);
+    const first = await send(destination, head!, options.parseMode);
+    if (first.status !== "delivered") return first;
+
+    for (const piece of tail) {
+      const result = await send(destination, piece, options.parseMode);
+      // A later piece failing still leaves earlier ones in the chat.
+      if (result.status !== "delivered") {
+        return uncertain(
+          "TELEGRAM_STREAM_PARTIAL",
+          "Telegram accepted only part of a split answer",
+          first.reference
+        );
+      }
+    }
+    return first;
+  }
+
+  async function streamMessage(
+    destinationValue: ChannelMessageSurface,
+    chunks: ReadableStream<ChannelChunk>,
+    streamOptions: ChannelStreamOptions
+  ): Promise<DeliveryResult> {
+    const destination = telegramSurface(destinationValue);
+    if (
+      !destination ||
+      (botUserId !== undefined &&
+        destination.address.botUserId !== undefined &&
+        destination.address.botUserId !== botUserId)
+    ) {
+      await chunks.cancel().catch(() => {});
+      return {
+        status: "failed",
+        retryable: false,
+        error: {
+          code: "TELEGRAM_SURFACE_INVALID",
+          message: `Telegram cannot parse the address for Channel "${destinationValue.channelKey}"`
+        }
+      };
+    }
+
+    const draftId = supportsDraft(destination.address.chatId)
+      ? newDraftId()
+      : undefined;
+    const prefix = streamOptions.title ? `${streamOptions.title}\n\n` : "";
+    const shouldPreview = createPacer(streamIntervalMs);
+    let answer = "";
+    let draftsStopped = draftId === undefined;
+
+    return consumeChunks(chunks, {
+      async onChunk(chunk) {
+        if (chunk.type !== "text" || chunk.text.length === 0) return;
+        answer += chunk.text;
+        if (draftsStopped || !shouldPreview()) return;
+        const shown = await sendDraft(
+          destination,
+          draftId!,
+          `${prefix}${answer}`.slice(0, maxLength)
+        );
+        if (!shown) draftsStopped = true;
+      },
+      async onFinish(outcome) {
+        // The draft is not the message. Without this send the reader's screen
+        // goes blank in thirty seconds and nothing is kept.
+        if (answer.length === 0) {
+          return {
+            status: "failed",
+            retryable: false,
+            error: outcome.interrupted
+              ? {
+                  code: "TELEGRAM_STREAM_INTERRUPTED",
+                  message: "The answer ended before producing any text to send"
+                }
+              : {
+                  code: "TELEGRAM_STREAM_EMPTY",
+                  message: "The stream carried no text to send"
+                }
+          };
+        }
+
+        const result = await sendComplete(destination, `${prefix}${answer}`);
+        if (!outcome.interrupted || result.status !== "delivered") {
+          return result;
+        }
+        return uncertain(
+          "TELEGRAM_STREAM_INTERRUPTED",
+          "An incomplete answer was sent because the stream ended early",
+          result.reference
+        );
+      }
+    });
+  }
+
   return {
     ...(options.route && { route: options.route }),
     ...(ingress && { ingress }),
@@ -624,6 +795,9 @@ export function telegram(
     },
     deliver(destination, message) {
       return send(destination, toText(message), options.parseMode);
+    },
+    stream(destination, chunks, streamOptions) {
+      return streamMessage(destination, chunks, streamOptions);
     },
     requestApproval(destination, { interactionId, request }) {
       if (interactionId.length === 0) {

--- a/packages/channels/src/adapters/web-protocol.ts
+++ b/packages/channels/src/adapters/web-protocol.ts
@@ -1,0 +1,109 @@
+import type { UIMessageChunk } from "ai";
+import type { ChannelChunk } from "../channel";
+import { isRecord } from "../internal";
+
+export type WebChatRequestBody = {
+  messages: unknown[];
+  [key: string]: unknown;
+};
+
+export type NormalizedWebChatMessage = {
+  id: string;
+  text: string;
+};
+
+/** Read the latest user message from an AI SDK useChat request body. */
+export function normalizeWebChatRequest(
+  body: unknown
+): { body: WebChatRequestBody; message: NormalizedWebChatMessage } | null {
+  if (!isRecord(body) || !Array.isArray(body.messages)) return null;
+
+  let candidate: unknown;
+  for (let index = body.messages.length - 1; index >= 0; index -= 1) {
+    const message = body.messages[index];
+    if (isRecord(message) && message.role === "user") {
+      candidate = message;
+      break;
+    }
+  }
+  if (!isRecord(candidate)) return null;
+
+  const id = typeof candidate.id === "string" ? candidate.id : undefined;
+  if (!id) return null;
+
+  const text = Array.isArray(candidate.parts)
+    ? candidate.parts
+        .filter(
+          (part): part is { type: "text"; text: string } =>
+            isRecord(part) &&
+            part.type === "text" &&
+            typeof part.text === "string"
+        )
+        .map((part) => part.text)
+        .join("")
+    : typeof candidate.content === "string"
+      ? candidate.content
+      : "";
+
+  return {
+    body: body as WebChatRequestBody,
+    message: { id, text }
+  };
+}
+
+/** Stateful projection from neutral Channel chunks to AI SDK UI chunks. */
+export class WebChatChunkEncoder {
+  readonly #requestId: string;
+  #active: { type: "text" | "reasoning"; id: string } | undefined;
+  #part = 0;
+  #source = 0;
+
+  constructor(requestId: string) {
+    this.#requestId = requestId;
+  }
+
+  push(chunk: ChannelChunk): UIMessageChunk[] {
+    switch (chunk.type) {
+      case "text":
+      case "reasoning": {
+        const output = this.#switchTo(chunk.type);
+        output.push({
+          type: `${chunk.type}-delta`,
+          id: this.#active!.id,
+          delta: chunk.text
+        } as UIMessageChunk);
+        return output;
+      }
+      case "source":
+        return [
+          ...this.finishPart(),
+          {
+            type: "source-url",
+            sourceId: `${this.#requestId}:source:${++this.#source}`,
+            url: chunk.url,
+            ...(chunk.title !== undefined && { title: chunk.title })
+          }
+        ];
+      case "tool":
+        // Tool progress has no lossless AI SDK UI chunk equivalent. Text is
+        // required to remain complete without it by the Channel contract.
+        return [];
+    }
+  }
+
+  finishPart(): UIMessageChunk[] {
+    if (!this.#active) return [];
+    const active = this.#active;
+    this.#active = undefined;
+    return [{ type: `${active.type}-end`, id: active.id } as UIMessageChunk];
+  }
+
+  #switchTo(type: "text" | "reasoning"): UIMessageChunk[] {
+    if (this.#active?.type === type) return [];
+    const output = this.finishPart();
+    const id = `${this.#requestId}:${type}:${++this.#part}`;
+    this.#active = { type, id };
+    output.push({ type: `${type}-start`, id } as UIMessageChunk);
+    return output;
+  }
+}

--- a/packages/channels/src/adapters/web.ts
+++ b/packages/channels/src/adapters/web.ts
@@ -83,10 +83,11 @@ function addressOf(surface: ChannelMessageSurface): WebChatAddress | null {
 function streamFailure(
   sent: boolean,
   code: string,
-  message: string
+  message: string,
+  reference: string
 ): DeliveryResult {
   return sent
-    ? { status: "uncertain", error: { code, message } }
+    ? { status: "uncertain", reference, error: { code, message } }
     : { status: "failed", retryable: true, error: { code, message } };
 }
 
@@ -206,6 +207,7 @@ class ConfiguredWebChannel
     const abort = new AbortController();
     this.#active.set(key, abort);
     const encoder = new WebChatChunkEncoder(address.requestId);
+    const reference = `web:${address.connectionId}:request:${address.requestId}`;
     let sent = false;
 
     try {
@@ -239,18 +241,20 @@ class ConfiguredWebChannel
                 return streamFailure(
                   sent,
                   "WEB_CHAT_STREAM_INTERRUPTED",
-                  message
+                  message,
+                  reference
                 );
               }
               connection.send(
                 responseFrame(address.requestId, "", { done: true })
               );
-              return { status: "delivered" };
+              return { status: "delivered", reference };
             } catch (error) {
               return streamFailure(
                 sent,
                 "WEB_CHAT_DELIVERY_FAILED",
-                errorMessage(error)
+                errorMessage(error),
+                reference
               );
             }
           }

--- a/packages/channels/src/adapters/web.ts
+++ b/packages/channels/src/adapters/web.ts
@@ -1,0 +1,376 @@
+import type { UIMessageChunk } from "ai";
+import type { Connection } from "agents";
+import {
+  CHAT_MESSAGE_TYPES,
+  STREAM_RESUME_NONE_REASONS,
+  parseProtocolMessage
+} from "agents/chat";
+import { WebSockets, type WebSocketsOptions } from "agents/websockets";
+import type {
+  Channel,
+  ChannelChunk,
+  ChannelMessage,
+  ChannelRoute,
+  ChannelStreamOptions,
+  DeliveryResult
+} from "../channel";
+import type { ChannelIngressEnvelope } from "../ingress";
+import {
+  bindChannelIngress,
+  defaultText,
+  type BindableChannelIngress
+} from "../internal";
+import { consumeChunks } from "../stream";
+import {
+  isChannelMessageSurface,
+  type ChannelMessageSurface
+} from "../surface";
+import {
+  normalizeWebChatRequest,
+  WebChatChunkEncoder,
+  type WebChatRequestBody
+} from "./web-protocol";
+
+export type WebChatSurface = ChannelMessageSurface<
+  string,
+  { connectionId: string; requestId: string }
+>;
+
+/** Exact browser request retained for application routing. */
+export type WebChatIngressPayload = {
+  requestId: string;
+  init: { method?: string; body?: string; [key: string]: unknown };
+  body: WebChatRequestBody;
+};
+
+export type WebChannelOptions = {
+  /** Select an application route from the browser turn and Host context. */
+  route?: ChannelRoute<WebChatIngressPayload>;
+  /** Additional configuration for the owned WebSockets capability. */
+  webSockets?: Omit<WebSocketsOptions, "handlers">;
+};
+
+/**
+ * A browser chat Channel paired with the WebSockets capability it uses.
+ * Install `webSockets` into the Durable Object's Lifecycle.
+ */
+export interface WebChannel extends Channel<WebChatIngressPayload> {
+  readonly webSockets: WebSockets;
+}
+
+type WebChatAddress = WebChatSurface["address"];
+
+function addressOf(surface: ChannelMessageSurface): WebChatAddress | null {
+  if (
+    !isChannelMessageSurface(surface) ||
+    surface.version !== 1 ||
+    surface.address === null ||
+    typeof surface.address !== "object" ||
+    Array.isArray(surface.address)
+  ) {
+    return null;
+  }
+  const address = surface.address as Record<string, unknown>;
+  return typeof address.connectionId === "string" &&
+    typeof address.requestId === "string"
+    ? {
+        connectionId: address.connectionId,
+        requestId: address.requestId
+      }
+    : null;
+}
+
+function streamFailure(
+  sent: boolean,
+  code: string,
+  message: string
+): DeliveryResult {
+  return sent
+    ? { status: "uncertain", error: { code, message } }
+    : { status: "failed", retryable: true, error: { code, message } };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "The stream ended early";
+}
+
+function responseFrame(
+  requestId: string,
+  body: UIMessageChunk | string,
+  options: { done: boolean; error?: boolean }
+): string {
+  return JSON.stringify({
+    body: typeof body === "string" ? body : JSON.stringify(body),
+    done: options.done,
+    id: requestId,
+    type: CHAT_MESSAGE_TYPES.USE_CHAT_RESPONSE,
+    ...(options.error === true && { error: true })
+  });
+}
+
+class ConfiguredWebChannel
+  implements WebChannel, BindableChannelIngress<WebChatIngressPayload>
+{
+  readonly route: ChannelRoute<WebChatIngressPayload> | undefined;
+  readonly webSockets: WebSockets;
+  readonly #active = new Map<string, AbortController>();
+  #dispatch:
+    | ((
+        envelope: ChannelIngressEnvelope<WebChatIngressPayload>
+      ) => Promise<void>)
+    | undefined;
+
+  constructor(options: WebChannelOptions) {
+    this.route = options.route;
+    this.webSockets = new WebSockets({
+      ...options.webSockets,
+      handlers: {
+        onMessage: (connection, message) =>
+          this.#onMessage(connection, message),
+        onClose: (connection) => this.#cancelConnection(connection.id),
+        onError: (connection) => this.#cancelConnection(connection.id)
+      }
+    });
+  }
+
+  [bindChannelIngress](
+    dispatch: (
+      envelope: ChannelIngressEnvelope<WebChatIngressPayload>
+    ) => Promise<void>
+  ): void {
+    if (this.#dispatch) {
+      throw new Error(
+        "A web Channel can only be configured in one ChannelHost"
+      );
+    }
+    this.#dispatch = dispatch;
+  }
+
+  isAvailable(surface: ChannelMessageSurface): boolean {
+    const address = addressOf(surface);
+    return Boolean(
+      address && this.webSockets.getConnection(address.connectionId)
+    );
+  }
+
+  deliver(
+    surface: ChannelMessageSurface,
+    message: ChannelMessage
+  ): Promise<DeliveryResult> {
+    const text = defaultText(message);
+    return this.stream(
+      surface,
+      new ReadableStream<ChannelChunk>({
+        start(controller) {
+          controller.enqueue({ type: "text", text });
+          controller.close();
+        }
+      }),
+      {}
+    );
+  }
+
+  async stream(
+    surface: ChannelMessageSurface,
+    chunks: ReadableStream<ChannelChunk>,
+    _options: ChannelStreamOptions
+  ): Promise<DeliveryResult> {
+    const address = addressOf(surface);
+    if (!address) {
+      await chunks.cancel().catch(() => {});
+      return {
+        status: "failed",
+        retryable: false,
+        error: {
+          code: "WEB_CHAT_SURFACE_INVALID",
+          message: `Web chat cannot parse the address for Channel "${surface.channelKey}"`
+        }
+      };
+    }
+
+    const connection = this.webSockets.getConnection(address.connectionId);
+    if (!connection) {
+      await chunks.cancel().catch(() => {});
+      return {
+        status: "failed",
+        retryable: true,
+        error: {
+          code: "WEB_CHAT_CONNECTION_UNAVAILABLE",
+          message: "The browser connection is no longer available"
+        }
+      };
+    }
+
+    const key = this.#requestKey(address.connectionId, address.requestId);
+    this.#active.get(key)?.abort();
+    const abort = new AbortController();
+    this.#active.set(key, abort);
+    const encoder = new WebChatChunkEncoder(address.requestId);
+    let sent = false;
+
+    try {
+      return await consumeChunks(
+        chunks,
+        {
+          onChunk: (chunk) => {
+            for (const output of encoder.push(chunk)) {
+              connection.send(
+                responseFrame(address.requestId, output, { done: false })
+              );
+              sent = true;
+            }
+          },
+          onFinish: (outcome) => {
+            try {
+              for (const output of encoder.finishPart()) {
+                connection.send(
+                  responseFrame(address.requestId, output, { done: false })
+                );
+                sent = true;
+              }
+              if (outcome.interrupted) {
+                const message = errorMessage(outcome.error);
+                connection.send(
+                  responseFrame(address.requestId, message, {
+                    done: true,
+                    error: true
+                  })
+                );
+                return streamFailure(
+                  sent,
+                  "WEB_CHAT_STREAM_INTERRUPTED",
+                  message
+                );
+              }
+              connection.send(
+                responseFrame(address.requestId, "", { done: true })
+              );
+              return { status: "delivered" };
+            } catch (error) {
+              return streamFailure(
+                sent,
+                "WEB_CHAT_DELIVERY_FAILED",
+                errorMessage(error)
+              );
+            }
+          }
+        },
+        { signal: abort.signal }
+      );
+    } finally {
+      if (this.#active.get(key) === abort) this.#active.delete(key);
+    }
+  }
+
+  async #onMessage(
+    connection: Connection,
+    message: string | ArrayBuffer | ArrayBufferView
+  ): Promise<void> {
+    if (typeof message !== "string") return;
+    const event = parseProtocolMessage(message);
+    if (!event) return;
+
+    switch (event.type) {
+      case "chat-request":
+        await this.#onChatRequest(connection, event.id, event.init);
+        return;
+      case "cancel":
+        this.#active
+          .get(this.#requestKey(connection.id, event.id))
+          ?.abort(
+            new DOMException("The browser cancelled the request", "AbortError")
+          );
+        return;
+      case "clear":
+        this.#cancelConnection(connection.id);
+        connection.send(
+          JSON.stringify({ type: CHAT_MESSAGE_TYPES.CHAT_CLEAR })
+        );
+        return;
+      case "stream-resume-request":
+        connection.send(
+          JSON.stringify({
+            type: CHAT_MESSAGE_TYPES.STREAM_RESUME_NONE,
+            reason: STREAM_RESUME_NONE_REASONS.IDLE,
+            ...(event.probeId !== undefined && { probeId: event.probeId })
+          })
+        );
+        return;
+      case "stream-resume-ack":
+      case "tool-result":
+      case "tool-approval":
+      case "messages":
+        return;
+    }
+  }
+
+  async #onChatRequest(
+    connection: Connection,
+    requestId: string,
+    init: { method?: string; body?: string; [key: string]: unknown }
+  ): Promise<void> {
+    try {
+      if (
+        typeof requestId !== "string" ||
+        !requestId ||
+        (init.method ?? "POST").toUpperCase() !== "POST"
+      ) {
+        throw new Error("Web chat requires a POST request with an id");
+      }
+      const normalized = normalizeWebChatRequest(JSON.parse(init.body ?? ""));
+      if (!normalized) {
+        throw new Error("Web chat requires a body with a user message");
+      }
+      if (!this.#dispatch) {
+        throw new Error("The web Channel is not configured in a ChannelHost");
+      }
+
+      const raw = {
+        requestId,
+        init,
+        body: normalized.body
+      } satisfies WebChatIngressPayload;
+      await this.#dispatch({
+        raw,
+        event: {
+          type: "message",
+          eventId: `web:${connection.id}:request:${requestId}`,
+          thread: { id: connection.id, isDirectMessage: true },
+          replySurface: {
+            version: 1,
+            address: { connectionId: connection.id, requestId },
+            label: "Web chat"
+          },
+          actor: { id: connection.id },
+          message: normalized.message
+        }
+      });
+    } catch (error) {
+      connection.send(
+        responseFrame(requestId, errorMessage(error), {
+          done: true,
+          error: true
+        })
+      );
+    }
+  }
+
+  #cancelConnection(connectionId: string): void {
+    const prefix = `${connectionId}\u0000`;
+    for (const [key, controller] of this.#active) {
+      if (key.startsWith(prefix)) controller.abort();
+    }
+  }
+
+  #requestKey(connectionId: string, requestId: string): string {
+    return `${connectionId}\u0000${requestId}`;
+  }
+}
+
+/**
+ * Create a Channel that speaks the AIChatAgent browser protocol over an owned
+ * WebSockets capability. The Host still owns all application message handling.
+ */
+export function web(options: WebChannelOptions = {}): WebChannel {
+  return new ConfiguredWebChannel(options);
+}

--- a/packages/channels/src/ai-sdk.ts
+++ b/packages/channels/src/ai-sdk.ts
@@ -1,5 +1,11 @@
-import { jsonSchema, tool, type Tool } from "ai";
-import type { ChannelMessage, DeliveryResult } from "./channel";
+import {
+  jsonSchema,
+  tool,
+  type TextStreamPart,
+  type Tool,
+  type ToolSet
+} from "ai";
+import type { ChannelChunk, ChannelMessage, DeliveryResult } from "./channel";
 import type { ChannelHost } from "./host";
 import type { ChannelMessageSurface } from "./surface";
 import { channelMessageJsonSchema, parseChannelMessage } from "./tool-schema";
@@ -48,5 +54,78 @@ export function createSendMessageTool(
     ...options,
     inputSchema: channelMessageSchema,
     execute: (message) => host.deliver(surface, message)
+  });
+}
+
+function toChannelChunk(
+  part: TextStreamPart<ToolSet>
+): ChannelChunk | undefined {
+  switch (part.type) {
+    case "text-delta":
+      return { type: "text", text: part.text };
+    case "reasoning-delta":
+      return { type: "reasoning", text: part.text };
+    case "source":
+      return part.sourceType === "url"
+        ? {
+            type: "source",
+            url: part.url,
+            ...(part.title !== undefined && { title: part.title })
+          }
+        : undefined;
+    case "tool-call":
+      return { type: "tool", name: part.toolName, status: "started" };
+    case "tool-result":
+      return { type: "tool", name: part.toolName, status: "completed" };
+    case "tool-error":
+      return { type: "tool", name: part.toolName, status: "failed" };
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Project an AI SDK `fullStream` onto neutral Channel chunks.
+ *
+ * Parts a Channel cannot express are dropped, which keeps provider part
+ * shapes out of `ChannelChunk`. An `error` or `abort` part errors the returned
+ * stream, so a generation that fails part-way reaches a Channel as the
+ * abnormal ending it is rather than as a complete answer.
+ */
+export function toChannelChunks(
+  fullStream: AsyncIterable<TextStreamPart<ToolSet>>
+): ReadableStream<ChannelChunk> {
+  const parts = fullStream[Symbol.asyncIterator]();
+  return new ReadableStream<ChannelChunk>({
+    async pull(controller) {
+      while (true) {
+        const { done, value } = await parts.next();
+        if (done) {
+          controller.close();
+          return;
+        }
+        if (value.type === "error") {
+          controller.error(
+            value.error instanceof Error
+              ? value.error
+              : new Error(String(value.error))
+          );
+          return;
+        }
+        if (value.type === "abort") {
+          controller.error(
+            new Error(value.reason ?? "The generation was aborted")
+          );
+          return;
+        }
+        const chunk = toChannelChunk(value);
+        if (!chunk) continue;
+        controller.enqueue(chunk);
+        return;
+      }
+    },
+    async cancel(reason) {
+      await parts.return?.(reason);
+    }
   });
 }

--- a/packages/channels/src/channel.ts
+++ b/packages/channels/src/channel.ts
@@ -26,12 +26,15 @@ export type DeliveryFailure = {
 };
 
 /**
- * The result of a direct delivery attempt.
+ * The result of a direct delivery attempt, defined by what reached the reader.
  *
- * `delivered` means the transport accepted the message, not that a person read
- * it. `failed` means the transport confirmed that no delivery occurred; its
- * `retryable` field says whether the same route can be attempted again.
- * `uncertain` means another attempt or route could produce a duplicate.
+ * `delivered` means the whole message reached the reader, not that a person
+ * read it. `failed` means none of it did; its `retryable` field says whether
+ * the same route can be attempted again. `uncertain` means an unknown amount
+ * of the message reached the reader, so another attempt or route could
+ * duplicate content. A stream that ends before its answer is complete is
+ * `uncertain`, and carries a `reference` when the Channel created something
+ * the caller can point at.
  */
 export type DeliveryResult =
   | {
@@ -45,8 +48,50 @@ export type DeliveryResult =
     }
   | {
       status: "uncertain";
+      reference?: string;
       error: DeliveryFailure;
     };
+
+/**
+ * One element of a progressively generated answer.
+ *
+ * The variants describe what an Agent produces, not what a provider renders.
+ * Any Channel may ignore any variant, so `text` alone must always be a
+ * complete answer; a variant carrying meaning `text` does not is a bug in the
+ * variant.
+ */
+export type ChannelChunk =
+  | { type: "text"; text: string }
+  | { type: "reasoning"; text: string }
+  | {
+      type: "tool";
+      name: string;
+      status: "started" | "completed" | "failed";
+      title?: string;
+      detail?: string;
+    }
+  | { type: "source"; url: string; title?: string };
+
+/** The normalized stream shape accepted by `ChannelHost.stream`. */
+export type ChannelChunkSource = ReadableStream<ChannelChunk>;
+
+/** Caller options for one finished delivery. */
+export type ChannelDeliveryOptions = {
+  /** Caller-owned identity for provider idempotency and observability. */
+  delivery?: ChannelDeliveryContext;
+};
+
+/** Caller options for one streamed answer. */
+export type ChannelStreamOptions = {
+  /**
+   * Optional topic. It is an option rather than a chunk because it is known
+   * before the first token, and a Channel usually needs it in its opening
+   * provider call.
+   */
+  title?: string;
+  /** Caller-owned identity for provider idempotency and observability. */
+  delivery?: ChannelDeliveryContext;
+};
 
 /** A caller-owned identity supplied to one provider delivery attempt. */
 export type ChannelDeliveryContext = {
@@ -91,7 +136,12 @@ export type OutboundResolver = {
   deliver(
     surface: ChannelMessageSurface,
     message: ChannelMessage,
-    context?: ChannelDeliveryContext
+    options?: ChannelDeliveryOptions
+  ): Promise<DeliveryResult>;
+  stream(
+    surface: ChannelMessageSurface,
+    chunks: ChannelChunkSource,
+    options?: ChannelStreamOptions
   ): Promise<DeliveryResult>;
   requestApproval(
     surface: ChannelMessageSurface,
@@ -121,7 +171,20 @@ export interface Channel<TRaw = unknown> {
   deliver?(
     surface: ChannelMessageSurface,
     message: ChannelMessage,
-    context?: ChannelDeliveryContext
+    options?: ChannelDeliveryOptions
+  ): Promise<DeliveryResult>;
+  /**
+   * Deliver one progressively generated answer. Absent for Channels that
+   * cannot stream, which the Host serves by collecting and calling `deliver`.
+   *
+   * The Channel owns the consumption loop. It must finalize whether the
+   * stream closed or errored, because a model can fail mid-generation, and it
+   * must not abandon a terminal provider call on error.
+   */
+  stream?(
+    surface: ChannelMessageSurface,
+    chunks: ReadableStream<ChannelChunk>,
+    options: ChannelStreamOptions
   ): Promise<DeliveryResult>;
   requestApproval?(
     surface: ChannelMessageSurface,

--- a/packages/channels/src/fallback.ts
+++ b/packages/channels/src/fallback.ts
@@ -1,8 +1,10 @@
 import type {
   Channel,
   ChannelApprovalRequestOptions,
-  ChannelDeliveryContext,
+  ChannelChunk,
+  ChannelDeliveryOptions,
   ChannelMessage,
+  ChannelStreamOptions,
   DeliveryResult,
   OutboundResolver
 } from "./channel";
@@ -39,6 +41,68 @@ export function fallback(surfaces: FallbackSurfaceOptions): FallbackSurface {
   };
 }
 
+/**
+ * Advance past a failed destination, replaying what the failed one consumed.
+ *
+ * Buffering the answer keeps `failed` meaning that nothing reached the reader,
+ * so streaming failover behaves exactly like one-shot failover. No Channel has
+ * to obey an invisible rule about calling its provider before its first read.
+ */
+async function streamWithReplay(
+  resolve: OutboundResolver,
+  destinations: readonly ChannelMessageSurface[],
+  chunks: ReadableStream<ChannelChunk>,
+  options: ChannelStreamOptions
+): Promise<DeliveryResult> {
+  const reader = chunks.getReader();
+  const buffered: ChannelChunk[] = [];
+  let drained = false;
+
+  function attempt(): ReadableStream<ChannelChunk> {
+    let index = 0;
+    return new ReadableStream<ChannelChunk>({
+      async pull(controller) {
+        if (index < buffered.length) {
+          controller.enqueue(buffered[index]!);
+          index += 1;
+          return;
+        }
+        if (drained) {
+          controller.close();
+          return;
+        }
+        const result = await reader.read();
+        if (result.done) {
+          drained = true;
+          controller.close();
+          return;
+        }
+        buffered.push(result.value);
+        index = buffered.length;
+        controller.enqueue(result.value);
+      }
+      // A cancelling destination must not cancel the shared source, which the
+      // next destination may still need.
+    });
+  }
+
+  try {
+    for (let index = 0; index < destinations.length - 1; index += 1) {
+      const destination = destinations[index]!;
+      if (!(await resolve.isAvailable(destination))) continue;
+
+      const result = await resolve.stream(destination, attempt(), options);
+      if (result.status !== "failed") return result;
+    }
+    // `return await` so the shared reader is released only after the final
+    // destination has finished consuming it.
+    return await resolve.stream(destinations.at(-1)!, attempt(), options);
+  } finally {
+    if (!drained) await reader.cancel().catch(() => {});
+    reader.releaseLock();
+  }
+}
+
 /** Build the ordinary Channel installed under the reserved fallback key. */
 export function fallbackChannel(resolve: OutboundResolver): Channel {
   async function run(
@@ -68,11 +132,27 @@ export function fallbackChannel(resolve: OutboundResolver): Channel {
     deliver(
       surface: ChannelMessageSurface,
       message: ChannelMessage,
-      context?: ChannelDeliveryContext
+      options?: ChannelDeliveryOptions
     ) {
       return run(surface, (destination) =>
-        resolve.deliver(destination, message, context)
+        resolve.deliver(destination, message, options)
       );
+    },
+
+    async stream(
+      surface: ChannelMessageSurface,
+      chunks: ReadableStream<ChannelChunk>,
+      options: ChannelStreamOptions
+    ) {
+      const destinations = compositeDestinations(surface);
+      if (!destinations) {
+        await chunks.cancel().catch(() => {});
+        return unsupported(
+          "FALLBACK_SURFACE_INVALID",
+          "Fallback surface must contain at least one valid destination"
+        );
+      }
+      return streamWithReplay(resolve, destinations, chunks, options);
     },
 
     requestApproval(

--- a/packages/channels/src/fanout.ts
+++ b/packages/channels/src/fanout.ts
@@ -1,8 +1,10 @@
 import type {
   Channel,
   ChannelApprovalRequestOptions,
-  ChannelDeliveryContext,
+  ChannelChunk,
+  ChannelDeliveryOptions,
   ChannelMessage,
+  ChannelStreamOptions,
   DeliveryResult,
   OutboundResolver
 } from "./channel";
@@ -23,6 +25,21 @@ export type FanoutSurfaceOptions = readonly [
 type FanoutOperation = (
   surface: ChannelMessageSurface
 ) => Promise<DeliveryResult>;
+
+function teeAll<T>(
+  source: ReadableStream<T>,
+  count: number
+): ReadableStream<T>[] {
+  const branches: ReadableStream<T>[] = [];
+  let rest = source;
+  for (let index = 0; index < count - 1; index += 1) {
+    const [branch, remainder] = rest.tee();
+    branches.push(branch);
+    rest = remainder;
+  }
+  branches.push(rest);
+  return branches;
+}
 
 /** Build an inert fanout destination for a `ChannelHost` to resolve. */
 export function fanout(surfaces: FanoutSurfaceOptions): FanoutSurface {
@@ -48,7 +65,10 @@ export function fanoutChannel(resolve: OutboundResolver): Channel {
       );
     }
 
-    const results = await Promise.all(destinations.map(operation));
+    return combine(await Promise.all(destinations.map(operation)));
+  }
+
+  function combine(results: readonly DeliveryResult[]): DeliveryResult {
     if (results.every((result) => result.status === "delivered")) {
       return { status: "delivered" };
     }
@@ -78,10 +98,33 @@ export function fanoutChannel(resolve: OutboundResolver): Channel {
     deliver(
       surface: ChannelMessageSurface,
       message: ChannelMessage,
-      context?: ChannelDeliveryContext
+      options?: ChannelDeliveryOptions
     ) {
       return run(surface, (destination) =>
-        resolve.deliver(destination, message, context)
+        resolve.deliver(destination, message, options)
+      );
+    },
+    async stream(
+      surface: ChannelMessageSurface,
+      chunks: ReadableStream<ChannelChunk>,
+      options: ChannelStreamOptions
+    ) {
+      const destinations = compositeDestinations(surface);
+      if (!destinations) {
+        await chunks.cancel().catch(() => {});
+        return unsupported(
+          "FANOUT_SURFACE_INVALID",
+          "Fanout surface must contain at least one valid destination"
+        );
+      }
+      // One branch per destination, so a slow reader cannot pace a fast one.
+      const branches = teeAll(chunks, destinations.length);
+      return combine(
+        await Promise.all(
+          destinations.map((destination, index) =>
+            resolve.stream(destination, branches[index]!, options)
+          )
+        )
       );
     },
     requestApproval(

--- a/packages/channels/src/host/index.ts
+++ b/packages/channels/src/host/index.ts
@@ -1,10 +1,13 @@
 import type {
   Channel,
   ChannelApprovalRequestOptions,
-  ChannelDeliveryContext,
+  ChannelChunk,
+  ChannelChunkSource,
+  ChannelDeliveryOptions,
   ChannelMessage,
   ChannelRoute,
   ChannelRouteContext,
+  ChannelStreamOptions,
   DeliveryResult
 } from "../channel";
 import { fallbackChannel } from "../fallback";
@@ -15,6 +18,7 @@ import type {
   UserIdentity
 } from "../identity";
 import { unsupported } from "../internal";
+import { collectText } from "../stream";
 import type {
   ChannelApprovalResponse,
   ChannelEmailInput,
@@ -23,10 +27,9 @@ import type {
   ChannelIngressEvent,
   ChannelIngressEventInput
 } from "../ingress";
-import {
-  isChannelMessageSurface,
-  type ChannelMessageSurface,
-  type ChannelMessageSurfaceInput
+import type {
+  ChannelMessageSurface,
+  ChannelMessageSurfaceInput
 } from "../surface";
 
 export type ChannelMessageEvent = {
@@ -143,7 +146,7 @@ export class ChannelHost {
   deliver(
     surface: ChannelMessageSurface,
     message: ChannelMessage,
-    context?: ChannelDeliveryContext
+    options?: ChannelDeliveryOptions
   ): Promise<DeliveryResult> {
     return this.#outbound(surface, (channel, destination) => {
       if (!channel.deliver) {
@@ -154,8 +157,34 @@ export class ChannelHost {
           )
         );
       }
-      return channel.deliver(destination, message, context);
+      return channel.deliver(destination, message, options);
     });
+  }
+
+  /**
+   * Deliver a progressively generated answer to the Channel or composite
+   * named by the surface.
+   *
+   * A Channel that can stream consumes the stream itself. A Channel that
+   * cannot never learns it was a stream, because the Host collects the answer
+   * and calls `deliver` once.
+   */
+  async stream(
+    surface: ChannelMessageSurface,
+    chunks: ChannelChunkSource,
+    options: ChannelStreamOptions = {}
+  ): Promise<DeliveryResult> {
+    const channel = this.#configuredChannel(surface.channelKey);
+    if (!channel.stream && !channel.deliver) {
+      await chunks.cancel().catch(() => {});
+      return unsupported(
+        "CHANNEL_DELIVERY_UNSUPPORTED",
+        `Channel "${surface.channelKey}" does not support delivery`
+      );
+    }
+
+    if (channel.stream) return channel.stream(surface, chunks, options);
+    return collectAndDeliver(channel, surface, chunks, options);
   }
 
   /** Request approval through the Channel or composite named by the surface. */
@@ -190,7 +219,6 @@ export class ChannelHost {
 
   /** Resolve whether a surface can currently be selected without delivery. */
   async isAvailable(surface: ChannelMessageSurface): Promise<boolean> {
-    if (!isChannelMessageSurface(surface)) return true;
     const channel = this.#configuredChannel(surface.channelKey);
     return channel.isAvailable?.(surface) ?? true;
   }
@@ -199,12 +227,6 @@ export class ChannelHost {
     surface: ChannelMessageSurface,
     operation: OutboundOperation
   ): Promise<DeliveryResult> {
-    if (!isChannelMessageSurface(surface)) {
-      return unsupported(
-        "CHANNEL_SURFACE_INVALID",
-        "Cannot resolve an invalid Channel message surface"
-      );
-    }
     const channel = this.#configuredChannel(surface.channelKey);
     return operation(channel, surface);
   }
@@ -300,6 +322,51 @@ export class ChannelHost {
       }
     };
   }
+}
+
+/**
+ * Serve a Channel that cannot stream by collecting the answer first.
+ *
+ * A generation that failed part-way still delivers what it produced, because
+ * losing the partial answer helps nobody, but the result is downgraded to
+ * `uncertain` since the reader received an incomplete answer.
+ */
+async function collectAndDeliver(
+  channel: Channel,
+  surface: ChannelMessageSurface,
+  stream: ReadableStream<ChannelChunk>,
+  options: ChannelStreamOptions
+): Promise<DeliveryResult> {
+  const collected = await collectText(stream);
+  if (collected.interrupted && collected.text.length === 0) {
+    return {
+      status: "failed",
+      retryable: false,
+      error: {
+        code: "CHANNEL_STREAM_INTERRUPTED",
+        message: "The stream ended before producing any content to deliver"
+      }
+    };
+  }
+
+  const result = await channel.deliver!(
+    surface,
+    {
+      ...(options.title !== undefined && { title: options.title }),
+      markdown: collected.text
+    },
+    options.delivery ? { delivery: options.delivery } : undefined
+  );
+  if (!collected.interrupted || result.status !== "delivered") return result;
+  return {
+    status: "uncertain",
+    ...(result.reference !== undefined && { reference: result.reference }),
+    error: {
+      code: "CHANNEL_STREAM_INTERRUPTED",
+      message:
+        "An incomplete answer was delivered because the stream ended early"
+    }
+  };
 }
 
 function stampSurface<TAddress extends ChannelMessageSurfaceInput["address"]>(

--- a/packages/channels/src/host/index.ts
+++ b/packages/channels/src/host/index.ts
@@ -17,7 +17,11 @@ import type {
   ChannelIdentityInput,
   UserIdentity
 } from "../identity";
-import { unsupported } from "../internal";
+import {
+  bindChannelIngress,
+  type BindableChannelIngress,
+  unsupported
+} from "../internal";
 import { collectText } from "../stream";
 import type {
   ChannelApprovalResponse,
@@ -106,6 +110,15 @@ export class ChannelHost {
     this.#onRoute = options.onRoute;
     this.#onMessage = options.onMessage;
     this.#onApprovalResponse = options.onApprovalResponse;
+
+    for (const [channelKey, channel] of Object.entries(options.channels)) {
+      const bind = (channel as Channel & Partial<BindableChannelIngress>)[
+        bindChannelIngress
+      ];
+      bind?.call(channel, (envelope) =>
+        this.#dispatch(channelKey, channel, envelope)
+      );
+    }
   }
 
   async handleRequest(request: Request): Promise<Response | undefined> {

--- a/packages/channels/src/index.ts
+++ b/packages/channels/src/index.ts
@@ -7,4 +7,11 @@ export * from "./host";
 export * from "./identity";
 export * from "./ingress";
 export * from "./routes";
+// Only the finalization contract is public. Pacing and collection stay
+// internal until a Channel outside this package needs them.
+export {
+  consumeChunks,
+  type ChunkConsumer,
+  type StreamOutcome
+} from "./stream";
 export * from "./surface";

--- a/packages/channels/src/index.ts
+++ b/packages/channels/src/index.ts
@@ -12,6 +12,7 @@ export * from "./routes";
 export {
   consumeChunks,
   type ChunkConsumer,
+  type ConsumeChunksOptions,
   type StreamOutcome
 } from "./stream";
 export * from "./surface";

--- a/packages/channels/src/internal.ts
+++ b/packages/channels/src/internal.ts
@@ -1,8 +1,18 @@
 import type { ChannelMessage, DeliveryResult } from "./channel";
-import type { ChannelIngressResult } from "./ingress";
+import type { ChannelIngressEnvelope, ChannelIngressResult } from "./ingress";
 import { isChannelMessageSurface, type ChannelMessageSurface } from "./surface";
 
 const textEncoder = new TextEncoder();
+
+/** @internal Binds push-based ingress to the Host's normal dispatch path. */
+export const bindChannelIngress = Symbol("bindChannelIngress");
+
+/** @internal Implemented by Channels whose provider pushes live events. */
+export type BindableChannelIngress<TRaw = unknown> = {
+  [bindChannelIngress](
+    dispatch: (envelope: ChannelIngressEnvelope<TRaw>) => Promise<void>
+  ): void;
+};
 
 export function encodeUtf8(value: string): Uint8Array<ArrayBuffer> {
   return textEncoder.encode(value);

--- a/packages/channels/src/internal.ts
+++ b/packages/channels/src/internal.ts
@@ -31,9 +31,14 @@ export function renderInput(input: unknown): string {
   }
 }
 
-export function uncertain(code: string, message: string): DeliveryResult {
+export function uncertain(
+  code: string,
+  message: string,
+  reference?: string
+): Extract<DeliveryResult, { status: "uncertain" }> {
   return {
     status: "uncertain",
+    ...(reference !== undefined && { reference }),
     error: { code, message }
   };
 }

--- a/packages/channels/src/stream.ts
+++ b/packages/channels/src/stream.ts
@@ -1,0 +1,91 @@
+import { TextSegmentJoiner } from "agents/chat";
+import type { Awaitable, ChannelChunk } from "./channel";
+
+/** Why a consumption loop stopped reading. */
+export type StreamOutcome =
+  | { interrupted: false }
+  | { interrupted: true; error: unknown };
+
+export type ChunkConsumer<TChunk, TResult> = {
+  onChunk(chunk: TChunk): Awaitable<void>;
+  /** Runs exactly once, whether the stream closed or ended abnormally. */
+  onFinish(outcome: StreamOutcome): Awaitable<TResult>;
+};
+
+/** The complete text of a stream, and whether it ended before its answer did. */
+export type CollectedText = {
+  text: string;
+  interrupted: boolean;
+};
+
+/**
+ * Read a stream to completion, then finalize exactly once.
+ *
+ * `onFinish` runs whether the stream closed normally, errored because the
+ * generation failed, or stopped because `onChunk` threw. A Channel that
+ * finalizes here cannot lose a terminal provider call to an early ending.
+ */
+export async function consumeChunks<TChunk, TResult>(
+  chunks: ReadableStream<TChunk>,
+  consumer: ChunkConsumer<TChunk, TResult>
+): Promise<TResult> {
+  const reader = chunks.getReader();
+  let outcome: StreamOutcome = { interrupted: false };
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      await consumer.onChunk(value);
+    }
+  } catch (error) {
+    outcome = { interrupted: true, error };
+    // Stop the producer, which is still generating when `onChunk` threw.
+    await reader.cancel().catch(() => {});
+  } finally {
+    reader.releaseLock();
+  }
+  return consumer.onFinish(outcome);
+}
+
+/**
+ * Collect every `text` chunk into one Markdown answer.
+ *
+ * The result reports interruption instead of throwing, because a Channel that
+ * has partial text still has to decide what to deliver.
+ */
+export function collectText(
+  chunks: ReadableStream<ChannelChunk>
+): Promise<CollectedText> {
+  let text = "";
+  const joiner = new TextSegmentJoiner();
+  return consumeChunks(chunks, {
+    onChunk(chunk) {
+      for (const event of joiner.pushChunk(
+        chunk.type === "text"
+          ? { type: "text-delta", text: chunk.text }
+          : { type: chunk.type }
+      )) {
+        if (event.type === "text") text += event.text;
+      }
+    },
+    onFinish: (outcome) => ({ text, interrupted: outcome.interrupted })
+  });
+}
+
+/**
+ * Pace repeated provider calls without dropping anything.
+ *
+ * A Channel accumulates into its own buffer and asks whether enough time has
+ * passed to flush. Keeping the buffer in the Channel means an interrupted
+ * stream leaves its tail in hand, ready for the terminal provider call, rather
+ * than stranded inside a transform.
+ */
+export function createPacer(intervalMs: number): () => boolean {
+  let lastFlushAt = Number.NEGATIVE_INFINITY;
+  return () => {
+    const now = Date.now();
+    if (now - lastFlushAt < intervalMs) return false;
+    lastFlushAt = now;
+    return true;
+  };
+}

--- a/packages/channels/src/stream.ts
+++ b/packages/channels/src/stream.ts
@@ -12,6 +12,11 @@ export type ChunkConsumer<TChunk, TResult> = {
   onFinish(outcome: StreamOutcome): Awaitable<TResult>;
 };
 
+export type ConsumeChunksOptions = {
+  /** Stop consumption and cancel the producer when aborted. */
+  signal?: AbortSignal;
+};
+
 /** The complete text of a stream, and whether it ended before its answer did. */
 export type CollectedText = {
   text: string;
@@ -27,21 +32,36 @@ export type CollectedText = {
  */
 export async function consumeChunks<TChunk, TResult>(
   chunks: ReadableStream<TChunk>,
-  consumer: ChunkConsumer<TChunk, TResult>
+  consumer: ChunkConsumer<TChunk, TResult>,
+  options: ConsumeChunksOptions = {}
 ): Promise<TResult> {
   const reader = chunks.getReader();
   let outcome: StreamOutcome = { interrupted: false };
+  const abortError = new DOMException("The stream was cancelled", "AbortError");
+  const abort = () => {
+    outcome = {
+      interrupted: true,
+      error: options.signal?.reason ?? abortError
+    };
+    void reader.cancel(outcome.error).catch(() => {});
+  };
+  options.signal?.addEventListener("abort", abort, { once: true });
   try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      await consumer.onChunk(value);
+    if (options.signal?.aborted) {
+      abort();
+    } else {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        await consumer.onChunk(value);
+      }
     }
   } catch (error) {
     outcome = { interrupted: true, error };
     // Stop the producer, which is still generating when `onChunk` threw.
     await reader.cancel().catch(() => {});
   } finally {
+    options.signal?.removeEventListener("abort", abort);
     reader.releaseLock();
   }
   return consumer.onFinish(outcome);

--- a/packages/channels/vitest.live.config.ts
+++ b/packages/channels/vitest.live.config.ts
@@ -2,7 +2,9 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["live-tests/delivery.test.ts"],
-    testTimeout: 180_000
+    include: ["live-tests/*.test.ts"],
+    // Every scenario clears the same provider-owned destinations.
+    fileParallelism: false,
+    testTimeout: 300_000
   }
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4163,6 +4163,9 @@ importers:
       '@cloudflare/voice':
         specifier: workspace:*
         version: link:../voice
+      agents:
+        specifier: workspace:*
+        version: link:../agents
       postal-mime:
         specifier: ^2.7.5
         version: 2.7.5
@@ -5773,9 +5776,21 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@img/sharp-darwin-arm64@0.35.2':
+    resolution: {integrity: sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@img/sharp-darwin-x64@0.34.5':
     resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.35.2':
+    resolution: {integrity: sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [darwin]
 
@@ -5789,13 +5804,29 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@img/sharp-libvips-darwin-arm64@1.3.1':
+    resolution: {integrity: sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@img/sharp-libvips-darwin-x64@1.2.4':
     resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
     cpu: [x64]
     os: [darwin]
 
+  '@img/sharp-libvips-darwin-x64@1.3.1':
+    resolution: {integrity: sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==}
+    cpu: [x64]
+    os: [darwin]
+
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm64@1.3.1':
+    resolution: {integrity: sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -5806,8 +5837,20 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-arm@1.3.1':
+    resolution: {integrity: sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.3.1':
+    resolution: {integrity: sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
@@ -5818,8 +5861,20 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-riscv64@1.3.1':
+    resolution: {integrity: sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.3.1':
+    resolution: {integrity: sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
@@ -5830,14 +5885,32 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-x64@1.3.1':
+    resolution: {integrity: sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.1':
+    resolution: {integrity: sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.1':
+    resolution: {integrity: sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -5849,9 +5922,23 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-arm64@0.35.2':
+    resolution: {integrity: sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.35.2':
+    resolution: {integrity: sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
@@ -5863,9 +5950,23 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-ppc64@0.35.2':
+    resolution: {integrity: sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.35.2':
+    resolution: {integrity: sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==}
+    engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
@@ -5877,9 +5978,23 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-s390x@0.35.2':
+    resolution: {integrity: sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.35.2':
+    resolution: {integrity: sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -5891,9 +6006,23 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@img/sharp-linuxmusl-arm64@0.35.2':
+    resolution: {integrity: sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.35.2':
+    resolution: {integrity: sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -5902,6 +6031,10 @@ packages:
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [wasm32]
+
+  '@img/sharp-wasm32@0.35.2':
+    resolution: {integrity: sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==}
+    engines: {node: '>=20.9.0'}
 
   '@img/sharp-webcontainers-wasm32@0.35.2':
     resolution: {integrity: sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==}
@@ -5914,15 +6047,33 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@img/sharp-win32-arm64@0.35.2':
+    resolution: {integrity: sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [win32]
+
   '@img/sharp-win32-ia32@0.34.5':
     resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ia32]
     os: [win32]
 
+  '@img/sharp-win32-ia32@0.35.2':
+    resolution: {integrity: sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==}
+    engines: {node: ^20.9.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@img/sharp-win32-x64@0.34.5':
     resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.35.2':
+    resolution: {integrity: sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
 
@@ -13772,42 +13923,84 @@ snapshots:
       '@img/sharp-libvips-darwin-arm64': 1.2.4
     optional: true
 
+  '@img/sharp-darwin-arm64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.3.1
+    optional: true
+
   '@img/sharp-darwin-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-darwin-x64': 1.2.4
     optional: true
 
+  '@img/sharp-darwin-x64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.3.1
+    optional: true
+
   '@img/sharp-freebsd-wasm32@0.35.2':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.2
     optional: true
 
   '@img/sharp-libvips-darwin-arm64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-darwin-arm64@1.3.1':
+    optional: true
+
   '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.3.1':
     optional: true
 
   '@img/sharp-libvips-linux-arm64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linux-arm64@1.3.1':
+    optional: true
+
   '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.3.1':
     optional: true
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linux-ppc64@1.3.1':
+    optional: true
+
   '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.3.1':
     optional: true
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linux-s390x@1.3.1':
+    optional: true
+
   '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.3.1':
     optional: true
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.1':
+    optional: true
+
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.1':
     optional: true
 
   '@img/sharp-linux-arm64@0.34.5':
@@ -13815,9 +14008,19 @@ snapshots:
       '@img/sharp-libvips-linux-arm64': 1.2.4
     optional: true
 
+  '@img/sharp-linux-arm64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.3.1
+    optional: true
+
   '@img/sharp-linux-arm@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.3.1
     optional: true
 
   '@img/sharp-linux-ppc64@0.34.5':
@@ -13825,9 +14028,19 @@ snapshots:
       '@img/sharp-libvips-linux-ppc64': 1.2.4
     optional: true
 
+  '@img/sharp-linux-ppc64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.3.1
+    optional: true
+
   '@img/sharp-linux-riscv64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.3.1
     optional: true
 
   '@img/sharp-linux-s390x@0.34.5':
@@ -13835,9 +14048,19 @@ snapshots:
       '@img/sharp-libvips-linux-s390x': 1.2.4
     optional: true
 
+  '@img/sharp-linux-s390x@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.3.1
+    optional: true
+
   '@img/sharp-linux-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.3.1
     optional: true
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
@@ -13845,9 +14068,19 @@ snapshots:
       '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
     optional: true
 
+  '@img/sharp-linuxmusl-arm64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.1
+    optional: true
+
   '@img/sharp-linuxmusl-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.35.2':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.1
     optional: true
 
   '@img/sharp-wasm32@0.34.5':
@@ -13855,16 +14088,32 @@ snapshots:
       '@emnapi/runtime': 1.11.1
     optional: true
 
+  '@img/sharp-wasm32@0.35.2':
+    dependencies:
+      '@emnapi/runtime': 1.11.1
+    optional: true
+
   '@img/sharp-webcontainers-wasm32@0.35.2':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.2
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
     optional: true
 
+  '@img/sharp-win32-arm64@0.35.2':
+    optional: true
+
   '@img/sharp-win32-ia32@0.34.5':
     optional: true
 
+  '@img/sharp-win32-ia32@0.35.2':
+    optional: true
+
   '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.2':
     optional: true
 
   '@inquirer/ansi@2.0.7': {}
@@ -19616,8 +19865,31 @@ snapshots:
       detect-libc: 2.1.2
       semver: 7.8.5
     optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.35.2
+      '@img/sharp-darwin-x64': 0.35.2
       '@img/sharp-freebsd-wasm32': 0.35.2
+      '@img/sharp-libvips-darwin-arm64': 1.3.1
+      '@img/sharp-libvips-darwin-x64': 1.3.1
+      '@img/sharp-libvips-linux-arm': 1.3.1
+      '@img/sharp-libvips-linux-arm64': 1.3.1
+      '@img/sharp-libvips-linux-ppc64': 1.3.1
+      '@img/sharp-libvips-linux-riscv64': 1.3.1
+      '@img/sharp-libvips-linux-s390x': 1.3.1
+      '@img/sharp-libvips-linux-x64': 1.3.1
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.1
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.1
+      '@img/sharp-linux-arm': 0.35.2
+      '@img/sharp-linux-arm64': 0.35.2
+      '@img/sharp-linux-ppc64': 0.35.2
+      '@img/sharp-linux-riscv64': 0.35.2
+      '@img/sharp-linux-s390x': 0.35.2
+      '@img/sharp-linux-x64': 0.35.2
+      '@img/sharp-linuxmusl-arm64': 0.35.2
+      '@img/sharp-linuxmusl-x64': 0.35.2
       '@img/sharp-webcontainers-wasm32': 0.35.2
+      '@img/sharp-win32-arm64': 0.35.2
+      '@img/sharp-win32-ia32': 0.35.2
+      '@img/sharp-win32-x64': 0.35.2
 
   shebang-command@2.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4119,7 +4119,7 @@ importers:
         version: 13.0.6
       just-bash:
         specifier: ^3.0.2
-        version: 3.0.2
+        version: 3.0.2(supports-color@7.2.0)
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -4176,6 +4176,9 @@ importers:
       ai:
         specifier: ^7.0.0
         version: 7.0.18(zod@4.4.3)
+      capnweb:
+        specifier: ^0.12.0
+        version: 0.12.0
       teleproto:
         specifier: ^1.228.5
         version: 1.228.5
@@ -4252,7 +4255,7 @@ importers:
         version: 4.31.0(ai@7.0.18(zod@4.4.3))(zod@4.4.3)
       just-bash:
         specifier: ^3.0.2
-        version: 3.0.2
+        version: 3.0.2(supports-color@7.2.0)
       workers-ai-provider:
         specifier: ^4.0.0
         version: 4.0.0(@ai-sdk/anthropic@4.0.10(zod@4.4.3))(@ai-sdk/google@4.0.10(zod@4.4.3))(@ai-sdk/openai@4.0.9(zod@4.4.3))(@ai-sdk/provider@4.0.2)(ai@7.0.18(zod@4.4.3))
@@ -13514,7 +13517,7 @@ snapshots:
       cjs-module-lexer: 1.2.3
       esbuild: 0.28.1
       miniflare: 4.20260730.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.0.1)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.0.1)(typescript@6.0.3))(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.2.0)(typescript@6.0.3))(vite@8.1.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       wrangler: 4.116.0(@cloudflare/workers-types@5.20260812.1)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -13576,7 +13579,7 @@ snapshots:
   '@cloudflare/workspace@https://pkg.pr.new/cloudflare/workspace/@cloudflare/workspace@98b74eb(@platformatic/vfs@0.4.0)(diff@9.0.0)(isomorphic-git@1.38.5)':
     dependencies:
       capnweb: 0.8.0
-      just-bash: 3.0.2
+      just-bash: 3.0.2(supports-color@7.2.0)
     optionalDependencies:
       '@platformatic/vfs': 0.4.0
       diff: 9.0.0
@@ -15456,7 +15459,7 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  '@tokenizer/inflate@0.4.1':
+  '@tokenizer/inflate@0.4.1(supports-color@7.2.0)':
     dependencies:
       debug: 4.4.3(supports-color@7.2.0)
       token-types: 6.1.2
@@ -17266,9 +17269,9 @@ snapshots:
       token-types: 6.1.2
       uint8array-extras: 1.5.0
 
-  file-type@21.3.4:
+  file-type@21.3.4(supports-color@7.2.0):
     dependencies:
-      '@tokenizer/inflate': 0.4.1
+      '@tokenizer/inflate': 0.4.1(supports-color@7.2.0)
       strtok3: 10.3.5
       token-types: 6.1.2
       uint8array-extras: 1.5.0
@@ -17915,11 +17918,11 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
-  just-bash@3.0.2:
+  just-bash@3.0.2(supports-color@7.2.0):
     dependencies:
       diff: 8.0.4
       fast-xml-parser: 5.9.3
-      file-type: 21.3.4
+      file-type: 21.3.4(supports-color@7.2.0)
       ini: 6.0.0
       minimatch: 10.2.5
       modern-tar: 0.7.6


### PR DESCRIPTION
## Summary

- add an ordinary Web Channel with an owned WebSockets capability for arbitrary Lifecycle Durable Objects
- dispatch AIChatAgent-compatible browser turns through the existing ChannelHost onMessage path and stream ChannelChunks back as AI SDK UI-message chunks
- make outbound chunk consumption abort-aware for transport cancellation
- add Web to the unchanged symmetric live adapter suite using a real Durable Object, WebSocketChatTransport observer, and Capn Web control session

## Current scope

This first slice is live, non-resumable Web chat. Durable replay, server-owned transcript mutation, client-tool continuation, regeneration, multi-tab synchronization, and Agent migration remain deferred.

## Validation

- pnpm --filter @cloudflare/channels test: 226 tests passed
- pnpm --filter @cloudflare/channels run build
- Web live suite: 5 scenarios passed against local Wrangler
- pnpm run check: exports, formatting, lint, and all 115 TypeScript projects passed