### PR TITLE
refactor(lifecycle): dissolve alarm memory-limit policy into the jobs domain

### DIFF
--- a/.changeset/tidy-breaker-domains.md
+++ b/.changeset/tidy-breaker-domains.md
@@ -1,0 +1,25 @@
+---
+"agents": minor
+"@cloudflare/ai-chat": patch
+"@cloudflare/think": patch
+---
+
+Make the alarm memory-limit circuit breaker (#1825) a self-contained
+Lifecycle concern instead of an Agent-mediated one.
+
+Recovery-loop membership is now a property of the job: schedules created
+with the new `recoveryLoop` option (and jobs pushed with the matching
+`LifecycleJobPushOptions` flag) are backed off by the breaker on a strike
+and purged when it seals at the strike budget, without disturbing unrelated
+rows — a new recovery schedule can no longer silently escape the breaker.
+Capabilities can react to a strike through the new optional `onMemoryLimit`
+hook, hosts through `onAlarmMemoryLimit`, and the strike budget is real
+Lifecycle configuration (`Lifecycle.install(host, { maxAlarmMemoryLimitStrikes })`)
+rather than a composition-root side channel.
+
+Removed accordingly: `Agent.onAlarmMemoryLimit`'s relay implementation, the
+`_cf_recoveryAlarmCallbacks` / `_cf_sealMemoryLimitedRecovery` template
+methods, `Scheduler.applyMemoryLimitPolicy`, and
+`setLifecycleAlarmMemoryLimitStrikes`. `AIChatAgent` and `Think` flag their
+recovery schedules via `chatRecoverySchedulePolicy` and seal in-flight
+incidents from their own protected `onAlarmMemoryLimit` hooks.

--- a/.changeset/tidy-breaker-domains.md
+++ b/.changeset/tidy-breaker-domains.md
@@ -26,4 +26,6 @@ Removed accordingly: `Agent.onAlarmMemoryLimit`'s relay implementation, the
 methods, `Scheduler.applyMemoryLimitPolicy`, and
 `setLifecycleAlarmMemoryLimitStrikes`. `AIChatAgent` and `Think` flag their
 recovery schedules via `chatRecoverySchedulePolicy` and seal in-flight
-incidents from their own protected `onAlarmMemoryLimit` hooks.
+incidents from their own protected `onAlarmMemoryLimit` hooks; both now
+require `agents >= 0.23.0` (they consume new `agents/chat` exports and no
+longer implement the old template-method breaker hooks).

--- a/.changeset/tidy-breaker-domains.md
+++ b/.changeset/tidy-breaker-domains.md
@@ -17,9 +17,13 @@ flag through internal scaffolding (`RecoveryLoopScheduleOptions`) that will
 be deleted when recovery migrates onto the Tasks capability, where
 OOM-prone loops belong.
 Capabilities can react to a strike through the new optional `onMemoryLimit`
-hook, hosts through `onAlarmMemoryLimit`, and the strike budget is real
-Lifecycle configuration (`Lifecycle.install(host, { maxAlarmMemoryLimitStrikes })`)
-rather than a composition-root side channel.
+hook, hosts through `onAlarmMemoryLimit`, and the context identifies the job
+that was executing when one exists. The strike budget is real Lifecycle
+configuration (`Lifecycle.install(host, { maxAlarmMemoryLimitStrikes })`)
+rather than a composition-root side channel. Until chat recovery moves to
+Tasks, a sealed routed recovery schedule also forwards the seal to its owning
+dynamic agent so a chat child under a plain Agent root persists its exhausted
+incident and terminal notification.
 
 Removed accordingly: `Agent.onAlarmMemoryLimit`'s relay implementation, the
 `_cf_recoveryAlarmCallbacks` / `_cf_sealMemoryLimitedRecovery` template

--- a/.changeset/tidy-breaker-domains.md
+++ b/.changeset/tidy-breaker-domains.md
@@ -7,11 +7,15 @@
 Make the alarm memory-limit circuit breaker (#1825) a self-contained
 Lifecycle concern instead of an Agent-mediated one.
 
-Recovery-loop membership is now a property of the job: schedules created
-with the new `recoveryLoop` option (and jobs pushed with the matching
-`LifecycleJobPushOptions` flag) are backed off by the breaker on a strike
-and purged when it seals at the strike budget, without disturbing unrelated
-rows — a new recovery schedule can no longer silently escape the breaker.
+Recovery-loop membership is now a property of the job row
+(`LifecycleJobPushOptions.recoveryLoop`): flagged jobs are backed off by
+the breaker on a strike and purged when it seals at the strike budget,
+without disturbing unrelated rows — a recovery schedule can no longer
+silently escape the breaker. The public `ScheduleOptions` vocabulary is
+unchanged: schedules only shape future work, and chat recovery reaches the
+flag through internal scaffolding (`RecoveryLoopScheduleOptions`) that will
+be deleted when recovery migrates onto the Tasks capability, where
+OOM-prone loops belong.
 Capabilities can react to a strike through the new optional `onMemoryLimit`
 hook, hosts through `onAlarmMemoryLimit`, and the strike budget is real
 Lifecycle configuration (`Lifecycle.install(host, { maxAlarmMemoryLimitStrikes })`)

--- a/.changeset/tidy-breaker-domains.md
+++ b/.changeset/tidy-breaker-domains.md
@@ -25,11 +25,14 @@ Tasks, a sealed routed recovery schedule also forwards the seal to its owning
 dynamic agent so a chat child under a plain Agent root persists its exhausted
 incident and terminal notification.
 
-Removed accordingly: `Agent.onAlarmMemoryLimit`'s relay implementation, the
-`_cf_recoveryAlarmCallbacks` / `_cf_sealMemoryLimitedRecovery` template
-methods, `Scheduler.applyMemoryLimitPolicy`, and
+Removed accordingly: `Agent.onAlarmMemoryLimit`'s policy relay, the
+`_cf_recoveryAlarmCallbacks` template hook, `Scheduler.applyMemoryLimitPolicy`,
+and
 `setLifecycleAlarmMemoryLimitStrikes`. `AIChatAgent` and `Think` flag their
 recovery schedules via `chatRecoverySchedulePolicy` and seal in-flight
 incidents from their own protected `onAlarmMemoryLimit` hooks; both now
 require `agents >= 0.23.0` (they consume new `agents/chat` exports and no
-longer implement the old template-method breaker hooks).
+longer implement the old template-method breaker hooks). Agent retains a
+sealed-only call to `_cf_sealMemoryLimitedRecovery` so already-published chat
+packages whose peer ranges accept agents 0.23 keep terminal notifications;
+that fallback carries no callback-name or queue policy.

--- a/packages/agents/src/chat/__tests__/recovery-engine.test.ts
+++ b/packages/agents/src/chat/__tests__/recovery-engine.test.ts
@@ -44,12 +44,16 @@ import {
  */
 describe("chatRecoverySchedulePolicy", () => {
   it("makes the initial recovery schedule idempotent (deploy-storm dedup)", () => {
-    expect(chatRecoverySchedulePolicy("initial")).toEqual({ idempotent: true });
+    expect(chatRecoverySchedulePolicy("initial")).toEqual({
+      idempotent: true,
+      recoveryLoop: true
+    });
   });
 
   it("makes the stable-timeout reschedule non-idempotent (survives row deletion)", () => {
     expect(chatRecoverySchedulePolicy("stable_timeout_retry")).toEqual({
-      idempotent: false
+      idempotent: false,
+      recoveryLoop: true
     });
   });
 
@@ -69,7 +73,7 @@ describe("recovery scheduling seam (fake scheduler)", () => {
   type ScheduleCall = {
     delaySeconds: number;
     callback: ChatRecoveryScheduleCallback;
-    options: { idempotent: boolean };
+    options: { idempotent?: boolean; recoveryLoop?: boolean };
   };
 
   function makeFakeScheduler() {
@@ -78,7 +82,7 @@ describe("recovery scheduling seam (fake scheduler)", () => {
       delaySeconds: number,
       callback: ChatRecoveryScheduleCallback,
       _data: Record<string, unknown>,
-      options: { idempotent: boolean }
+      options: { idempotent?: boolean; recoveryLoop?: boolean }
     ): Promise<void> => {
       calls.push({ delaySeconds, callback, options });
       return Promise.resolve();
@@ -96,7 +100,10 @@ describe("recovery scheduling seam (fake scheduler)", () => {
       chatRecoverySchedulePolicy("initial")
     );
     expect(scheduler.calls).toHaveLength(1);
-    expect(scheduler.calls[0]?.options).toEqual({ idempotent: true });
+    expect(scheduler.calls[0]?.options).toEqual({
+      idempotent: true,
+      recoveryLoop: true
+    });
   });
 
   it("passes idempotent:false when a package reschedules after a stable timeout", async () => {
@@ -109,7 +116,10 @@ describe("recovery scheduling seam (fake scheduler)", () => {
       chatRecoverySchedulePolicy("stable_timeout_retry")
     );
     expect(scheduler.calls).toHaveLength(1);
-    expect(scheduler.calls[0]?.options).toEqual({ idempotent: false });
+    expect(scheduler.calls[0]?.options).toEqual({
+      idempotent: false,
+      recoveryLoop: true
+    });
   });
 });
 

--- a/packages/agents/src/chat/index.ts
+++ b/packages/agents/src/chat/index.ts
@@ -255,6 +255,7 @@ export {
 } from "./recovery-incident";
 
 export {
+  chatRecoveryRedeferPolicy,
   chatRecoverySchedulePolicy,
   ChatRecoveryEngine,
   runChatRecoveryExhaustion,

--- a/packages/agents/src/chat/recovery-engine.ts
+++ b/packages/agents/src/chat/recovery-engine.ts
@@ -74,18 +74,21 @@ export type RecoveryPartial = {
 export type ChatStreamStatus = "streaming" | "completed" | "error";
 
 /**
- * Resolve the `schedule()` idempotency option for a recovery schedule. Single
- * source of truth for both packages; see {@link ChatRecoveryScheduleReason} for
- * the rationale behind each case.
+ * Resolve the `schedule()` options for a recovery schedule. Single source of
+ * truth for both packages; see {@link ChatRecoveryScheduleReason} for the
+ * rationale behind each idempotency case. Every recovery schedule is flagged
+ * `recoveryLoop` so the alarm memory-limit circuit breaker (#1825) backs the
+ * loop off on a strike and purges it when it seals.
  *
- * This is a cutover invariant: flipping either case silently breaks deploy-storm
- * dedup (initial) or stalls stable-timeout retries (reschedule), and neither is
- * caught by a type error — only by the recovery suites.
+ * This is a cutover invariant: flipping either idempotency case silently
+ * breaks deploy-storm dedup (initial) or stalls stable-timeout retries
+ * (reschedule), and neither is caught by a type error — only by the recovery
+ * suites.
  */
 export function chatRecoverySchedulePolicy(
   reason: ChatRecoveryScheduleReason
-): { idempotent: boolean } {
-  return { idempotent: reason === "initial" };
+): { idempotent: boolean; recoveryLoop: true } {
+  return { idempotent: reason === "initial", recoveryLoop: true };
 }
 
 /** Identity + context for opening (or re-evaluating) a recovery incident. */

--- a/packages/agents/src/chat/recovery-engine.ts
+++ b/packages/agents/src/chat/recovery-engine.ts
@@ -10,6 +10,7 @@
  */
 
 import type { FiberRecoveryContext } from "../index";
+import type { RecoveryLoopScheduleOptions } from "../schedules/types";
 import type {
   ChatRecoveryExhaustedContext,
   ChatRecoveryOptions,
@@ -87,8 +88,18 @@ export type ChatStreamStatus = "streaming" | "completed" | "error";
  */
 export function chatRecoverySchedulePolicy(
   reason: ChatRecoveryScheduleReason
-): { idempotent: boolean; recoveryLoop: true } {
+): RecoveryLoopScheduleOptions {
   return { idempotent: reason === "initial", recoveryLoop: true };
+}
+
+/**
+ * Options for a manual post-handoff re-defer of a recovery continuation
+ * (#1730): non-idempotent like every reschedule, and flagged for the alarm
+ * memory-limit breaker like every recovery schedule — the flag is internal
+ * scaffolding, so call sites route through here rather than writing it.
+ */
+export function chatRecoveryRedeferPolicy(): RecoveryLoopScheduleOptions {
+  return { idempotent: false, recoveryLoop: true };
 }
 
 /** Identity + context for opening (or re-evaluating) a recovery incident. */

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -52,7 +52,6 @@ import {
   type ConnectionContext,
   Lifecycle,
   type LifecycleJobOutcome,
-  setLifecycleAlarmMemoryLimitStrikes,
   setLifecycleEventSink,
   setLifecycleHostInvoker,
   setLifecycleRouteTransport,
@@ -128,8 +127,16 @@ import type { McpAgent } from "./mcp";
 import { Scheduler, setSchedulerCallbackResolver } from "./schedules/scheduler";
 import { Tasks, setTaskDefinitionResolver } from "./tasks/tasks";
 import type { TaskCallbacks, TaskHandlers } from "./tasks/types";
-import type { Schedule, ScheduleCriteria } from "./schedules/types";
-export type { Schedule, ScheduleCriteria } from "./schedules/types";
+import type {
+  Schedule,
+  ScheduleCriteria,
+  ScheduleOptions
+} from "./schedules/types";
+export type {
+  Schedule,
+  ScheduleCriteria,
+  ScheduleOptions
+} from "./schedules/types";
 export {
   AGENT_TOOL_PROGRESS_PART,
   AGENT_TOOL_MILESTONE_PART
@@ -1540,7 +1547,9 @@ export class Agent<
    *
    * @experimental The API surface may change before stabilizing.
    */
-  readonly lifecycle = Lifecycle.install<Env, Props>(this);
+  readonly lifecycle = Lifecycle.install<Env, Props>(this, {
+    maxAlarmMemoryLimitStrikes: this._resolvedOptions.maxAlarmMemoryLimitStrikes
+  });
 
   /**
    * WebSocket connection subsystem. Constructed as a field initializer
@@ -2314,11 +2323,6 @@ export class Agent<
         },
         run
       )
-    );
-
-    setLifecycleAlarmMemoryLimitStrikes(
-      this.lifecycle,
-      this._resolvedOptions.maxAlarmMemoryLimitStrikes
     );
 
     this.scheduler = new Scheduler({
@@ -4130,13 +4134,14 @@ export class Agent<
    * @param options Options for the scheduled task
    * @param options.retry Retry options for the callback execution
    * @param options.idempotent Dedup by callback+payload. Defaults to `true` for cron, `false` otherwise.
+   * @param options.recoveryLoop Let the alarm memory-limit circuit breaker back off / purge this schedule (#1825)
    * @returns Schedule object representing the scheduled task
    */
   schedule<T = string>(
     when: Date | string | number,
     callback: keyof this,
     payload?: T,
-    options?: { retry?: RetryOptions; idempotent?: boolean }
+    options?: ScheduleOptions
   ): Promise<Schedule<T>> {
     // SAFETY: Agent's historical generic promises Schedule<T>; the untyped
     // scheduler default carries Schedule<unknown> for name-based calls.
@@ -5892,42 +5897,12 @@ export class Agent<
   }
 
   /**
-   * Apply Agent's domain policy when the Lifecycle alarm memory-limit
-   * circuit breaker records a strike (#1825). Lifecycle already handled the
-   * item that was executing; this backs off or purges the recovery-loop
-   * schedules named by {@link _cf_recoveryAlarmCallbacks} and, at the strike
-   * budget, seals in-flight recovery via {@link _cf_sealMemoryLimitedRecovery}.
-   * @internal
-   */
-  async onAlarmMemoryLimit(context: {
-    readonly sealed: boolean;
-    readonly nextTime?: number;
-  }): Promise<void> {
-    const callbacks = this._cf_recoveryAlarmCallbacks();
-    try {
-      await this.scheduler.applyMemoryLimitPolicy({
-        callbacks,
-        sealed: context.sealed,
-        nextTime: context.nextTime
-      });
-    } catch {
-      // best-effort at a host failure boundary
-    }
-    if (context.sealed) {
-      try {
-        await this._cf_sealMemoryLimitedRecovery();
-      } catch {
-        // best-effort terminalization; the purge above already broke the loop
-      }
-    }
-  }
-
-  /**
    * Run Lifecycle's alarm event loop after the pending-destroy preamble.
    *
    * The alarm memory-limit circuit breaker (#1825) lives inside
-   * `Lifecycle.alarm()`; Agent contributes domain policy through
-   * {@link onAlarmMemoryLimit}.
+   * `Lifecycle.alarm()`; capabilities and hosts opt into extra domain
+   * policy via their `onMemoryLimit` / `onAlarmMemoryLimit` hooks and the
+   * `recoveryLoop` schedule option.
    *
    * @remarks Use `this.schedule()` for named Agent callbacks. Reusable durable
    * work belongs in a capability that pushes jobs and implements `onJob()`.
@@ -5947,26 +5922,6 @@ export class Agent<
 
     await this.lifecycle.alarm();
   }
-
-  /**
-   * The schedule-callback names whose jobs drive a recovery loop that can
-   * deterministically OOM. The base agent has none; chat hosts (`Think`,
-   * `AIChatAgent`) override this to return their recovery continuation callbacks
-   * so the circuit breaker can surgically back them off / purge them WITHOUT
-   * disturbing unrelated scheduled tasks. See {@link onAlarmMemoryLimit}.
-   */
-  protected _cf_recoveryAlarmCallbacks(): string[] {
-    return [];
-  }
-
-  /**
-   * Hook for a host to terminalize ("seal") any in-flight recovery work as an
-   * out-of-memory exhaustion when the alarm circuit breaker trips at its strike
-   * budget (#1825). Runs at the outermost alarm frame (post-unwind, so writes
-   * can land). Default: no-op. Chat hosts override to fire `onExhausted` + the
-   * terminal banner and persist the sealed incident.
-   */
-  protected async _cf_sealMemoryLimitedRecovery(): Promise<void> {}
 
   // ── Sub-agent routing (external addressability for facets) ──────────────
 

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -48,6 +48,7 @@ import {
 } from "cloudflare:workers";
 import {
   type LifecycleJobContext,
+  type MemoryLimitContext,
   type Connection,
   type ConnectionContext,
   Lifecycle,
@@ -5910,6 +5911,30 @@ export class Agent<
         console.warn(`Unknown Agent host job fn ${JSON.stringify(fn)}`);
         return undefined;
     }
+  }
+
+  /**
+   * Apply host policy after the alarm memory-limit breaker records a strike.
+   *
+   * New chat hosts override this hook directly. The sealed-only fallback keeps
+   * `agents` 0.23 compatible with already-published chat packages whose peer
+   * ranges accept it but which implement only the former
+   * `_cf_sealMemoryLimitedRecovery` template method. Queue membership remains
+   * job-row policy; this invokes terminalization only and can be removed once
+   * old chat releases no longer accept the current `agents` range.
+   *
+   * @internal
+   */
+  protected async onAlarmMemoryLimit(
+    context: MemoryLimitContext
+  ): Promise<void> {
+    if (!context.sealed) return;
+    const legacySeal = (
+      this as unknown as {
+        _cf_sealMemoryLimitedRecovery?: () => void | Promise<void>;
+      }
+    )._cf_sealMemoryLimitedRecovery;
+    await legacySeal?.call(this);
   }
 
   /**

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -124,7 +124,11 @@ import { MessageType } from "./types";
 import { RPC_DO_PREFIX } from "./mcp/rpc";
 import { ensureMcpServerTable } from "./mcp/client/storage";
 import type { McpAgent } from "./mcp";
-import { Scheduler, setSchedulerCallbackResolver } from "./schedules/scheduler";
+import {
+  Scheduler,
+  setSchedulerCallbackResolver,
+  setSchedulerRoutedMemoryLimitHandler
+} from "./schedules/scheduler";
 import { Tasks, setTaskDefinitionResolver } from "./tasks/tasks";
 import type { TaskCallbacks, TaskHandlers } from "./tasks/types";
 import type {
@@ -2352,6 +2356,19 @@ export class Agent<
         (
           method as (payload: unknown, schedule: Schedule<unknown>) => unknown
         ).call(this, payload, schedule);
+    });
+
+    // Temporary bridge for a legacy routed chat-recovery schedule: the queue
+    // and physical alarm live on the root Agent, but the incident and sealing
+    // hook live on each owning dynamic agent. Scheduler routes a sealed strike
+    // to owners whose flagged rows were purged. Recovery-on-Tasks removes this.
+    setSchedulerRoutedMemoryLimitHandler(this.scheduler, (context) => {
+      const hook = (
+        this as unknown as {
+          onAlarmMemoryLimit?: (value: typeof context) => void | Promise<void>;
+        }
+      ).onAlarmMemoryLimit;
+      return hook?.call(this, context);
     });
 
     this.tasks = new Tasks({

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -4134,7 +4134,6 @@ export class Agent<
    * @param options Options for the scheduled task
    * @param options.retry Retry options for the callback execution
    * @param options.idempotent Dedup by callback+payload. Defaults to `true` for cron, `false` otherwise.
-   * @param options.recoveryLoop Let the alarm memory-limit circuit breaker back off / purge this schedule (#1825)
    * @returns Schedule object representing the scheduled task
    */
   schedule<T = string>(

--- a/packages/agents/src/lifecycle/capability-runner.ts
+++ b/packages/agents/src/lifecycle/capability-runner.ts
@@ -39,6 +39,17 @@ export type CapabilityWebSocketUpgradeContext = {
 };
 
 /**
+ * Context supplied when the alarm memory-limit circuit breaker records a
+ * strike (#1825), to capabilities and the host alike.
+ */
+export type MemoryLimitContext = {
+  /** Whether the breaker hit its strike budget and sealed recovery work. */
+  readonly sealed: boolean;
+  /** The backoff wake time (epoch ms) armed for an unsealed strike. */
+  readonly nextTime?: number;
+};
+
+/**
  * A capability installed into a Durable Object lifecycle.
  *
  * Capabilities extending `LifecycleCapability` receive the standard storage,
@@ -144,6 +155,15 @@ export interface DurableObjectCapability<Props extends object = object> {
     context: LifecycleJobContext,
     error: unknown
   ): MaybePromise<LifecycleJobOutcome | void>;
+
+  /**
+   * Apply domain policy after the alarm memory-limit circuit breaker
+   * records a strike (#1825). Lifecycle has already handled the queue: the
+   * executing job and every `recoveryLoop`-flagged job are backed off (or
+   * purged when `sealed`). Runs at the outermost alarm frame, post-unwind,
+   * best-effort — the isolate resets right after, so keep writes small.
+   */
+  onMemoryLimit?(context: MemoryLimitContext): MaybePromise<void>;
 
   /** Handle one message routed to this capability identity. */
   onRoute?(context: LifecycleRouteContext): MaybePromise<unknown>;
@@ -314,6 +334,24 @@ export class CapabilityRunner<Props extends object = object> {
       );
     }
     return capability.onRoute(context);
+  }
+
+  /**
+   * Offer a memory-limit strike to every capability, best-effort.
+   *
+   * Deliberately not gated on startup: a strike can land while startup
+   * itself is the work that exceeded the memory limit, and the breaker's
+   * policy must still reach capabilities. One capability's failure does not
+   * stop the next — the isolate is about to reset either way.
+   */
+  async memoryLimit(context: MemoryLimitContext): Promise<void> {
+    for (const capability of this.#getCapabilities()) {
+      try {
+        await capability.onMemoryLimit?.(context);
+      } catch (error) {
+        console.error("Lifecycle capability memory-limit policy failed", error);
+      }
+    }
   }
 
   /** Dispose installed capabilities in reverse registration order. */

--- a/packages/agents/src/lifecycle/capability-runner.ts
+++ b/packages/agents/src/lifecycle/capability-runner.ts
@@ -1,7 +1,11 @@
 import { lifecycleCapabilityId } from "./capability";
 import type { LifecycleRouteContext } from "./capability";
 import type { WSMessage } from "./types";
-import type { LifecycleJobContext, LifecycleJobOutcome } from "./job-queue";
+import type {
+  LifecycleJob,
+  LifecycleJobContext,
+  LifecycleJobOutcome
+} from "./job-queue";
 
 type MaybePromise<T> = T | Promise<T>;
 
@@ -47,6 +51,24 @@ export type MemoryLimitContext = {
   readonly sealed: boolean;
   /** The backoff wake time (epoch ms) armed for an unsealed strike. */
   readonly nextTime?: number;
+  /**
+   * The queue job that was executing when the strike landed. Absent when the
+   * reset happened during startup or host alarm work. Lifecycle has already
+   * backed off or purged its row before invoking memory-limit policy.
+   *
+   * Capabilities whose durable state outlives their queue row use this to
+   * apply the same policy to the underlying work. Scheduler temporarily also
+   * uses a routed job's address to deliver sealing to its owning dynamic agent;
+   * chat recovery's Tasks migration removes that compatibility path.
+   */
+  readonly executing?: LifecycleJob;
+  /**
+   * Recovery-loop jobs removed when this strike sealed the breaker. This is a
+   * pre-purge snapshot because the durable rows no longer exist when policy
+   * hooks run. Routed capabilities can use it to notify each owning Lifecycle;
+   * ordinary capabilities should prefer `executing`.
+   */
+  readonly purgedRecoveryLoopJobs?: ReadonlyArray<LifecycleJob>;
 };
 
 /**

--- a/packages/agents/src/lifecycle/current-agent.ts
+++ b/packages/agents/src/lifecycle/current-agent.ts
@@ -1,6 +1,7 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 import type { DurableObject } from "cloudflare:workers";
 
+import type { MemoryLimitContext } from "./capability-runner";
 import type { Lifecycle } from "./durable-object-lifecycle";
 import type { Connection } from "./types";
 import type { LifecycleJobContext, LifecycleJobOutcome } from "./job-queue";
@@ -24,10 +25,18 @@ export interface LifecycleObject<
   onJob?(
     context: LifecycleJobContext
   ): LifecycleJobOutcome | void | Promise<LifecycleJobOutcome | void>;
-  onAlarmMemoryLimit?(context: {
-    readonly sealed: boolean;
-    readonly nextTime?: number;
-  }): void | Promise<void>;
+  /**
+   * Host domain policy applied when the alarm memory-limit circuit breaker
+   * records a strike (#1825), after every capability's `onMemoryLimit` hook.
+   *
+   * Lifecycle dispatches host hooks structurally through its internal host
+   * cast, so TS visibility is the host's to choose: a framework host whose
+   * implementation is internal machinery declares the hook `protected` (the
+   * pattern — see `AIChatAgent`/`Think`) and keeps the real work in a
+   * `private _cf_`-prefixed method, without falling out of this contract at
+   * runtime.
+   */
+  onAlarmMemoryLimit?(context: MemoryLimitContext): void | Promise<void>;
 }
 
 /** Values associated with the currently executing Lifecycle host. */

--- a/packages/agents/src/lifecycle/durable-object-lifecycle.ts
+++ b/packages/agents/src/lifecycle/durable-object-lifecycle.ts
@@ -36,7 +36,8 @@ export {
   type CapabilityWebSocketUpgradeContext,
   type LifecycleEvent,
   type CapabilityStartContext,
-  type DurableObjectCapability
+  type DurableObjectCapability,
+  type MemoryLimitContext
 } from "./capability-runner";
 export {
   type LifecycleJobContext,
@@ -139,19 +140,15 @@ export function setLifecycleEventSink<
   lifecycleEventSinks.set(lifecycle, sink);
 }
 
-const lifecycleMemoryLimitStrikeBudgets = new WeakMap<object, number>();
-
-/**
- * @internal Set the consecutive alarm memory-limit strikes tolerated before
- * the Lifecycle circuit breaker seals recovery work (#1825). Composition
- * roots (Agent) supply their configured budget; the default is 3.
- */
-export function setLifecycleAlarmMemoryLimitStrikes<
-  Env extends object,
-  Props extends Record<string, unknown>
->(lifecycle: Lifecycle<Env, Props>, maxStrikes: number): void {
-  lifecycleMemoryLimitStrikeBudgets.set(lifecycle, maxStrikes);
-}
+/** Configuration accepted when constructing a {@link Lifecycle}. */
+export type LifecycleOptions = {
+  /**
+   * Consecutive alarm invocations that may end in a Durable Object
+   * memory-limit reset before the circuit breaker (#1825) seals recovery
+   * work instead of backing it off. Default: 3.
+   */
+  readonly maxAlarmMemoryLimitStrikes?: number;
+};
 
 /**
  * Installs and coordinates the runtime lifecycle for a Durable Object.
@@ -193,8 +190,11 @@ export class Lifecycle<
   static install<
     Env extends object,
     Props extends Record<string, unknown> = Record<string, unknown>
-  >(host: DurableObject<Env>): Lifecycle<Env, Props> {
-    const lifecycle = new Lifecycle<Env, Props>(host);
+  >(
+    host: DurableObject<Env>,
+    options?: LifecycleOptions
+  ): Lifecycle<Env, Props> {
+    const lifecycle = new Lifecycle<Env, Props>(host, options);
     lifecycle.installHandlers();
     return lifecycle;
   }
@@ -203,8 +203,9 @@ export class Lifecycle<
    * Bind a lifecycle to a Durable Object instance without mutating its handlers.
    *
    * @param host - The Durable Object whose runtime lifecycle this object owns.
+   * @param options - Policy configuration for this lifecycle.
    */
-  constructor(host: DurableObject<Env>) {
+  constructor(host: DurableObject<Env>, options?: LifecycleOptions) {
     // SAFETY: DurableObject exposes ctx as protected to subclasses. The
     // lifecycle is constructed by that subclass with `this`, so this boundary
     // accesses the same runtime-owned context without exposing it publicly.
@@ -217,11 +218,15 @@ export class Lifecycle<
       storage: this.#ctx.storage,
       disabled: () => this.#alarmsDisabled,
       resolveDispatch: (owner) => this.#resolveJobDispatch(owner),
-      maxMemoryLimitStrikes: () => lifecycleMemoryLimitStrikeBudgets.get(this),
-      onMemoryLimit: (context) =>
-        runInLifecycleHostContext({ host: this.#host }, () =>
+      maxMemoryLimitStrikes: () => options?.maxAlarmMemoryLimitStrikes,
+      onMemoryLimit: async (context) => {
+        // Capabilities first (each best-effort inside the runner), then the
+        // host hook — a failed capability policy must not silence the host's.
+        await this.#capabilityRunner.memoryLimit(context);
+        await runInLifecycleHostContext({ host: this.#host }, () =>
           this.#host.onAlarmMemoryLimit?.(context)
-        ),
+        );
+      },
       emit: (type, payload) =>
         this.#emitCapabilityEvent({ source: "lifecycle", type, payload }),
       rearm: () => this.rearmAlarm(),

--- a/packages/agents/src/lifecycle/index.ts
+++ b/packages/agents/src/lifecycle/index.ts
@@ -20,6 +20,8 @@ export {
 } from "./current-agent";
 export {
   Lifecycle,
+  type LifecycleOptions,
+  type MemoryLimitContext,
   type LifecycleJobContext,
   type LifecycleJobs,
   type LifecycleJob,

--- a/packages/agents/src/lifecycle/job-driver.ts
+++ b/packages/agents/src/lifecycle/job-driver.ts
@@ -16,6 +16,7 @@ import {
   isPlatformFailure,
   tryN
 } from "../retries";
+import type { MemoryLimitContext } from "./capability-runner";
 import {
   hungTimeoutMs,
   isHungRow,
@@ -69,11 +70,8 @@ export type JobDriverOptions = {
   readonly resolveDispatch: (owner: string) => Promise<JobDispatch | undefined>;
   /** Consecutive memory-limit strikes tolerated before sealing (#1825). */
   readonly maxMemoryLimitStrikes: () => number | undefined;
-  /** Host domain policy applied on each memory-limit strike. */
-  readonly onMemoryLimit: (context: {
-    readonly sealed: boolean;
-    readonly nextTime?: number;
-  }) => void | Promise<void>;
+  /** Capability and host domain policy applied on each memory-limit strike. */
+  readonly onMemoryLimit: (context: MemoryLimitContext) => void | Promise<void>;
   /** Best-effort lifecycle telemetry. */
   readonly emit: (type: string, payload: unknown) => void;
   /** Recompute the physical alarm from queue state. */
@@ -312,9 +310,10 @@ export class JobDriver {
    * Alarm-boundary circuit breaker for Durable Object memory-limit resets
    * (#1825). Unhandled, the platform would auto-retry the alarm forever,
    * re-running the doomed work each cycle. A durable strike counter
-   * tolerates a few consecutive resets — backing off the executing job so
-   * the retry is not a hot loop — then seals: the executing job is purged
-   * and the host's memory-limit policy hook runs. Each step is best-effort:
+   * tolerates a few consecutive resets — backing off the executing job and
+   * every pending recovery-loop job so the retry is not a hot loop — then
+   * seals: those jobs are purged and the capability + host memory-limit
+   * policy hooks run. Each step is best-effort:
    * even these small writes can OOM, but swallowing still halts the
    * platform's auto-retry, and a later wake re-arms legitimate work.
    */
@@ -354,6 +353,14 @@ export class JobDriver {
         } else if (nextTime !== undefined) {
           queue.retime(executing.id, nextTime);
         }
+      }
+      // Recovery-loop rows travel as a pack: a doomed loop's sibling rows
+      // would re-trigger it on the next wake, so they back off (or purge)
+      // together with the row that struck.
+      if (sealed) {
+        queue.purgeRecoveryLoopJobs();
+      } else if (nextTime !== undefined) {
+        queue.delayRecoveryLoopJobs(nextTime);
       }
     } catch {
       // best-effort at a failure boundary

--- a/packages/agents/src/lifecycle/job-driver.ts
+++ b/packages/agents/src/lifecycle/job-driver.ts
@@ -23,6 +23,7 @@ import {
   jobFromRow,
   type JobQueue,
   type JobStorageRow,
+  type LifecycleJob,
   type LifecycleJobContext,
   type LifecycleJobOutcome
 } from "./job-queue";
@@ -345,6 +346,15 @@ export class JobDriver {
     const nextTime = sealed
       ? undefined
       : Date.now() + Math.min(300, 30 * strikes) * 1000;
+    // Capture routed ownership before sealing deletes the rows. Domain policy
+    // runs afterward, when the loop is already broken, and uses this snapshot
+    // only to terminalize durable state owned outside the alarm host.
+    let purgedRecoveryLoopJobs: LifecycleJob[] | undefined;
+    try {
+      if (sealed) purgedRecoveryLoopJobs = queue.recoveryLoopJobs();
+    } catch {
+      // best-effort at a failure boundary
+    }
 
     try {
       if (executing) {
@@ -367,7 +377,12 @@ export class JobDriver {
     }
 
     try {
-      await this.#options.onMemoryLimit({ sealed, nextTime });
+      await this.#options.onMemoryLimit({
+        sealed,
+        nextTime,
+        executing: executing ? jobFromRow(executing) : undefined,
+        purgedRecoveryLoopJobs
+      });
     } catch {
       // best-effort domain policy; the purge above already broke the loop
     }

--- a/packages/agents/src/lifecycle/job-queue.ts
+++ b/packages/agents/src/lifecycle/job-queue.ts
@@ -37,6 +37,8 @@ export type LifecycleJob = {
   readonly singleflight: boolean;
   /** Whether the job suppresses ordinary alarm candidates while pending. */
   readonly exclusive: boolean;
+  /** Whether the alarm memory-limit breaker governs this pending job (#1825). */
+  readonly recoveryLoop: boolean;
   /** Creation time in epoch seconds. */
   readonly createdAt: number;
 };
@@ -65,6 +67,15 @@ export type LifecycleJobPushOptions = {
   readonly hungTimeoutSeconds?: number;
   /** Suppress ordinary alarm candidates while this job is pending. */
   readonly exclusive?: boolean;
+  /**
+   * Mark this job as part of a recovery loop that can deterministically
+   * exhaust memory. On an alarm memory-limit strike the circuit breaker
+   * (#1825) backs off every pending flagged job to the strike's backoff
+   * time, and purges them all when it seals at the strike budget — so a
+   * doomed loop cannot re-trigger through a sibling row while unrelated
+   * jobs stay untouched.
+   */
+  readonly recoveryLoop?: boolean;
 };
 
 /**
@@ -128,6 +139,7 @@ export type JobStorageRow = {
   singleflight: number;
   hung_timeout_seconds: number | null;
   exclusive: number;
+  recovery_loop: number;
   running: number;
   execution_started_at: number | null;
   created_at: number;
@@ -148,6 +160,7 @@ export function jobFromRow(row: JobStorageRow): LifecycleJob {
         : undefined,
     singleflight: row.singleflight === 1,
     exclusive: row.exclusive === 1,
+    recoveryLoop: row.recovery_loop === 1,
     createdAt: row.created_at
   };
 }
@@ -199,6 +212,7 @@ export class JobQueue {
         singleflight INTEGER NOT NULL DEFAULT 0,
         hung_timeout_seconds INTEGER,
         exclusive INTEGER NOT NULL DEFAULT 0,
+        recovery_loop INTEGER NOT NULL DEFAULT 0,
         running INTEGER NOT NULL DEFAULT 0,
         execution_started_at INTEGER,
         created_at INTEGER NOT NULL DEFAULT (unixepoch())
@@ -223,8 +237,9 @@ export class JobQueue {
     this.#sql(
       `INSERT INTO cf_agents_jobs
         (id, capability, fn, time, payload, retry_options, singleflight,
-         hung_timeout_seconds, exclusive, running, execution_started_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL)
+         hung_timeout_seconds, exclusive, recovery_loop, running,
+         execution_started_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL)
        ON CONFLICT(id) DO UPDATE SET
          fn = excluded.fn,
          time = excluded.time,
@@ -233,6 +248,7 @@ export class JobQueue {
          singleflight = excluded.singleflight,
          hung_timeout_seconds = excluded.hung_timeout_seconds,
          exclusive = excluded.exclusive,
+         recovery_loop = excluded.recovery_loop,
          running = 0,
          execution_started_at = NULL
        WHERE cf_agents_jobs.capability = excluded.capability`,
@@ -244,7 +260,8 @@ export class JobQueue {
       options.retry ? JSON.stringify(options.retry) : null,
       options.singleflight ? 1 : 0,
       options.hungTimeoutSeconds ?? null,
-      options.exclusive ? 1 : 0
+      options.exclusive ? 1 : 0,
+      options.recoveryLoop ? 1 : 0
     );
     const job = this.get(capability, id);
     if (!job) {
@@ -368,6 +385,30 @@ export class JobQueue {
       Math.floor(time),
       id
     );
+  }
+
+  /**
+   * Back off every pending recovery-loop job that would fire before the
+   * breaker's backoff time (#1825), so a doomed loop's sibling rows cannot
+   * re-trigger it on the next wake. Unguarded like {@link retime}: the
+   * breaker's backoff must land regardless of dispatch markers.
+   */
+  delayRecoveryLoopJobs(time: number): void {
+    this.#sql(
+      `UPDATE cf_agents_jobs
+       SET time = ?, running = 0, execution_started_at = NULL
+       WHERE recovery_loop = 1 AND time <= ?`,
+      Math.floor(time),
+      Math.floor(time)
+    );
+  }
+
+  /**
+   * Purge every recovery-loop job when the breaker seals at its strike
+   * budget (#1825). Unrelated jobs are untouched.
+   */
+  purgeRecoveryLoopJobs(): void {
+    this.#sql("DELETE FROM cf_agents_jobs WHERE recovery_loop = 1");
   }
 
   /**

--- a/packages/agents/src/lifecycle/job-queue.ts
+++ b/packages/agents/src/lifecycle/job-queue.ts
@@ -404,6 +404,17 @@ export class JobQueue {
   }
 
   /**
+   * Read every recovery-loop job before breaker sealing. The memory-limit
+   * policy phase uses this snapshot after the rows are purged so routed owners
+   * can terminalize their own durable recovery state.
+   */
+  recoveryLoopJobs(): LifecycleJob[] {
+    return this.#sql(
+      "SELECT * FROM cf_agents_jobs WHERE recovery_loop = 1 ORDER BY time ASC"
+    ).map(jobFromRow);
+  }
+
+  /**
    * Purge every recovery-loop job when the breaker seals at its strike
    * budget (#1825). Unrelated jobs are untouched.
    */

--- a/packages/agents/src/schedules/scheduler.ts
+++ b/packages/agents/src/schedules/scheduler.ts
@@ -74,6 +74,19 @@ const SCHEDULE_SCHEMA_VERSION_KEY = "cf_agents:schedules_schema_version";
 /** Version 2: schedule rows live in the Lifecycle job queue. */
 const CURRENT_SCHEDULE_SCHEMA_VERSION = 2;
 
+/**
+ * Legacy schedule callbacks whose rows drive chat recovery loops from before
+ * the job queue carried breaker membership. The migration is the one place
+ * allowed to know legacy names (it already drops `_cf_keepAliveHeartbeat`
+ * rows by name): a recovery row migrated without its `recoveryLoop` flag
+ * would escape the alarm memory-limit breaker (#1825) and could re-trigger
+ * a doomed loop on an upgraded object.
+ */
+const LEGACY_RECOVERY_LOOP_CALLBACKS = new Set([
+  "_chatRecoveryContinue",
+  "_chatRecoveryRetry"
+]);
+
 const DEFAULT_RETRY: Required<RetryOptions> = {
   maxAttempts: 3,
   baseDelayMs: 100,
@@ -268,7 +281,8 @@ export class Scheduler<
         } satisfies SchedulerJobPayload,
         retry: resolveRetryConfig(retry, this.#retryDefaults),
         singleflight: row.type === "interval",
-        hungTimeoutSeconds: this.#hungScheduleTimeoutSeconds
+        hungTimeoutSeconds: this.#hungScheduleTimeoutSeconds,
+        recoveryLoop: LEGACY_RECOVERY_LOOP_CALLBACKS.has(row.callback)
       });
     }
     storage.sql.exec("DROP TABLE cf_agents_schedules");
@@ -793,6 +807,23 @@ export class Scheduler<
         JSON.stringify(payload)
       );
       if (existing) {
+        // A dedup hit onto a row without breaker membership the caller asks
+        // for (a row migrated from the legacy schedule table) re-pushes the
+        // same durable intent in place with the flag — otherwise the row
+        // would escape the alarm memory-limit breaker (#1825) forever.
+        if (options?.recoveryLoop && !existing.job.recoveryLoop) {
+          await this.lifecycle.jobs.push({
+            id: existing.job.id,
+            fn: existing.job.fn,
+            time: existing.job.time,
+            payload: existing.job.payload,
+            retry: existing.job.retry,
+            singleflight: existing.job.singleflight,
+            exclusive: existing.job.exclusive,
+            hungTimeoutSeconds: this.#hungScheduleTimeoutSeconds,
+            recoveryLoop: true
+          });
+        }
         // A dedup hit still re-arms so a lost physical alarm recovers, as
         // idempotent re-scheduling on startup historically guaranteed.
         await this.lifecycle.jobs.rearm();

--- a/packages/agents/src/schedules/scheduler.ts
+++ b/packages/agents/src/schedules/scheduler.ts
@@ -663,36 +663,6 @@ export class Scheduler<
     }
   }
 
-  /**
-   * @internal Apply the alarm memory-limit breaker's policy to this
-   * Scheduler's recovery schedules (#1825). The host names the callbacks
-   * whose jobs drive a recovery loop; sealed purges them, otherwise they are
-   * delayed to `nextTime` (epoch ms) so the next attempt runs on a fresh
-   * isolate after a backoff. Lifecycle handles the job that was executing.
-   */
-  async applyMemoryLimitPolicy(options: {
-    readonly callbacks: ReadonlyArray<string>;
-    readonly sealed: boolean;
-    readonly nextTime?: number;
-  }): Promise<void> {
-    const callbacks = new Set(options.callbacks);
-    for (const { job } of this.#ownedJobs()) {
-      if (!callbacks.has(job.fn)) continue;
-      try {
-        if (options.sealed) {
-          await this.lifecycle.jobs.cancel(job.id);
-        } else if (
-          options.nextTime !== undefined &&
-          job.time <= options.nextTime
-        ) {
-          await this.lifecycle.jobs.reschedule(job.id, options.nextTime);
-        }
-      } catch {
-        // best-effort at a host failure boundary
-      }
-    }
-  }
-
   // ── Validation ───────────────────────────────────────────────────────────
 
   #validateSchedule(
@@ -851,7 +821,8 @@ export class Scheduler<
       payload: jobPayload,
       retry: resolveRetryConfig(options?.retry, this.#retryDefaults),
       singleflight: timing.type === "interval",
-      hungTimeoutSeconds: this.#hungScheduleTimeoutSeconds
+      hungTimeoutSeconds: this.#hungScheduleTimeoutSeconds,
+      recoveryLoop: options?.recoveryLoop
     });
 
     return {

--- a/packages/agents/src/schedules/scheduler.ts
+++ b/packages/agents/src/schedules/scheduler.ts
@@ -34,6 +34,7 @@ import {
   type ScheduleTiming
 } from "./schedule-timing";
 import type {
+  RecoveryLoopScheduleOptions,
   Schedule,
   ScheduleCriteria,
   ScheduleOptions,
@@ -798,6 +799,12 @@ export class Scheduler<
     const idempotent = isRecurring(timing)
       ? options?.idempotent !== false
       : Boolean(options?.idempotent);
+    // Not part of the public ScheduleOptions vocabulary — chat-recovery
+    // scaffolding passed through to the job row until recovery migrates
+    // onto Tasks. See {@link RecoveryLoopScheduleOptions}.
+    const recoveryLoop = (
+      options as Partial<RecoveryLoopScheduleOptions> | undefined
+    )?.recoveryLoop;
 
     if (idempotent) {
       const existing = this.#findMatchingJob(
@@ -811,7 +818,7 @@ export class Scheduler<
         // for (a row migrated from the legacy schedule table) re-pushes the
         // same durable intent in place with the flag — otherwise the row
         // would escape the alarm memory-limit breaker (#1825) forever.
-        if (options?.recoveryLoop && !existing.job.recoveryLoop) {
+        if (recoveryLoop && !existing.job.recoveryLoop) {
           await this.lifecycle.jobs.push({
             id: existing.job.id,
             fn: existing.job.fn,
@@ -853,7 +860,7 @@ export class Scheduler<
       retry: resolveRetryConfig(options?.retry, this.#retryDefaults),
       singleflight: timing.type === "interval",
       hungTimeoutSeconds: this.#hungScheduleTimeoutSeconds,
-      recoveryLoop: options?.recoveryLoop
+      recoveryLoop
     });
 
     return {

--- a/packages/agents/src/schedules/scheduler.ts
+++ b/packages/agents/src/schedules/scheduler.ts
@@ -12,6 +12,7 @@ import {
   type LifecycleRouteAddress,
   type LifecycleRouteContext
 } from "../lifecycle/capability";
+import type { MemoryLimitContext } from "../lifecycle/capability-runner";
 import type {
   LifecycleJob,
   LifecycleJobContext,
@@ -57,6 +58,11 @@ const schedulerCallbackResolvers = new WeakMap<
   (name: string) => ResolvedSchedulerCallback | undefined
 >();
 
+const schedulerRoutedMemoryLimitHandlers = new WeakMap<
+  object,
+  (context: MemoryLimitContext) => void | Promise<void>
+>();
+
 /**
  * @internal Supply a composition-root fallback for callback names outside the
  * registered map. Agent uses this to keep its historical name-based
@@ -69,6 +75,20 @@ export function setSchedulerCallbackResolver(
   resolver: (name: string) => ResolvedSchedulerCallback | undefined
 ): void {
   schedulerCallbackResolvers.set(scheduler, resolver);
+}
+
+/**
+ * @internal Temporary compatibility bridge for chat-recovery schedules owned
+ * by a routed dynamic agent. The root owns the physical alarm and queue row;
+ * this handler lets Scheduler deliver a sealed memory-limit strike to the
+ * routed host that owns the incident. Delete with the recovery-on-Tasks
+ * migration, when the owning Tasks capability terminalizes its own run.
+ */
+export function setSchedulerRoutedMemoryLimitHandler(
+  scheduler: Scheduler<never>,
+  handler: (context: MemoryLimitContext) => void | Promise<void>
+): void {
+  schedulerRoutedMemoryLimitHandlers.set(scheduler, handler);
 }
 
 const SCHEDULE_SCHEMA_VERSION_KEY = "cf_agents:schedules_schema_version";
@@ -136,6 +156,11 @@ type SchedulerRouteMessage =
       readonly fn: string;
       readonly job: SchedulerJobPayload;
       readonly retry?: RetryOptions;
+    }
+  | {
+      /** @internal Removed with routed chat recovery's Tasks migration. */
+      readonly type: "memoryLimit";
+      readonly context: MemoryLimitContext;
     };
 
 type InsertResult<T> = {
@@ -369,6 +394,57 @@ export class Scheduler<
     return this.#recurrenceOutcome(timing);
   }
 
+  /**
+   * Deliver a sealed strike to each routed owner whose recovery row was
+   * purged. The queue already broke the loop; this only lets those dynamic
+   * agents persist their terminal chat state. Tasks will move that policy into
+   * the owning capability and delete this bridge.
+   */
+  async onMemoryLimit(context: MemoryLimitContext): Promise<void> {
+    if (!context.sealed) return;
+
+    const candidates = [
+      ...(context.purgedRecoveryLoopJobs ?? []),
+      ...(context.executing ? [context.executing] : [])
+    ];
+    const targets = new Map<string, LifecycleRouteAddress>();
+    for (const job of candidates) {
+      if (
+        job.capability !== this.capabilityId ||
+        !job.recoveryLoop ||
+        !isSchedulerJobPayload(job.payload) ||
+        !job.payload.owner_path
+      ) {
+        continue;
+      }
+      const target = {
+        key: job.payload.owner_path_key ?? job.payload.owner_path,
+        data: job.payload.owner_path
+      };
+      targets.set(target.key, target);
+    }
+
+    const routedContext: MemoryLimitContext = {
+      sealed: true,
+      executing: context.executing
+    };
+    for (const target of targets.values()) {
+      try {
+        await this.lifecycle.routes.to(target, {
+          type: "memoryLimit",
+          context: routedContext
+        } satisfies SchedulerRouteMessage);
+      } catch (error) {
+        // One deleted or broken dynamic agent must not prevent the remaining
+        // owners from terminalizing after their queue rows were purged.
+        console.error(
+          `Failed to route sealed recovery policy to ${target.key}`,
+          error
+        );
+      }
+    }
+  }
+
   /** Observe one schedule's terminal application failure. */
   async onJobError(
     context: LifecycleJobContext,
@@ -444,6 +520,12 @@ export class Scheduler<
           message.retry
         );
         return true;
+      case "memoryLimit": {
+        const handler = schedulerRoutedMemoryLimitHandlers.get(this);
+        if (!handler) return false;
+        await this.lifecycle.runInHostContext(() => handler(message.context));
+        return true;
+      }
       default:
         throw new Error("Unknown routed Scheduler message");
     }

--- a/packages/agents/src/schedules/types.ts
+++ b/packages/agents/src/schedules/types.ts
@@ -97,13 +97,20 @@ export type ScheduleOptions = {
    * one-shot schedules.
    */
   idempotent?: boolean;
-  /**
-   * Mark this schedule as driving a recovery loop that can deterministically
-   * exhaust memory. The alarm memory-limit circuit breaker (#1825) backs
-   * flagged schedules off on a strike and purges them when it seals at the
-   * strike budget, without disturbing unrelated schedules.
-   */
-  recoveryLoop?: boolean;
+};
+
+/**
+ * @internal Chat-recovery scaffolding, deliberately NOT part of
+ * {@link ScheduleOptions}: schedules only shape future work — a row that
+ * drives an OOM-prone loop belongs in the Tasks capability, whose runs
+ * carry their own memory-limit policy. Until chat recovery migrates onto
+ * Tasks, its schedules ride the alarm memory-limit breaker (#1825) through
+ * this option; the Scheduler passes it through to the Lifecycle job row
+ * untouched (`LifecycleJobPushOptions.recoveryLoop`). Removed with that
+ * migration — do not use it for new work.
+ */
+export type RecoveryLoopScheduleOptions = ScheduleOptions & {
+  recoveryLoop: true;
 };
 
 /** Filters accepted by `getSchedules()` and `listSchedules()`. */

--- a/packages/agents/src/schedules/types.ts
+++ b/packages/agents/src/schedules/types.ts
@@ -97,6 +97,13 @@ export type ScheduleOptions = {
    * one-shot schedules.
    */
   idempotent?: boolean;
+  /**
+   * Mark this schedule as driving a recovery loop that can deterministically
+   * exhaust memory. The alarm memory-limit circuit breaker (#1825) backs
+   * flagged schedules off on a strike and purges them when it seals at the
+   * strike budget, without disturbing unrelated schedules.
+   */
+  recoveryLoop?: boolean;
 };
 
 /** Filters accepted by `getSchedules()` and `listSchedules()`. */

--- a/packages/agents/src/tests/agents/schedule.ts
+++ b/packages/agents/src/tests/agents/schedule.ts
@@ -4,6 +4,7 @@ import {
   getCurrentAgent,
   type Schedule
 } from "../../index.ts";
+import type { RecoveryLoopScheduleOptions } from "../../schedules/types";
 import { captureConsoleWarnings } from "../capabilities/console-capture";
 
 /**
@@ -293,13 +294,15 @@ export class TestScheduleAgent extends Agent {
   // alarm memory-limit breaker backs it off on a strike and purges it at seal.
   @callable()
   async createRecoveryLoopSchedule(delaySeconds: number): Promise<string> {
+    const options: RecoveryLoopScheduleOptions = {
+      idempotent: false,
+      recoveryLoop: true
+    };
     const schedule = await this.schedule(
       delaySeconds,
       "testCallback",
       undefined,
-      {
-        recoveryLoop: true
-      }
+      options
     );
     return schedule.id;
   }

--- a/packages/agents/src/tests/agents/schedule.ts
+++ b/packages/agents/src/tests/agents/schedule.ts
@@ -206,6 +206,20 @@ export class TestOnStartScheduleExplicitFalseAgent extends Agent {
 
 export class TestScheduleAgent extends Agent {
   /**
+   * Legacy chat-package sealing hook retained by already-published hosts.
+   * Agents 0.23 must invoke it when the host has no new onAlarmMemoryLimit.
+   */
+  protected async _cf_sealMemoryLimitedRecovery(): Promise<void> {
+    const count =
+      (await this.ctx.storage.get<number>("legacyMemoryLimitSeals")) ?? 0;
+    await this.ctx.storage.put("legacyMemoryLimitSeals", count + 1);
+  }
+
+  async getLegacyMemoryLimitSealsForTest(): Promise<number> {
+    return (await this.ctx.storage.get<number>("legacyMemoryLimitSeals")) ?? 0;
+  }
+
+  /**
    * Simulate a memory-limit reset thrown during startup hydration (#1825):
    * while the durable countdown is set, every cold start throws the
    * platform's memory-limit error before any job can run.

--- a/packages/agents/src/tests/agents/schedule.ts
+++ b/packages/agents/src/tests/agents/schedule.ts
@@ -289,6 +289,21 @@ export class TestScheduleAgent extends Agent {
     return schedule.id;
   }
 
+  // A schedule flagged as part of an OOM-prone recovery loop (#1825): the
+  // alarm memory-limit breaker backs it off on a strike and purges it at seal.
+  @callable()
+  async createRecoveryLoopSchedule(delaySeconds: number): Promise<string> {
+    const schedule = await this.schedule(
+      delaySeconds,
+      "testCallback",
+      undefined,
+      {
+        recoveryLoop: true
+      }
+    );
+    return schedule.id;
+  }
+
   @callable()
   async createIntervalSchedule(intervalSeconds: number): Promise<string> {
     const schedule = await this.scheduleEvery(

--- a/packages/agents/src/tests/capabilities/tasks.ts
+++ b/packages/agents/src/tests/capabilities/tasks.ts
@@ -309,6 +309,7 @@ export function seedTaskRun(
       singleflight INTEGER NOT NULL DEFAULT 0,
       hung_timeout_seconds INTEGER,
       exclusive INTEGER NOT NULL DEFAULT 0,
+      recovery_loop INTEGER NOT NULL DEFAULT 0,
       running INTEGER NOT NULL DEFAULT 0,
       execution_started_at INTEGER,
       created_at INTEGER NOT NULL DEFAULT (unixepoch())

--- a/packages/agents/src/tests/schedule.test.ts
+++ b/packages/agents/src/tests/schedule.test.ts
@@ -6,6 +6,7 @@ import {
 } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
 import { getAgentByName } from "..";
+import type { RecoveryLoopScheduleOptions } from "../schedules/types";
 import type { TestScheduleAgent } from "./agents/schedule";
 
 describe("schedule operations", () => {
@@ -1161,9 +1162,10 @@ describe("schedule operations", () => {
       const oom =
         "Durable Object's isolate exceeded its memory limit and was reset.";
       const stub = await getAgentByName(env.TestScheduleAgent, name);
-      // A flagged sibling row that would fire before the backoff wake, and an
+      // A flagged sibling row due before the ~30s backoff wake (but far
+      // enough out that it cannot fire on its own mid-test), and an
       // unflagged control the breaker must never touch.
-      const flaggedId = await stub.createRecoveryLoopSchedule(1);
+      const flaggedId = await stub.createRecoveryLoopSchedule(20);
       const controlId = await stub.createSchedule(3600);
 
       // Strike 1: the flagged row travels with the strike — backed off past
@@ -1292,10 +1294,10 @@ describe("schedule operations", () => {
           `INSERT INTO cf_agents_schedules
              (id, callback, payload, type, time, delayInSeconds)
            VALUES
-             ('legacy-rec-near', '_chatRecoveryContinue', '{"incidentId":"i1"}', 'delayed', ?, 2),
+             ('legacy-rec-near', '_chatRecoveryContinue', '{"incidentId":"i1"}', 'delayed', ?, 20),
              ('legacy-rec-far', '_chatRecoveryRetry', '{"incidentId":"i2"}', 'delayed', ?, 3600),
              ('legacy-plain', 'testCallback', '"x"', 'delayed', ?, 3600)`,
-          nowSec + 2,
+          nowSec + 20,
           nowSec + 3600,
           nowSec + 3600
         );
@@ -1372,10 +1374,16 @@ describe("schedule operations", () => {
         const first = await instance.schedule(60, "testCallback", "seed", {
           idempotent: true
         });
-        const second = await instance.schedule(60, "testCallback", "seed", {
+        const flagged: RecoveryLoopScheduleOptions = {
           idempotent: true,
           recoveryLoop: true
-        });
+        };
+        const second = await instance.schedule(
+          60,
+          "testCallback",
+          "seed",
+          flagged
+        );
         expect(second.id).toBe(first.id);
         const rows = instance.sql<{ recovery_loop: number }>`
           SELECT recovery_loop FROM cf_agents_jobs WHERE id = ${first.id}

--- a/packages/agents/src/tests/schedule.test.ts
+++ b/packages/agents/src/tests/schedule.test.ts
@@ -1156,6 +1156,45 @@ describe("schedule operations", () => {
       expect(await fresh.getAlarmStrikesForTest()).toBe(0);
     });
 
+    it("backs off pending recovery-loop schedules with the strike and purges them at seal", async () => {
+      const name = "oom-breaker-recovery-loop-pack";
+      const oom =
+        "Durable Object's isolate exceeded its memory limit and was reset.";
+      const stub = await getAgentByName(env.TestScheduleAgent, name);
+      // A flagged sibling row that would fire before the backoff wake, and an
+      // unflagged control the breaker must never touch.
+      const flaggedId = await stub.createRecoveryLoopSchedule(1);
+      const controlId = await stub.createSchedule(3600);
+
+      // Strike 1: the flagged row travels with the strike — backed off past
+      // the ~30s backoff wake instead of re-triggering the doomed loop.
+      expect(await driveOomStrike(name, oom)).toEqual({
+        threw: false,
+        remaining: 1
+      });
+      let fresh = await getAgentByName(env.TestScheduleAgent, name);
+      const backedOff = await fresh.getStoredScheduleById(flaggedId);
+      expect(backedOff).toBeDefined();
+      expect((backedOff?.time ?? 0) * 1000).toBeGreaterThan(
+        Date.now() + 20_000
+      );
+
+      // Strikes 2 and 3: sealing purges every flagged row…
+      expect(await driveOomStrike(name, oom)).toEqual({
+        threw: false,
+        remaining: 1
+      });
+      expect(await driveOomStrike(name, oom)).toEqual({
+        threw: false,
+        remaining: 0
+      });
+      fresh = await getAgentByName(env.TestScheduleAgent, name);
+      expect(await fresh.getStoredScheduleById(flaggedId)).toBeUndefined();
+      // …while unrelated schedules survive untouched.
+      expect(await fresh.getStoredScheduleById(controlId)).toBeDefined();
+      await fresh.cancelScheduleById(controlId);
+    });
+
     it("a memory-limit reset during startup hydration is broken by the breaker", async () => {
       // The exact #1825 boot-hydration case: the reset is thrown before any
       // job runs. Initialization runs inside the breaker, so the alarm must

--- a/packages/agents/src/tests/schedule.test.ts
+++ b/packages/agents/src/tests/schedule.test.ts
@@ -1157,6 +1157,24 @@ describe("schedule operations", () => {
       expect(await fresh.getAlarmStrikesForTest()).toBe(0);
     });
 
+    it("seals recovery through the legacy chat-host hook when no new host hook exists", async () => {
+      const name = `oom-breaker-legacy-host-${crypto.randomUUID()}`;
+      const stub = await getAgentByName(env.TestScheduleAgent, name);
+      await runInDurableObject(stub, async (_instance, state) => {
+        await state.storage.put("cf_agents:oom_alarm_strikes", 2);
+      });
+
+      expect(
+        await driveOomStrike(
+          name,
+          "Durable Object's isolate exceeded its memory limit and was reset."
+        )
+      ).toEqual({ threw: false, remaining: 0 });
+
+      const fresh = await getAgentByName(env.TestScheduleAgent, name);
+      expect(await fresh.getLegacyMemoryLimitSealsForTest()).toBe(1);
+    });
+
     it("backs off pending recovery-loop schedules with the strike and purges them at seal", async () => {
       const name = "oom-breaker-recovery-loop-pack";
       const oom =

--- a/packages/agents/src/tests/schedule.test.ts
+++ b/packages/agents/src/tests/schedule.test.ts
@@ -1257,6 +1257,135 @@ describe("schedule operations", () => {
     });
   });
 
+  describe("legacy schedule migration keeps breaker membership (#1825)", () => {
+    // Same shape as the breaker suite's helper: drive one OOM strike and let
+    // the deferred isolate reset land before the next stub call.
+    async function driveOomStrike(name: string, message: string) {
+      const stub = await getAgentByName(env.TestScheduleAgent, name);
+      const result = await stub.runOneShotThrowingForTest(message);
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      return result;
+    }
+
+    // Rows migrated from the legacy cf_agents_schedules table predate the
+    // job queue's recovery_loop flag. Chat-recovery rows must come out of the
+    // migration flagged — an unflagged survivor would escape the alarm
+    // memory-limit breaker and could re-trigger the doomed loop it drives.
+    it("flags migrated chat-recovery rows and drives them through backoff and seal", async () => {
+      const name = "legacy-migration-recovery-loop";
+      const oom =
+        "Durable Object's isolate exceeded its memory limit and was reset.";
+      const stub = await getAgentByName(env.TestScheduleAgent, name);
+      await runInDurableObject(stub, async (_instance, ctx) => {
+        ctx.storage.sql.exec(`
+          CREATE TABLE cf_agents_schedules (
+            id TEXT PRIMARY KEY,
+            callback TEXT,
+            payload TEXT,
+            type TEXT,
+            time INTEGER,
+            delayInSeconds INTEGER
+          )
+        `);
+        const nowSec = Math.floor(Date.now() / 1000);
+        ctx.storage.sql.exec(
+          `INSERT INTO cf_agents_schedules
+             (id, callback, payload, type, time, delayInSeconds)
+           VALUES
+             ('legacy-rec-near', '_chatRecoveryContinue', '{"incidentId":"i1"}', 'delayed', ?, 2),
+             ('legacy-rec-far', '_chatRecoveryRetry', '{"incidentId":"i2"}', 'delayed', ?, 3600),
+             ('legacy-plain', 'testCallback', '"x"', 'delayed', ?, 3600)`,
+          nowSec + 2,
+          nowSec + 3600,
+          nowSec + 3600
+        );
+        await ctx.storage.delete("cf_agents:schedules_schema_version");
+      });
+      await evictDurableObject(stub);
+
+      // Any RPC restarts the object; startup runs the migration.
+      const fresh = await getAgentByName(env.TestScheduleAgent, name);
+      const flags = await runInDurableObject(
+        fresh,
+        async (instance: TestScheduleAgent) =>
+          instance.sql<{ id: string; recovery_loop: number }>`
+            SELECT id, recovery_loop FROM cf_agents_jobs
+            WHERE id IN ('legacy-rec-near', 'legacy-rec-far', 'legacy-plain')
+            ORDER BY id
+          `
+      );
+      expect(flags).toEqual([
+        { id: "legacy-plain", recovery_loop: 0 },
+        { id: "legacy-rec-far", recovery_loop: 1 },
+        { id: "legacy-rec-near", recovery_loop: 1 }
+      ]);
+
+      // Strike 1 (unsealed): the near migrated row is backed off past the
+      // strike's ~30s backoff wake instead of re-triggering the loop.
+      expect(await driveOomStrike(name, oom)).toEqual({
+        threw: false,
+        remaining: 1
+      });
+      let survivor = await getAgentByName(env.TestScheduleAgent, name);
+      const near = await runInDurableObject(
+        survivor,
+        async (instance: TestScheduleAgent) =>
+          instance.sql<{ time: number }>`
+            SELECT time FROM cf_agents_jobs WHERE id = 'legacy-rec-near'
+          `
+      );
+      expect(near[0].time).toBeGreaterThan(Date.now() + 20_000);
+
+      // Strikes 2 and 3: sealing purges both migrated recovery rows while
+      // the unrelated migrated schedule survives.
+      expect(await driveOomStrike(name, oom)).toEqual({
+        threw: false,
+        remaining: 1
+      });
+      expect(await driveOomStrike(name, oom)).toEqual({
+        threw: false,
+        remaining: 0
+      });
+      survivor = await getAgentByName(env.TestScheduleAgent, name);
+      const after = await runInDurableObject(
+        survivor,
+        async (instance: TestScheduleAgent) =>
+          instance.sql<{ id: string }>`
+            SELECT id FROM cf_agents_jobs
+            WHERE id IN ('legacy-rec-near', 'legacy-rec-far', 'legacy-plain')
+          `
+      );
+      expect(after.map((row) => row.id)).toEqual(["legacy-plain"]);
+    });
+
+    it("an idempotent recovery re-schedule restores membership on an unflagged row", async () => {
+      // The deploy-storm dedup path: an initial recovery schedule dedupes
+      // onto an existing matching row. When that row lost its flag (legacy
+      // migration ran before this fix, or any historical write), the dedup
+      // hit must restore breaker membership rather than return it unflagged
+      // forever.
+      const stub = await getAgentByName(
+        env.TestScheduleAgent,
+        "dedup-restores-recovery-flag"
+      );
+      await runInDurableObject(stub, async (instance: TestScheduleAgent) => {
+        const first = await instance.schedule(60, "testCallback", "seed", {
+          idempotent: true
+        });
+        const second = await instance.schedule(60, "testCallback", "seed", {
+          idempotent: true,
+          recoveryLoop: true
+        });
+        expect(second.id).toBe(first.id);
+        const rows = instance.sql<{ recovery_loop: number }>`
+          SELECT recovery_loop FROM cf_agents_jobs WHERE id = ${first.id}
+        `;
+        expect(rows[0].recovery_loop).toBe(1);
+        await instance.cancelSchedule(first.id);
+      });
+    });
+  });
+
   describe("one-shot defer on retry exhaustion of a platform transient (#1730)", () => {
     // A deploy-reset window outlasts the in-process retry schedule by design
     // (all attempts land inside the same few-seconds storage-unavailable

--- a/packages/agents/src/tests/schema-and-state-optimization.test.ts
+++ b/packages/agents/src/tests/schema-and-state-optimization.test.ts
@@ -57,6 +57,7 @@ const EXPECTED_SCHEMA_DDL = [
         singleflight INTEGER NOT NULL DEFAULT 0,
         hung_timeout_seconds INTEGER,
         exclusive INTEGER NOT NULL DEFAULT 0,
+        recovery_loop INTEGER NOT NULL DEFAULT 0,
         running INTEGER NOT NULL DEFAULT 0,
         execution_started_at INTEGER,
         created_at INTEGER NOT NULL DEFAULT (unixepoch())

--- a/packages/ai-chat/package.json
+++ b/packages/ai-chat/package.json
@@ -24,13 +24,14 @@
   "devDependencies": {
     "@playwright/test": "^1.61.1",
     "@types/react": "^19.2.17",
+    "agents": "workspace:*",
     "ai": "^7.0.0",
     "react": "^19.2.7",
     "zod": "^4.5.4"
   },
   "peerDependencies": {
     "@ai-sdk/react": "^3.0.0 || ^4.0.0",
-    "agents": ">=0.17.1 <1.0.0",
+    "agents": ">=0.23.0 <1.0.0",
     "ai": "^6.0.0 || ^7.0.0",
     "react": "^19.0.0"
   },

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -4938,7 +4938,8 @@ export class AIChatAgent<
         void this.schedule(
           CHAT_RECOVERY_STABLE_RETRY_DELAY_SECONDS,
           "_chatRecoveryContinue",
-          data
+          data,
+          { recoveryLoop: true }
         ).catch(() => {});
         return;
       }
@@ -5237,21 +5238,26 @@ export class AIChatAgent<
    *    unlikely.
    */
   /**
-   * Recovery continuation callbacks the alarm-boundary OOM circuit breaker may
-   * back off / purge (#1825). See `Agent._cf_handleAlarmMemoryLimitReset`.
+   * Host memory-limit policy hook (#1825), dispatched structurally by
+   * Lifecycle's circuit breaker — protected because it is framework
+   * machinery, not part of the public chat API. The breaker has already
+   * backed off / purged the `recoveryLoop`-flagged schedule rows (see
+   * `chatRecoverySchedulePolicy`); at the strike budget this seals
+   * in-flight recovery via {@link _cf_sealMemoryLimitedRecovery}.
    */
-  protected override _cf_recoveryAlarmCallbacks(): string[] {
-    return ["_chatRecoveryContinue", "_chatRecoveryRetry"];
+  protected async onAlarmMemoryLimit(context: { readonly sealed: boolean }) {
+    if (!context.sealed) return;
+    await this._cf_sealMemoryLimitedRecovery();
   }
 
   /**
-   * Seal any still-live recovery incident as an out-of-memory exhaustion when
-   * the alarm circuit breaker trips at its strike budget (#1825). Runs at the
-   * outermost alarm frame (post-unwind), so the terminal banner / `onExhausted`
-   * and the sealed-incident write can land where mid-turn writes OOMed. Reuses
-   * the shared give-up spine via the recovery engine.
+   * Seal any still-live recovery incident as an out-of-memory exhaustion
+   * when the alarm circuit breaker trips at its strike budget (#1825). Runs
+   * at the outermost alarm frame (post-unwind), so the terminal banner /
+   * `onExhausted` and the sealed-incident write can land where mid-turn
+   * writes OOMed. Reuses the shared give-up spine via the recovery engine.
    */
-  protected override async _cf_sealMemoryLimitedRecovery(): Promise<void> {
+  private async _cf_sealMemoryLimitedRecovery(): Promise<void> {
     const active = await listActiveChatRecoveryIncidents(this.ctx.storage);
     for (const { incident } of active) {
       const callback: ChatRecoveryScheduleCallback =
@@ -5388,7 +5394,8 @@ export class AIChatAgent<
         void this.schedule(
           CHAT_RECOVERY_STABLE_RETRY_DELAY_SECONDS,
           "_chatRecoveryRetry",
-          data
+          data,
+          { recoveryLoop: true }
         ).catch(() => {});
         return;
       }

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -85,6 +85,7 @@ import {
 } from "agents/chat";
 import {
   resolveChatRecoveryConfig,
+  chatRecoveryRedeferPolicy,
   chatRecoverySchedulePolicy,
   ChatRecoveryEngine,
   runChatRecoveryExhaustion,
@@ -4939,7 +4940,7 @@ export class AIChatAgent<
           CHAT_RECOVERY_STABLE_RETRY_DELAY_SECONDS,
           "_chatRecoveryContinue",
           data,
-          { recoveryLoop: true }
+          chatRecoveryRedeferPolicy()
         ).catch(() => {});
         return;
       }
@@ -5395,7 +5396,7 @@ export class AIChatAgent<
           CHAT_RECOVERY_STABLE_RETRY_DELAY_SECONDS,
           "_chatRecoveryRetry",
           data,
-          { recoveryLoop: true }
+          chatRecoveryRedeferPolicy()
         ).catch(() => {});
         return;
       }

--- a/packages/ai-chat/src/tests/agent-tools.test.ts
+++ b/packages/ai-chat/src/tests/agent-tools.test.ts
@@ -241,6 +241,15 @@ type ParentStub = DurableObjectStub & {
     abortedAfter: boolean;
     childStatus: string | null;
   }>;
+  driveFacetRecoveryOomSealForTest(
+    executing: { childName: string; incidentId: string },
+    pending: { childName: string; incidentId: string }
+  ): Promise<string[]>;
+  facetRecoveryIncidentStatusForTest(
+    childName: string,
+    incidentId: string
+  ): Promise<string | null>;
+  rootHasScheduleForTest(scheduleId: string): Promise<boolean>;
 };
 
 function getParent(name = crypto.randomUUID()) {
@@ -251,6 +260,41 @@ function getParent(name = crypto.randomUUID()) {
 }
 
 describe("AIChatAgent as an agent-tool child", () => {
+  it("seals affected facet recovery incidents when the plain root alarm breaker seals", async () => {
+    const parentName = crypto.randomUUID();
+    const parent = await getParent(parentName);
+    const executing = {
+      childName: crypto.randomUUID(),
+      incidentId: `facet-oom-${crypto.randomUUID()}`
+    };
+    const pending = {
+      childName: crypto.randomUUID(),
+      incidentId: `facet-pending-${crypto.randomUUID()}`
+    };
+
+    const scheduleIds = await parent.driveFacetRecoveryOomSealForTest(
+      executing,
+      pending
+    );
+    // The breaker resets the alarm-owning root after its writes settle. Read
+    // through a fresh stub so the assertion does not race the condemned RPC
+    // session.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    const freshParent = await getParent(parentName);
+
+    for (const scheduleId of scheduleIds) {
+      expect(await freshParent.rootHasScheduleForTest(scheduleId)).toBe(false);
+    }
+    for (const recovery of [executing, pending]) {
+      expect(
+        await freshParent.facetRecoveryIncidentStatusForTest(
+          recovery.childName,
+          recovery.incidentId
+        )
+      ).toBe("exhausted");
+    }
+  });
+
   it("runs an AIChatAgent child and returns summary, output, events, and chunks", async () => {
     const parent = await getParent();
     const runId = crypto.randomUUID();

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -26,7 +26,7 @@ import type {
   ChatRecoveryExhaustedContext,
   ChatRecoveryOptions
 } from "../";
-import { ResumableStream } from "agents/chat";
+import { ResumableStream, chatRecoverySchedulePolicy } from "agents/chat";
 
 // Type helper for tool call parts - extracts from ChatMessage parts
 type TestToolCallPart = Extract<
@@ -3235,6 +3235,55 @@ type AgentToolInput = {
 };
 
 export class AIChatAgentToolChild extends AIChatAgent<Env> {
+  /**
+   * Test-only routed recovery callback that deterministically reaches the
+   * root alarm's memory-limit breaker.
+   */
+  async facetRecoveryOomForTest(): Promise<void> {
+    throw new Error(
+      "Durable Object's isolate exceeded its memory limit and was reset."
+    );
+  }
+
+  /** Seed one active incident and its root-owned routed recovery schedule. */
+  async seedFacetRecoveryOomForTest(incidentId: string): Promise<string> {
+    const now = Date.now();
+    await this.ctx.storage.put(
+      `cf:chat-recovery:incident:${encodeURIComponent(incidentId)}`,
+      {
+        incidentId,
+        requestId: incidentId,
+        recoveryRootRequestId: incidentId,
+        recoveryKind: "continue",
+        attempt: 1,
+        maxAttempts: 10,
+        status: "scheduled",
+        firstSeenAt: now,
+        lastAttemptAt: now
+      }
+    );
+    const schedule = await this.schedule(
+      60,
+      "facetRecoveryOomForTest",
+      { incidentId },
+      {
+        ...chatRecoverySchedulePolicy("initial"),
+        retry: { maxAttempts: 1 }
+      }
+    );
+    return schedule.id;
+  }
+
+  /** Read the persisted status of a test recovery incident. */
+  async facetRecoveryIncidentStatusForTest(
+    incidentId: string
+  ): Promise<string | null> {
+    const incident = await this.ctx.storage.get<{ status: string }>(
+      `cf:chat-recovery:incident:${encodeURIComponent(incidentId)}`
+    );
+    return incident?.status ?? null;
+  }
+
   override formatAgentToolInput(
     input: AgentToolInput,
     request: { runId: string }
@@ -3821,6 +3870,55 @@ export class AIChatAgentToolParent extends Agent<Env> {
   private finishes: AgentToolFinishForTest[] = [];
   private finishRunIdsToThrow = new Set<string>();
   private lifecycleOrder: string[] = [];
+
+  /**
+   * Drive the root alarm straight to sealing for one routed child recovery
+   * row. The root is deliberately a plain Agent: only the child owns the
+   * active chat-recovery incident and terminal policy.
+   */
+  async driveFacetRecoveryOomSealForTest(
+    executing: { childName: string; incidentId: string },
+    pending: { childName: string; incidentId: string }
+  ): Promise<string[]> {
+    const pendingChild = await this.subAgent(
+      AIChatAgentToolChild,
+      pending.childName
+    );
+    const pendingScheduleId = await pendingChild.seedFacetRecoveryOomForTest(
+      pending.incidentId
+    );
+    const executingChild = await this.subAgent(
+      AIChatAgentToolChild,
+      executing.childName
+    );
+    const executingScheduleId =
+      await executingChild.seedFacetRecoveryOomForTest(executing.incidentId);
+    this.sql`
+      UPDATE cf_agents_jobs
+      SET time = ${Date.now() - 1_000}
+      WHERE id = ${executingScheduleId}
+    `;
+    await this.ctx.storage.put("cf_agents:oom_alarm_strikes", 2);
+    await this.alarm();
+    return [executingScheduleId, pendingScheduleId];
+  }
+
+  /** Read a child facet's durable recovery incident after root sealing. */
+  async facetRecoveryIncidentStatusForTest(
+    childName: string,
+    incidentId: string
+  ): Promise<string | null> {
+    const child = await this.subAgent(AIChatAgentToolChild, childName);
+    return child.facetRecoveryIncidentStatusForTest(incidentId);
+  }
+
+  /** Whether a root-owned schedule row still exists. */
+  rootHasScheduleForTest(scheduleId: string): boolean {
+    const rows = this.sql<{ count: number }>`
+      SELECT COUNT(*) AS count FROM cf_agents_jobs WHERE id = ${scheduleId}
+    `;
+    return (rows[0]?.count ?? 0) > 0;
+  }
 
   override broadcast(
     msg: string | ArrayBuffer | ArrayBufferView,

--- a/packages/think/package.json
+++ b/packages/think/package.json
@@ -48,7 +48,7 @@
   "peerDependencies": {
     "@ai-sdk/react": "^3.0.0 || ^4.0.0",
     "@chat-adapter/telegram": "^4.29.0",
-    "agents": ">=0.20.2 <1.0.0",
+    "agents": ">=0.23.0 <1.0.0",
     "ai": "^6.0.0 || ^7.0.0",
     "react": "^19.0.0",
     "zod": "^4.0.0"

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -213,6 +213,7 @@ import {
   MAX_BOUND_PARAMS,
   buildInClauseStrings,
   resolveChatRecoveryConfig,
+  chatRecoveryRedeferPolicy,
   chatRecoverySchedulePolicy,
   ChatRecoveryEngine,
   runChatRecoveryExhaustion,
@@ -15075,7 +15076,7 @@ export class Think<
           CHAT_RECOVERY_STABLE_RETRY_DELAY_SECONDS,
           "_chatRecoveryRetry",
           data,
-          { recoveryLoop: true }
+          chatRecoveryRedeferPolicy()
         ).catch(() => {});
         return;
       }
@@ -15357,7 +15358,7 @@ export class Think<
           CHAT_RECOVERY_STABLE_RETRY_DELAY_SECONDS,
           "_chatRecoveryContinue",
           data,
-          { recoveryLoop: true }
+          chatRecoveryRedeferPolicy()
         ).catch(() => {});
         return;
       }

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -14860,21 +14860,27 @@ export class Think<
    *    (the terminal writes themselves are idempotent).
    */
   /**
-   * Recovery continuation callbacks the alarm-boundary OOM circuit breaker may
-   * back off / purge (#1825). See `Agent._cf_handleAlarmMemoryLimitReset`.
+   * Host memory-limit policy hook (#1825), dispatched structurally by
+   * Lifecycle's circuit breaker — protected because it is framework
+   * machinery, not part of the public Think API. The breaker has already
+   * backed off / purged the `recoveryLoop`-flagged schedule rows (see
+   * `chatRecoverySchedulePolicy`); at the strike budget this seals
+   * in-flight recovery via {@link _cf_sealMemoryLimitedRecovery}.
    */
-  protected override _cf_recoveryAlarmCallbacks(): string[] {
-    return ["_chatRecoveryContinue", "_chatRecoveryRetry"];
+  protected async onAlarmMemoryLimit(context: { readonly sealed: boolean }) {
+    if (!context.sealed) return;
+    await this._cf_sealMemoryLimitedRecovery();
   }
 
   /**
-   * Seal any still-live recovery incident as an out-of-memory exhaustion when
-   * the alarm circuit breaker trips at its strike budget (#1825). Runs at the
-   * outermost alarm frame (post-unwind), so the terminal banner / `onExhausted`
-   * and the sealed-incident write can land where the mid-turn give-up's writes
-   * OOMed. Reuses the shared give-up spine via `_exhaustRecoveryGiveUp`.
+   * Seal any still-live recovery incident as an out-of-memory exhaustion
+   * when the alarm circuit breaker trips at its strike budget (#1825). Runs
+   * at the outermost alarm frame (post-unwind), so the terminal banner /
+   * `onExhausted` and the sealed-incident write can land where the mid-turn
+   * give-up's writes OOMed. Reuses the shared give-up spine via
+   * `_exhaustRecoveryGiveUp`.
    */
-  protected override async _cf_sealMemoryLimitedRecovery(): Promise<void> {
+  private async _cf_sealMemoryLimitedRecovery(): Promise<void> {
     const active = await listActiveChatRecoveryIncidents(this.ctx.storage);
     for (const { incident } of active) {
       const callback: ChatRecoveryScheduleCallback =
@@ -15068,7 +15074,8 @@ export class Think<
         void this.schedule(
           CHAT_RECOVERY_STABLE_RETRY_DELAY_SECONDS,
           "_chatRecoveryRetry",
-          data
+          data,
+          { recoveryLoop: true }
         ).catch(() => {});
         return;
       }
@@ -15349,7 +15356,8 @@ export class Think<
         void this.schedule(
           CHAT_RECOVERY_STABLE_RETRY_DELAY_SECONDS,
           "_chatRecoveryContinue",
-          data
+          data,
+          { recoveryLoop: true }
         ).catch(() => {});
         return;
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3070,7 +3070,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4
-        version: 4.3.1(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.3.1(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       tailwindcss:
         specifier: ^4.3.2
         version: 4.3.2
@@ -3534,7 +3534,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4
-        version: 4.3.1(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.3.1(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       tailwindcss:
         specifier: ^4.3.2
         version: 4.3.2
@@ -3550,7 +3550,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4
-        version: 4.3.1(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.3.1(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       tailwindcss:
         specifier: ^4.3.2
         version: 4.3.2
@@ -3575,7 +3575,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4
-        version: 4.3.1(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.3.1(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       tailwindcss:
         specifier: ^4.3.2
         version: 4.3.2
@@ -3603,7 +3603,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4
-        version: 4.3.1(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.3.1(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       tailwindcss:
         specifier: ^4.3.2
         version: 4.3.2
@@ -3631,7 +3631,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4
-        version: 4.3.1(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.3.1(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       tailwindcss:
         specifier: ^4.3.2
         version: 4.3.2
@@ -3659,7 +3659,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4
-        version: 4.3.1(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.3.1(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       tailwindcss:
         specifier: ^4.3.2
         version: 4.3.2
@@ -3708,7 +3708,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       wrangler:
         specifier: ^4.115.0
         version: 4.115.0(@cloudflare/workers-types@5.20260729.1)
@@ -3757,7 +3757,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       wrangler:
         specifier: ^4.115.0
         version: 4.115.0(@cloudflare/workers-types@5.20260729.1)
@@ -3791,7 +3791,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4
-        version: 4.3.1(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.3.1(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       tailwindcss:
         specifier: ^4.3.2
         version: 4.3.2
@@ -3822,7 +3822,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4
-        version: 4.3.1(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.3.1(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       tailwindcss:
         specifier: ^4.3.2
         version: 4.3.2
@@ -3859,7 +3859,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4
-        version: 4.3.1(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.3.1(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@types/pg':
         specifier: ^8.20.0
         version: 8.20.0
@@ -3896,7 +3896,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4
-        version: 4.3.1(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.3.1(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       tailwindcss:
         specifier: ^4.3.2
         version: 4.3.2
@@ -3927,7 +3927,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4
-        version: 4.3.1(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.3.1(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       tailwindcss:
         specifier: ^4.3.2
         version: 4.3.2
@@ -4169,10 +4169,7 @@ importers:
     dependencies:
       '@ai-sdk/react':
         specifier: ^3.0.0 || ^4.0.0
-        version: 4.0.19(react@19.2.7)(zod@4.4.3)
-      agents:
-        specifier: '>=0.17.1 <1.0.0'
-        version: link:../agents
+        version: 4.0.19(react@19.2.7)(zod@4.5.4)
       nanoid:
         specifier: ^5.1.16
         version: 5.1.16
@@ -4183,6 +4180,9 @@ importers:
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
+      agents:
+        specifier: workspace:*
+        version: link:../agents
       ai:
         specifier: ^7.0.0
         version: 7.0.18(zod@4.5.4)
@@ -4213,7 +4213,7 @@ importers:
         version: 1.228.5
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/codemode:
     dependencies:
@@ -4263,7 +4263,7 @@ importers:
         version: 0.19.1(@cloudflare/workers-types@5.20260812.1)(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10)
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/think:
     dependencies:
@@ -5808,21 +5808,9 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-darwin-arm64@0.35.2':
-    resolution: {integrity: sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg==}
-    engines: {node: '>=20.9.0'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@img/sharp-darwin-x64@0.34.5':
     resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [darwin]
-
-  '@img/sharp-darwin-x64@0.35.2':
-    resolution: {integrity: sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw==}
-    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [darwin]
 
@@ -5836,29 +5824,13 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-arm64@1.3.1':
-    resolution: {integrity: sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g==}
-    cpu: [arm64]
-    os: [darwin]
-
   '@img/sharp-libvips-darwin-x64@1.2.4':
     resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-x64@1.3.1':
-    resolution: {integrity: sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ==}
-    cpu: [x64]
-    os: [darwin]
-
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-arm64@1.3.1':
-    resolution: {integrity: sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -5869,20 +5841,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-arm@1.3.1':
-    resolution: {integrity: sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg==}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-ppc64@1.3.1':
-    resolution: {integrity: sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
@@ -5893,20 +5853,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-riscv64@1.3.1':
-    resolution: {integrity: sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-libvips-linux-s390x@1.3.1':
-    resolution: {integrity: sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
@@ -5917,32 +5865,14 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-libvips-linux-x64@1.3.1':
-    resolution: {integrity: sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.3.1':
-    resolution: {integrity: sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-libvips-linuxmusl-x64@1.3.1':
-    resolution: {integrity: sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -5954,23 +5884,9 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-arm64@0.35.2':
-    resolution: {integrity: sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA==}
-    engines: {node: '>=20.9.0'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-arm@0.35.2':
-    resolution: {integrity: sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A==}
-    engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
@@ -5982,23 +5898,9 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-ppc64@0.35.2':
-    resolution: {integrity: sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg==}
-    engines: {node: '>=20.9.0'}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-riscv64@0.35.2':
-    resolution: {integrity: sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA==}
-    engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
@@ -6010,23 +5912,9 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@img/sharp-linux-s390x@0.35.2':
-    resolution: {integrity: sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA==}
-    engines: {node: '>=20.9.0'}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@img/sharp-linux-x64@0.35.2':
-    resolution: {integrity: sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA==}
-    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -6038,23 +5926,9 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@img/sharp-linuxmusl-arm64@0.35.2':
-    resolution: {integrity: sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg==}
-    engines: {node: '>=20.9.0'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@img/sharp-linuxmusl-x64@0.35.2':
-    resolution: {integrity: sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg==}
-    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -6063,10 +5937,6 @@ packages:
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [wasm32]
-
-  '@img/sharp-wasm32@0.35.2':
-    resolution: {integrity: sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw==}
-    engines: {node: '>=20.9.0'}
 
   '@img/sharp-webcontainers-wasm32@0.35.2':
     resolution: {integrity: sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g==}
@@ -6079,33 +5949,15 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@img/sharp-win32-arm64@0.35.2':
-    resolution: {integrity: sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ==}
-    engines: {node: '>=20.9.0'}
-    cpu: [arm64]
-    os: [win32]
-
   '@img/sharp-win32-ia32@0.34.5':
     resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ia32]
     os: [win32]
 
-  '@img/sharp-win32-ia32@0.35.2':
-    resolution: {integrity: sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog==}
-    engines: {node: ^20.9.0}
-    cpu: [ia32]
-    os: [win32]
-
   '@img/sharp-win32-x64@0.34.5':
     resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [win32]
-
-  '@img/sharp-win32-x64@0.35.2':
-    resolution: {integrity: sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ==}
-    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
 
@@ -6870,8 +6722,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@rolldown/binding-android-arm64@1.2.6':
+    resolution: {integrity: sha512-lkWU8ZJaRk9q3CIEY1Tc7vIFALp3Xw5NfGJo2hQg5oIqNgxWi1zI+IiDEK3r70BF5Dzol1tcXsnzsRc8NLhG+Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
   '@rolldown/binding-darwin-arm64@1.1.2':
     resolution: {integrity: sha512-RkPMJnygxsgOYdkfqgpwY0/Fzm8d0VQe6HGU2/B00Xa9eqdLbrII+DOKAodbJAn3ZL1AJxGHkZRPYazgGY6Ljw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-arm64@1.2.6':
+    resolution: {integrity: sha512-dgR56NYnvAszm7Ob1B2/Vn0e8bUQYZH2UjVaMMtMVOCKFSfjhfLmuA/9+O+F+ajUdG6B/bSssrKW6JJYASa8jA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -6882,8 +6746,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@rolldown/binding-darwin-x64@1.2.6':
+    resolution: {integrity: sha512-vpVxFvUCFioJqug7OTvqptkc4yb8UX0AwfDmJpaR/0sWz+BUmqSVAf7c8JkUgnN8YLspb4a/N6NhTyMAmdyQ7Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
   '@rolldown/binding-freebsd-x64@1.1.2':
     resolution: {integrity: sha512-+TpdtTRgHiJFjCVFbw311SuLk3KfytPOQQn+VlAEv+gBxYPtL7E6JS9e/tk+8CwxhIZvemJKo4rTKgfWNsKkkA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-freebsd-x64@1.2.6':
+    resolution: {integrity: sha512-h1wG6Y6K3JlRswxsI64qQJqBAy4vrLuHgRbc8CZMGSWTOFRY6ghMApM1NKzB2I0n5xV1fjkE18SuVl2QpLeNpA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -6894,8 +6770,21 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.6':
+    resolution: {integrity: sha512-tbCiqub0q2MVWJKgF5PoAlNWCtQydiOYSLIkd8sByqK/6MMYLJRcSXSYodqYtd0O+Fw7QaVmKKlS4oL94YRZ0w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@rolldown/binding-linux-arm64-gnu@1.1.2':
     resolution: {integrity: sha512-gBSUVO0eaWgw1JMjK3gB8BMlX2Mk148s2lTiVT3e9vjVxbl7UDfMWWY8CfIaaqiXuM9fVTMxIpUz6CAo/B6Vlw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.6':
+    resolution: {integrity: sha512-oxK9+baEBPhZG5HB4URY+uU04zJWeZlH6Tb9rB5DK4DF9XR1uXNLXt5Q5ZsugTKayNCNLhkcwz/ye74hRI98dg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -6908,8 +6797,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-linux-arm64-musl@1.2.6':
+    resolution: {integrity: sha512-muWCk27FVBEZtv0MsK8gnfSmgczA8KQ0uRVJbTABKhkRfQc38aUrcb7fhi3BNiyseFmgcRsoMfQsSNJ+DbZdSw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-linux-ppc64-gnu@1.1.2':
     resolution: {integrity: sha512-X/7bVLWelEsbyWDUSXt7zVsTniLLPIY2n1rH58qr78l9i7MNbbxBWD8gI2vRfBWf4NUXJCUuQnfZDsp32LqsfQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.6':
+    resolution: {integrity: sha512-eWDoSfU7Co2qj3vgB3Dt4lj1mG6CoWbcJQkRMP3XJplyCMtuaq3LHvPFjS9QIPvMGWVadJC04Xiy0IdcVPtnwQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -6922,8 +6825,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rolldown/binding-linux-s390x-gnu@1.2.6':
+    resolution: {integrity: sha512-2bWNjRSIayvupRKxXUY2tWG9fYdoUlTqWywHRvE8Eq3GvuQ+f2HeIkve697fIt+IQs/PV8yFsdWuhp1aJ1PdnA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@rolldown/binding-linux-x64-gnu@1.1.2':
     resolution: {integrity: sha512-JY4w85pU3iAiJVMh5nuk4/Mh9GjMsupe8MrIN53rwxAZW64GKrWeJBuN6SxQg9QTU5uB1cxyhDzW8jqRn1EABw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.6':
+    resolution: {integrity: sha512-KekI0gS0wLxe1UBSQSjenBVwou/JkcQPDzBPICGZjxUv9k3RteHDPBQaiOicZUFKRIH2wKEimGwVpnJsbPzu7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -6936,8 +6853,21 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-linux-x64-musl@1.2.6':
+    resolution: {integrity: sha512-TvtPnfVr+HtyGiDmPK4VWmlNm7QhNNAcK5Q9A7aOXsI8545yCyaoMaicXrFZ72JzeYjaUVk7yT243zT0jzjFKQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-openharmony-arm64@1.1.2':
     resolution: {integrity: sha512-p/ts6KBLjuk49Bp21XH77poQGt02iNz7ChgHep7tudPOaLinR/De/RHdxF8w8Yj4r/bF/bqXwH6PZrB2sA+Nvw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-openharmony-arm64@1.2.6':
+    resolution: {integrity: sha512-iOo0VEay2XFhaCcH0sps5XIimkSuOnNaZrf6+ZkoSOQBJPKNU48RkmJv0/lSpipexu5P+ouFgafe5IGr/DiQfg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -6953,8 +6883,20 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@rolldown/binding-win32-arm64-msvc@1.2.6':
+    resolution: {integrity: sha512-y5NTmmasMS455JlOCO4ZM9krIchv3Mvm1crL1iUPGOPgEzSkves9n0SdC5Sjz6+qWDFhd8/JpfWMH8NSWNHe+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
   '@rolldown/binding-win32-x64-msvc@1.1.2':
     resolution: {integrity: sha512-85YiLQqjUKgSO/Zjnf9e0XIn5Ymrh1fLDWBeAkZqpuBR/3R8TpfoHXuyblqyQrftSSgWO9qpcHN8mkyKsLraoA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.6':
+    resolution: {integrity: sha512-np8iZSLfXlAD4kWhiyq/u0Yt8oZDtRQ8lGhQaCXo2rl37KNjeU0GjJuwr4P3oeZ++ROfofsKNBqR5LTO8aXyWQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -12157,9 +12099,6 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.4.3:
-    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
-
   zod@4.5.4:
     resolution: {integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==}
 
@@ -12201,13 +12140,6 @@ snapshots:
       '@vercel/oidc': 3.2.0
       zod: 4.5.4
 
-  '@ai-sdk/gateway@4.0.14(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 4.0.2
-      '@ai-sdk/provider-utils': 5.0.6(zod@4.4.3)
-      '@vercel/oidc': 3.2.0
-      zod: 4.4.3
-
   '@ai-sdk/gateway@4.0.14(zod@4.5.4)':
     dependencies:
       '@ai-sdk/provider': 4.0.2
@@ -12220,13 +12152,6 @@ snapshots:
       '@ai-sdk/provider': 4.0.2
       '@ai-sdk/provider-utils': 5.0.6(zod@4.5.4)
       zod: 4.5.4
-
-  '@ai-sdk/mcp@2.0.9(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 4.0.2
-      '@ai-sdk/provider-utils': 5.0.6(zod@4.4.3)
-      pkce-challenge: 5.0.1
-      zod: 4.4.3
 
   '@ai-sdk/mcp@2.0.9(zod@4.5.4)':
     dependencies:
@@ -12262,14 +12187,6 @@ snapshots:
       eventsource-parser: 3.1.0
       zod: 4.5.4
 
-  '@ai-sdk/provider-utils@5.0.6(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 4.0.2
-      '@standard-schema/spec': 1.1.0
-      '@workflow/serde': 4.1.0
-      eventsource-parser: 3.1.0
-      zod: 4.4.3
-
   '@ai-sdk/provider-utils@5.0.6(zod@4.5.4)':
     dependencies:
       '@ai-sdk/provider': 4.0.2
@@ -12293,18 +12210,6 @@ snapshots:
   '@ai-sdk/provider@4.0.2':
     dependencies:
       json-schema: 0.4.0
-
-  '@ai-sdk/react@4.0.19(react@19.2.7)(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/mcp': 2.0.9(zod@4.4.3)
-      '@ai-sdk/provider': 4.0.2
-      '@ai-sdk/provider-utils': 5.0.6(zod@4.4.3)
-      ai: 7.0.18(zod@4.4.3)
-      react: 19.2.7
-      swr: 2.4.1(react@19.2.7)
-      throttleit: 2.1.0
-    transitivePeerDependencies:
-      - zod
 
   '@ai-sdk/react@4.0.19(react@19.2.7)(zod@4.5.4)':
     dependencies:
@@ -13986,84 +13891,42 @@ snapshots:
       '@img/sharp-libvips-darwin-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-darwin-arm64@0.35.2':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.3.1
-    optional: true
-
   '@img/sharp-darwin-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-darwin-x64': 1.2.4
     optional: true
 
-  '@img/sharp-darwin-x64@0.35.2':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.3.1
-    optional: true
-
   '@img/sharp-freebsd-wasm32@0.35.2':
-    dependencies:
-      '@img/sharp-wasm32': 0.35.2
     optional: true
 
   '@img/sharp-libvips-darwin-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.3.1':
-    optional: true
-
   '@img/sharp-libvips-darwin-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-darwin-x64@1.3.1':
     optional: true
 
   '@img/sharp-libvips-linux-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.3.1':
-    optional: true
-
   '@img/sharp-libvips-linux-arm@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm@1.3.1':
     optional: true
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-ppc64@1.3.1':
-    optional: true
-
   '@img/sharp-libvips-linux-riscv64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-riscv64@1.3.1':
     optional: true
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-s390x@1.3.1':
-    optional: true
-
   '@img/sharp-libvips-linux-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-x64@1.3.1':
     optional: true
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.3.1':
-    optional: true
-
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-x64@1.3.1':
     optional: true
 
   '@img/sharp-linux-arm64@0.34.5':
@@ -14071,19 +13934,9 @@ snapshots:
       '@img/sharp-libvips-linux-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-arm64@0.35.2':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.3.1
-    optional: true
-
   '@img/sharp-linux-arm@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-arm': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-arm@0.35.2':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.3.1
     optional: true
 
   '@img/sharp-linux-ppc64@0.34.5':
@@ -14091,19 +13944,9 @@ snapshots:
       '@img/sharp-libvips-linux-ppc64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-ppc64@0.35.2':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.3.1
-    optional: true
-
   '@img/sharp-linux-riscv64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-riscv64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-riscv64@0.35.2':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-riscv64': 1.3.1
     optional: true
 
   '@img/sharp-linux-s390x@0.34.5':
@@ -14111,19 +13954,9 @@ snapshots:
       '@img/sharp-libvips-linux-s390x': 1.2.4
     optional: true
 
-  '@img/sharp-linux-s390x@0.35.2':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.3.1
-    optional: true
-
   '@img/sharp-linux-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-x64@0.35.2':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.3.1
     optional: true
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
@@ -14131,19 +13964,9 @@ snapshots:
       '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-arm64@0.35.2':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.3.1
-    optional: true
-
   '@img/sharp-linuxmusl-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-linuxmusl-x64@0.35.2':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.3.1
     optional: true
 
   '@img/sharp-wasm32@0.34.5':
@@ -14151,32 +13974,16 @@ snapshots:
       '@emnapi/runtime': 1.11.1
     optional: true
 
-  '@img/sharp-wasm32@0.35.2':
-    dependencies:
-      '@emnapi/runtime': 1.11.1
-    optional: true
-
   '@img/sharp-webcontainers-wasm32@0.35.2':
-    dependencies:
-      '@img/sharp-wasm32': 0.35.2
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
     optional: true
 
-  '@img/sharp-win32-arm64@0.35.2':
-    optional: true
-
   '@img/sharp-win32-ia32@0.34.5':
     optional: true
 
-  '@img/sharp-win32-ia32@0.35.2':
-    optional: true
-
   '@img/sharp-win32-x64@0.34.5':
-    optional: true
-
-  '@img/sharp-win32-x64@0.35.2':
     optional: true
 
   '@inquirer/ansi@2.0.7': {}
@@ -14194,6 +14001,14 @@ snapshots:
       '@inquirer/type': 4.1.0(@types/node@26.2.0)
     optionalDependencies:
       '@types/node': 26.2.0
+    optional: true
+
+  '@inquirer/confirm@6.3.0(@types/node@26.4.0)':
+    dependencies:
+      '@inquirer/core': 12.0.1(@types/node@26.4.0)
+      '@inquirer/type': 4.1.0(@types/node@26.4.0)
+    optionalDependencies:
+      '@types/node': 26.4.0
     optional: true
 
   '@inquirer/core@12.0.1(@types/node@26.0.1)':
@@ -14221,6 +14036,19 @@ snapshots:
       '@types/node': 26.2.0
     optional: true
 
+  '@inquirer/core@12.0.1(@types/node@26.4.0)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/figures': 2.0.8
+      '@inquirer/type': 4.1.0(@types/node@26.4.0)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.2
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 26.4.0
+    optional: true
+
   '@inquirer/external-editor@1.0.3(@types/node@26.0.1)':
     dependencies:
       chardet: 2.2.0
@@ -14237,6 +14065,11 @@ snapshots:
   '@inquirer/type@4.1.0(@types/node@26.2.0)':
     optionalDependencies:
       '@types/node': 26.2.0
+    optional: true
+
+  '@inquirer/type@4.1.0(@types/node@26.4.0)':
+    optionalDependencies:
+      '@types/node': 26.4.0
     optional: true
 
   '@isaacs/cliui@9.0.0': {}
@@ -14873,37 +14706,73 @@ snapshots:
   '@rolldown/binding-android-arm64@1.1.2':
     optional: true
 
+  '@rolldown/binding-android-arm64@1.2.6':
+    optional: true
+
   '@rolldown/binding-darwin-arm64@1.1.2':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.2.6':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.1.2':
     optional: true
 
+  '@rolldown/binding-darwin-x64@1.2.6':
+    optional: true
+
   '@rolldown/binding-freebsd-x64@1.1.2':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.1.2':
     optional: true
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.6':
+    optional: true
+
   '@rolldown/binding-linux-arm64-gnu@1.1.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.1.2':
     optional: true
 
+  '@rolldown/binding-linux-arm64-musl@1.2.6':
+    optional: true
+
   '@rolldown/binding-linux-ppc64-gnu@1.1.2':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-s390x-gnu@1.1.2':
     optional: true
 
+  '@rolldown/binding-linux-s390x-gnu@1.2.6':
+    optional: true
+
   '@rolldown/binding-linux-x64-gnu@1.1.2':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.1.2':
     optional: true
 
+  '@rolldown/binding-linux-x64-musl@1.2.6':
+    optional: true
+
   '@rolldown/binding-openharmony-arm64@1.1.2':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.6':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.1.2':
@@ -14916,7 +14785,13 @@ snapshots:
   '@rolldown/binding-win32-arm64-msvc@1.1.2':
     optional: true
 
+  '@rolldown/binding-win32-arm64-msvc@1.2.6':
+    optional: true
+
   '@rolldown/binding-win32-x64-msvc@1.1.2':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.6':
     optional: true
 
   '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
@@ -15354,12 +15229,12 @@ snapshots:
       tailwindcss: 4.3.1
       vite: 8.2.2(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  '@tailwindcss/vite@4.3.1(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@tailwindcss/vite@4.3.1(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.1
       '@tailwindcss/oxide': 4.3.1
       tailwindcss: 4.3.1
-      vite: 8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@tanstack/ai-anthropic@0.15.11(@tanstack/ai@0.38.0(@opentelemetry/api@1.9.1))(zod@4.5.4)':
     dependencies:
@@ -15898,13 +15773,13 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser-playwright@4.1.10(msw@2.14.6(@types/node@26.2.0)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.10)':
+  '@vitest/browser-playwright@4.1.10(msw@2.14.6(@types/node@26.4.0)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
-      '@vitest/browser': 4.1.10(msw@2.14.6(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.10)
-      '@vitest/mocker': 4.1.10(msw@2.14.6(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/browser': 4.1.10(msw@2.14.6(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/mocker': 4.1.10(msw@2.14.6(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       playwright: 1.62.1
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -15947,16 +15822,16 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser@4.1.10(msw@2.14.6(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.10)':
+  '@vitest/browser@4.1.10(msw@2.14.6(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.10)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.10(msw@2.14.6(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.10(msw@2.14.6(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/utils': 4.1.10
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
@@ -15992,14 +15867,14 @@ snapshots:
       msw: 2.14.6(@types/node@26.2.0)(typescript@6.0.3)
       vite: 8.1.0(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  '@vitest/mocker@4.1.10(msw@2.14.6(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.10(msw@2.14.6(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      msw: 2.14.6(@types/node@26.2.0)(typescript@6.0.3)
-      vite: 8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      msw: 2.14.6(@types/node@26.4.0)(typescript@6.0.3)
+      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -16219,13 +16094,6 @@ snapshots:
       '@ai-sdk/provider': 4.0.0
       '@ai-sdk/provider-utils': 5.0.0(zod@4.5.4)
       zod: 4.5.4
-
-  ai@7.0.18(zod@4.4.3):
-    dependencies:
-      '@ai-sdk/gateway': 4.0.14(zod@4.4.3)
-      '@ai-sdk/provider': 4.0.2
-      '@ai-sdk/provider-utils': 5.0.6(zod@4.4.3)
-      zod: 4.4.3
 
   ai@7.0.18(zod@4.5.4):
     dependencies:
@@ -18793,6 +18661,32 @@ snapshots:
       - '@types/node'
     optional: true
 
+  msw@2.14.6(@types/node@26.4.0)(typescript@6.0.3):
+    dependencies:
+      '@inquirer/confirm': 6.3.0(@types/node@26.4.0)
+      '@mswjs/interceptors': 0.41.9
+      '@open-draft/deferred-promise': 3.0.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.14.2
+      headers-polyfill: 5.0.1
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.11.11
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.2
+      type-fest: 5.8.0
+      until-async: 3.0.2
+      yargs: 17.7.3
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - '@types/node'
+    optional: true
+
   muggle-string@0.4.1: {}
 
   mute-stream@3.0.0: {}
@@ -19781,6 +19675,20 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
       '@rolldown/binding-android-arm-eabi': 1.2.6
+      '@rolldown/binding-android-arm64': 1.2.6
+      '@rolldown/binding-darwin-arm64': 1.2.6
+      '@rolldown/binding-darwin-x64': 1.2.6
+      '@rolldown/binding-freebsd-x64': 1.2.6
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.6
+      '@rolldown/binding-linux-arm64-gnu': 1.2.6
+      '@rolldown/binding-linux-arm64-musl': 1.2.6
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.6
+      '@rolldown/binding-linux-s390x-gnu': 1.2.6
+      '@rolldown/binding-linux-x64-gnu': 1.2.6
+      '@rolldown/binding-linux-x64-musl': 1.2.6
+      '@rolldown/binding-openharmony-arm64': 1.2.6
+      '@rolldown/binding-win32-arm64-msvc': 1.2.6
+      '@rolldown/binding-win32-x64-msvc': 1.2.6
 
   rollup@4.62.2:
     dependencies:
@@ -19974,31 +19882,8 @@ snapshots:
       detect-libc: 2.1.2
       semver: 7.8.5
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.35.2
-      '@img/sharp-darwin-x64': 0.35.2
       '@img/sharp-freebsd-wasm32': 0.35.2
-      '@img/sharp-libvips-darwin-arm64': 1.3.1
-      '@img/sharp-libvips-darwin-x64': 1.3.1
-      '@img/sharp-libvips-linux-arm': 1.3.1
-      '@img/sharp-libvips-linux-arm64': 1.3.1
-      '@img/sharp-libvips-linux-ppc64': 1.3.1
-      '@img/sharp-libvips-linux-riscv64': 1.3.1
-      '@img/sharp-libvips-linux-s390x': 1.3.1
-      '@img/sharp-libvips-linux-x64': 1.3.1
-      '@img/sharp-libvips-linuxmusl-arm64': 1.3.1
-      '@img/sharp-libvips-linuxmusl-x64': 1.3.1
-      '@img/sharp-linux-arm': 0.35.2
-      '@img/sharp-linux-arm64': 0.35.2
-      '@img/sharp-linux-ppc64': 0.35.2
-      '@img/sharp-linux-riscv64': 0.35.2
-      '@img/sharp-linux-s390x': 0.35.2
-      '@img/sharp-linux-x64': 0.35.2
-      '@img/sharp-linuxmusl-arm64': 0.35.2
-      '@img/sharp-linuxmusl-x64': 0.35.2
       '@img/sharp-webcontainers-wasm32': 0.35.2
-      '@img/sharp-win32-arm64': 0.35.2
-      '@img/sharp-win32-ia32': 0.35.2
-      '@img/sharp-win32-x64': 0.35.2
 
   shebang-command@2.0.0:
     dependencies:
@@ -20754,7 +20639,7 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0):
+  vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
       picomatch: 4.0.7
@@ -20762,7 +20647,7 @@ snapshots:
       rolldown: 1.2.6
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 26.2.0
+      '@types/node': 26.4.0
       esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 2.7.0
@@ -20782,10 +20667,10 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
-  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(msw@2.14.6(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.10(msw@2.14.6(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -20802,12 +20687,12 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/node': 26.2.0
-      '@vitest/browser-playwright': 4.1.10(msw@2.14.6(@types/node@26.2.0)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser-playwright': 4.1.10(msw@2.14.6(@types/node@26.4.0)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.10)
       jsdom: 29.1.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - msw
@@ -20872,10 +20757,10 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/browser-playwright@4.1.10)(jsdom@29.1.1(@noble/hashes@1.8.0))(msw@2.14.6(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(msw@2.14.6(@types/node@26.2.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.10(msw@2.14.6(@types/node@26.4.0)(typescript@6.0.3))(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -20892,12 +20777,12 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 26.2.0
-      '@vitest/browser-playwright': 4.1.10(msw@2.14.6(@types/node@26.2.0)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@26.2.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.10)
+      '@vitest/browser-playwright': 4.1.10(msw@2.14.6(@types/node@26.4.0)(typescript@6.0.3))(playwright@1.62.1)(vite@8.2.2(@types/node@26.4.0)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vitest@4.1.10)
       jsdom: 29.1.1(@noble/hashes@1.8.0)
     transitivePeerDependencies:
       - msw
@@ -21182,8 +21067,6 @@ snapshots:
       zod: 4.5.4
 
   zod@3.25.76: {}
-
-  zod@4.4.3: {}
 
   zod@4.5.4: {}
 


### PR DESCRIPTION
## What

Makes the alarm memory-limit circuit breaker (#1825) a self-contained Lifecycle concern instead of an Agent-mediated one. `Agent` previously sat between the breaker and the Scheduler, relaying callback-name lists through protected template methods (`_cf_recoveryAlarmCallbacks` / `_cf_sealMemoryLimitedRecovery`) — exactly the host-adapter shape the capability design doctrine forbids. After this change `packages/agents/src/index.ts` contains no OOM-breaker code, and the public schedule vocabulary is untouched: schedules only shape future work.

## How

- **Recovery-loop membership is a property of the job row.** Jobs pushed with `LifecycleJobPushOptions.recoveryLoop` (persisted as a `recovery_loop` column; the queue schema is unshipped, so it is added in place) are backed off by the breaker on a strike and purged when it seals at the strike budget, without touching unrelated rows. A recovery schedule can no longer silently escape the breaker by not being on someone's name list.
- **`ScheduleOptions` is unchanged.** OOM-prone loops belong in the Tasks capability, whose runs will carry their own memory-limit policy; until chat recovery migrates onto Tasks, its schedules reach the flag through an explicitly `@internal` scaffolding type (`RecoveryLoopScheduleOptions`) that documents its own removal. Chat writes it in exactly two helpers (`chatRecoverySchedulePolicy`, `chatRecoveryRedeferPolicy`).
- **Capabilities get an optional `onMemoryLimit` hook** next to `onJob`, dispatched best-effort before the host hook — deliberately not gated on capability startup, since a strike can land while startup itself is the doomed work. This is the hook the Tasks capability will implement for its own runs.
- **The strike budget is real Lifecycle config**: `Lifecycle.install(host, { maxAlarmMemoryLimitStrikes })` replaces the `setLifecycleAlarmMemoryLimitStrikes` WeakMap side channel.
- **Seal-terminalization lives where the incidents live.** `AIChatAgent` and `Think` seal in-flight incidents from their own protected `onAlarmMemoryLimit` hooks (Lifecycle dispatches host hooks structurally, so framework hosts keep internal machinery in `private _cf_`-prefixed methods behind a protected hook — pattern documented on `LifecycleObject`).
- **Legacy migration keeps membership** (Devin review): `#migrateLegacyScheduleTable` flags legacy `_chatRecoveryContinue`/`_chatRecoveryRetry` rows by name (precedent: it already drops `_cf_keepAliveHeartbeat` by name), and an idempotent dedup hit restores the flag on an unflagged row by re-pushing the same durable intent in place.
- Deleted: `Agent.onAlarmMemoryLimit` relay, both `_cf_` template methods, `Scheduler.applyMemoryLimitPolicy`, `setLifecycleAlarmMemoryLimitStrikes`.

## Follow-up direction

Chat recovery is a hand-rolled task system that predates the Tasks capability (incidents ≈ runs, attempt budgets ≈ retry policy, idempotent schedules ≈ idempotency keys). Migrating it onto Tasks deletes the scaffolding type and most of the engine's scheduling plumbing; Tasks needs an indefinite-park primitive first.

## Testing

- Breaker suite covers: pending flagged schedules backed off past the strike's backoff wake and purged at seal (unflagged control untouched); migrated legacy recovery rows through an unsealed strike and sealing; the dedup-restore path.
- Full suites green: agents default unit target 2735 (workers, chat, react, node, x402, webmcp projects), ai-chat workers 655, think workers 887 + react 2. Full repo check (sherif, exports, oxfmt, oxlint, 117-project typecheck) passes.

https://claude.ai/code/session_011QZUJztM1rMTsHEC7mbcbz