### PR TITLE
test(think): remove timing races from Durable Object tests

### DIFF
--- a/packages/think/src/tests/action-pause-recovery.test.ts
+++ b/packages/think/src/tests/action-pause-recovery.test.ts
@@ -76,10 +76,11 @@ describe("action-pause during an active recovery incident", () => {
       user: null
     });
 
-    await agent.triggerFiberRecovery();
-    expect(
-      await agent.getScheduledChatRecoveryCountForTest("_chatRecoveryRetry")
-    ).toBe(1);
+    // Assert on the counts returned from inside the trigger RPC: the
+    // zero-delay recovery alarm may fire (and consume the job row) as soon as
+    // the RPC releases the DO, so a follow-up count read can race it.
+    const scheduled = await agent.triggerFiberRecovery();
+    expect(scheduled.scheduledRetryCount).toBe(1);
     await agent.runScheduledRecoveryRetryForTest();
 
     // Recovery ran the interrupted turn to completion (no leaked fiber)...
@@ -155,10 +156,8 @@ describe("action-pause during an active recovery incident", () => {
       }
     );
 
-    await agent.triggerFiberRecovery();
-    expect(
-      await agent.getScheduledChatRecoveryCountForTest("_chatRecoveryContinue")
-    ).toBe(1);
+    const scheduled = await agent.triggerFiberRecovery();
+    expect(scheduled.scheduledContinueCount).toBe(1);
     await agent.runScheduledRecoveryContinueForTest();
 
     // Recovery settled the interrupted turn without disturbing the pause.

--- a/packages/think/src/tests/agent-tool-reattach-recovery.test.ts
+++ b/packages/think/src/tests/agent-tool-reattach-recovery.test.ts
@@ -77,10 +77,11 @@ describe("agent-tool child re-attach: request_id rebinding across recovery", () 
       }
     );
 
-    await agent.triggerFiberRecovery();
-    expect(
-      await agent.getScheduledChatRecoveryCountForTest("_chatRecoveryContinue")
-    ).toBe(1);
+    // Assert on the counts returned from inside the trigger RPC: the
+    // zero-delay recovery alarm may fire (and consume the job row) as soon as
+    // the RPC releases the DO, so a follow-up count read can race it.
+    const scheduled = await agent.triggerFiberRecovery();
+    expect(scheduled.scheduledContinueCount).toBe(1);
     await agent.runScheduledRecoveryContinueForTest();
 
     // The row's request_id moved off the pre-eviction turn to the recovery
@@ -124,10 +125,8 @@ describe("agent-tool child re-attach: request_id rebinding across recovery", () 
       }
     );
 
-    await agent.triggerFiberRecovery();
-    expect(
-      await agent.getScheduledChatRecoveryCountForTest("_chatRecoveryRetry")
-    ).toBe(1);
+    const scheduled = await agent.triggerFiberRecovery();
+    expect(scheduled.scheduledRetryCount).toBe(1);
     await agent.runScheduledRecoveryRetryForTest();
 
     const reboundReqId =

--- a/packages/think/src/tests/agent-tools.test.ts
+++ b/packages/think/src/tests/agent-tools.test.ts
@@ -4,7 +4,7 @@ import {
   AGENT_TOOL_PROGRESS_PART,
   getAgentByName
 } from "agents";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { ThinkAgentToolParent, ThinkTestAgent } from "./agents";
 import type {
   AgentToolEventMessage,
@@ -23,7 +23,9 @@ type ThinkAgentToolTestStub = {
   setAgentToolOutputForTest(runId: string, output: unknown): Promise<void>;
   clearAgentToolOutputForTest(runId: string): Promise<void>;
   setStripTextResponseForTest(strip: boolean): Promise<void>;
-  setBeforeStepAsyncDelay(ms: number): Promise<void>;
+  holdBeforeStepForTest(): Promise<void>;
+  hasEnteredBeforeStepForTest(): Promise<boolean>;
+  releaseBeforeStepForTest(): Promise<void>;
   resetTurnStateForTest(): Promise<void>;
   startAgentToolRun(
     input: unknown,
@@ -191,18 +193,18 @@ async function waitForAgentToolRun(
   agent: ThinkAgentToolTestStub,
   runId: string
 ): Promise<AgentToolInspection> {
-  for (let attempt = 0; attempt < 20; attempt++) {
-    const inspection = await agent.inspectAgentToolRun(runId);
-    if (
-      inspection?.status === "completed" ||
-      inspection?.status === "error" ||
-      inspection?.status === "aborted"
-    ) {
+  // The child turn runs detached (`startAgentToolRun` returns immediately),
+  // so terminal status is only observable by polling. Use a long deadline —
+  // it costs nothing when the run is fast, and fails with a clear timeout
+  // instead of handing callers a misleading non-terminal snapshot.
+  return vi.waitFor(
+    async () => {
+      const inspection = await agent.inspectAgentToolRun(runId);
+      expect(["completed", "error", "aborted"]).toContain(inspection?.status);
       return inspection;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 10));
-  }
-  return agent.inspectAgentToolRun(runId);
+    },
+    { timeout: 8000, interval: 25 }
+  );
 }
 
 describe("Think agent tools", () => {
@@ -269,10 +271,21 @@ describe("Think agent tools", () => {
     const agent = await freshAgent();
     const runId = crypto.randomUUID();
 
-    await agent.setBeforeStepAsyncDelay(50);
+    // Park the child turn inside `beforeStep` on a promise gate so the reset
+    // deterministically lands while the turn is in flight (a wall-clock sleep
+    // here could lose the race and observe a completed turn instead).
+    await agent.holdBeforeStepForTest();
     await agent.startAgentToolRun("skipped probe", { runId });
-    await new Promise((resolve) => setTimeout(resolve, 5));
+    await vi.waitFor(
+      async () => {
+        expect(await agent.hasEnteredBeforeStepForTest()).toBe(true);
+      },
+      { timeout: 8000, interval: 25 }
+    );
     await agent.resetTurnStateForTest();
+    // Release AFTER the reset so the resumed turn observes the generation
+    // bump and seals the child run promptly.
+    await agent.releaseBeforeStepForTest();
 
     const inspection = await waitForAgentToolRun(agent, runId);
 
@@ -287,9 +300,17 @@ describe("Think agent tools", () => {
     const agent = await freshAgent();
     const runId = crypto.randomUUID();
 
-    await agent.setBeforeStepAsyncDelay(50);
+    // Park the child turn inside `beforeStep` so the cancel deterministically
+    // lands while the run is still cancellable (a wall-clock sleep here could
+    // lose the race and observe a completed turn instead).
+    await agent.holdBeforeStepForTest();
     await agent.startAgentToolRun("cancelled probe", { runId });
-    await new Promise((resolve) => setTimeout(resolve, 5));
+    await vi.waitFor(
+      async () => {
+        expect(await agent.hasEnteredBeforeStepForTest()).toBe(true);
+      },
+      { timeout: 8000, interval: 25 }
+    );
     await agent.cancelAgentToolRun(runId, "stop");
 
     const inspection = await waitForAgentToolRun(agent, runId);
@@ -299,7 +320,19 @@ describe("Think agent tools", () => {
       error: "stop"
     });
 
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    // Let the parked turn resume and run its finish path to the end (the
+    // cleanup maps empty only when it has), then re-assert: the finalizer's
+    // guarded UPDATE must NOT clobber the aborted seal.
+    await agent.releaseBeforeStepForTest();
+    await vi.waitFor(
+      async () => {
+        expect(await agent.getAgentToolCleanupMapSizesForTest()).toEqual({
+          lastErrors: 0,
+          preTurnAssistantIds: 0
+        });
+      },
+      { timeout: 8000, interval: 25 }
+    );
     await expect(agent.inspectAgentToolRun(runId)).resolves.toMatchObject({
       runId,
       status: "aborted",

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -743,6 +743,9 @@ export class ThinkTestAgent extends Think {
   private _turnConfigOverride: TurnConfig | null = null;
   private _stepConfigOverride: StepConfig | null = null;
   private _beforeStepAsyncDelayMs = 0;
+  private _beforeStepGate: Promise<void> | null = null;
+  private _releaseBeforeStepGate: (() => void) | null = null;
+  private _beforeStepGateEntered = false;
   private _lastModelCallSettings: CapturedModelCallSettings | null = null;
   private _reasoningResponse: { response: string; reasoning: string } | null =
     null;
@@ -902,6 +905,10 @@ export class ThinkTestAgent extends Think {
     if (this._beforeStepAsyncDelayMs > 0) {
       await new Promise((r) => setTimeout(r, this._beforeStepAsyncDelayMs));
     }
+    if (this._beforeStepGate) {
+      this._beforeStepGateEntered = true;
+      await this._beforeStepGate;
+    }
     if (this._stepConfigOverride) return this._stepConfigOverride;
   }
 
@@ -915,6 +922,31 @@ export class ThinkTestAgent extends Think {
 
   async setBeforeStepAsyncDelay(ms: number): Promise<void> {
     this._beforeStepAsyncDelayMs = ms;
+  }
+
+  /**
+   * Arm a promise gate that parks the next `beforeStep` until released. Tests
+   * use it to hold a turn deterministically in flight — instead of racing a
+   * wall-clock delay — while they reset or cancel from outside the turn.
+   */
+  async holdBeforeStepForTest(): Promise<void> {
+    this._beforeStepGateEntered = false;
+    this._beforeStepGate = new Promise((resolve) => {
+      this._releaseBeforeStepGate = resolve;
+    });
+  }
+
+  /** Whether a turn is currently parked inside the armed `beforeStep` gate. */
+  async hasEnteredBeforeStepForTest(): Promise<boolean> {
+    return this._beforeStepGateEntered;
+  }
+
+  /** Release the parked turn (and disarm the gate for later steps). */
+  async releaseBeforeStepForTest(): Promise<void> {
+    const release = this._releaseBeforeStepGate;
+    this._beforeStepGate = null;
+    this._releaseBeforeStepGate = null;
+    release?.();
   }
 
   async resetTurnStateForTest(): Promise<void> {
@@ -4803,19 +4835,37 @@ export class ThinkToolsTestAgent extends Think {
     `;
   }
 
-  async triggerFiberRecovery(): Promise<void> {
+  async triggerFiberRecovery(): Promise<{
+    scheduledContinueCount: number;
+    scheduledRetryCount: number;
+  }> {
     await (
       this as unknown as { _checkRunFibers(): Promise<void> }
     )._checkRunFibers();
+    // Recovery arms ZERO-delay schedules whose alarms the workers test pool
+    // can fire as soon as this RPC releases the DO, consuming the job rows.
+    // Read the counts synchronously inside the same invocation so callers can
+    // assert on them without racing that alarm.
+    return {
+      scheduledContinueCount: this._countScheduledChatRecovery(
+        "_chatRecoveryContinue"
+      ),
+      scheduledRetryCount:
+        this._countScheduledChatRecovery("_chatRecoveryRetry")
+    };
+  }
+
+  private _countScheduledChatRecovery(callback: string): number {
+    const rows = this.sql<{ count: number }>`
+      SELECT COUNT(*) as count FROM cf_agents_jobs WHERE capability = 'scheduler' AND fn = ${callback}
+    `;
+    return rows[0]?.count ?? 0;
   }
 
   async getScheduledChatRecoveryCountForTest(
     callback = "_chatRecoveryContinue"
   ): Promise<number> {
-    const rows = this.sql<{ count: number }>`
-      SELECT COUNT(*) as count FROM cf_agents_jobs WHERE capability = 'scheduler' AND fn = ${callback}
-    `;
-    return rows[0]?.count ?? 0;
+    return this._countScheduledChatRecovery(callback);
   }
 
   async runScheduledRecoveryRetryForTest(): Promise<void> {
@@ -5540,8 +5590,11 @@ export class ThinkProgrammaticTestAgent extends Think {
       const submission = await this.testSubmitMessages("alarm owned", {
         submissionId
       });
-      for (let attempt = 0; attempt < 20 && alarmDrainCalls === 0; attempt++) {
-        await new Promise((resolve) => setTimeout(resolve, 10));
+      // The drain is delivered by a platform-scheduled alarm whose firing
+      // latency is not bounded by our timer ticks — give it a generous (~5s)
+      // deadline; the happy path still exits on the first tick after it fires.
+      for (let attempt = 0; attempt < 200 && alarmDrainCalls === 0; attempt++) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
       }
       return { alarmDrainCalls, inlineDrainCalls, submission };
     } finally {
@@ -7710,12 +7763,7 @@ export class ThinkRecoveryTestAgent extends Think {
   async getScheduledChatRecoveryCountForTest(
     callback = "_chatRecoveryContinue"
   ): Promise<number> {
-    const rows = this.sql<{ count: number }>`
-      SELECT COUNT(*) as count
-      FROM cf_agents_jobs
-      WHERE capability = 'scheduler' AND fn = ${callback}
-    `;
-    return rows[0]?.count ?? 0;
+    return this._countScheduledChatRecovery(callback);
   }
 
   /** Insert a stream-metadata row aged `ageMs` in the past (for cleanup tests). */
@@ -7826,10 +7874,33 @@ export class ThinkRecoveryTestAgent extends Think {
     `;
   }
 
-  async triggerFiberRecovery(): Promise<void> {
+  async triggerFiberRecovery(): Promise<{
+    scheduledContinueCount: number;
+    scheduledRetryCount: number;
+  }> {
     await (
       this as unknown as { _checkRunFibers(): Promise<void> }
     )._checkRunFibers();
+    // Recovery arms ZERO-delay schedules whose alarms the workers test pool
+    // can fire as soon as this RPC releases the DO, consuming the job rows.
+    // Read the counts synchronously inside the same invocation so callers can
+    // assert on them without racing that alarm.
+    return {
+      scheduledContinueCount: this._countScheduledChatRecovery(
+        "_chatRecoveryContinue"
+      ),
+      scheduledRetryCount:
+        this._countScheduledChatRecovery("_chatRecoveryRetry")
+    };
+  }
+
+  private _countScheduledChatRecovery(callback: string): number {
+    const rows = this.sql<{ count: number }>`
+      SELECT COUNT(*) as count
+      FROM cf_agents_jobs
+      WHERE capability = 'scheduler' AND fn = ${callback}
+    `;
+    return rows[0]?.count ?? 0;
   }
 
   async persistTestMessage(msg: UIMessage): Promise<void> {

--- a/packages/think/src/tests/assistant-agent.test.ts
+++ b/packages/think/src/tests/assistant-agent.test.ts
@@ -1,5 +1,5 @@
 import { env, exports } from "cloudflare:workers";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { getAgentByName } from "agents";
 import type { UIMessage } from "ai";
 
@@ -235,14 +235,21 @@ describe("Think — clear", () => {
 
     await waitForMessageOfType(ws, MSG_CHAT_MESSAGES);
 
-    let messages = (await agent.getMessages()) as unknown as UIMessage[];
+    const messages = (await agent.getMessages()) as unknown as UIMessage[];
     expect(messages.length).toBe(2);
 
     ws.send(JSON.stringify({ type: MSG_CHAT_CLEAR }));
-    await new Promise((r) => setTimeout(r, 200));
-
-    messages = (await agent.getMessages()) as unknown as UIMessage[];
-    expect(messages.length).toBe(0);
+    // The clear frame (WS) and the read (RPC) travel independent transports
+    // with no ordering guarantee, so poll for the effect instead of sleeping.
+    // Messages only reach 0 via the clear, so this cannot pass spuriously.
+    await vi.waitFor(
+      async () => {
+        expect(
+          ((await agent.getMessages()) as unknown as UIMessage[]).length
+        ).toBe(0);
+      },
+      { timeout: 5000, interval: 50 }
+    );
 
     await closeWS(ws);
   });

--- a/packages/think/src/tests/channel-recovery.test.ts
+++ b/packages/think/src/tests/channel-recovery.test.ts
@@ -74,10 +74,11 @@ describe("recovery × channels", () => {
       }
     );
 
-    await agent.triggerFiberRecovery();
-    expect(
-      await agent.getScheduledChatRecoveryCountForTest("_chatRecoveryContinue")
-    ).toBe(1);
+    // Assert on the counts returned from inside the trigger RPC: the
+    // zero-delay recovery alarm may fire (and consume the job row) as soon as
+    // the RPC releases the DO, so a follow-up count read can race it.
+    const scheduled = await agent.triggerFiberRecovery();
+    expect(scheduled.scheduledContinueCount).toBe(1);
     await agent.runScheduledRecoveryContinueForTest();
 
     // (a) The channel stamp survives recovery.
@@ -117,10 +118,8 @@ describe("recovery × channels", () => {
       user: null
     });
 
-    await agent.triggerFiberRecovery();
-    expect(
-      await agent.getScheduledChatRecoveryCountForTest("_chatRecoveryRetry")
-    ).toBe(1);
+    const scheduled = await agent.triggerFiberRecovery();
+    expect(scheduled.scheduledRetryCount).toBe(1);
     await agent.runScheduledRecoveryRetryForTest();
 
     // (a) The channel stamp survives recovery.

--- a/packages/think/src/tests/run-turn-recovery.test.ts
+++ b/packages/think/src/tests/run-turn-recovery.test.ts
@@ -86,10 +86,11 @@ describe("recovery × runTurn", () => {
       }
     );
 
-    await agent.triggerFiberRecovery();
-    expect(
-      await agent.getScheduledChatRecoveryCountForTest("_chatRecoveryContinue")
-    ).toBe(1);
+    // Assert on the counts returned from inside the trigger RPC: the
+    // zero-delay recovery alarm may fire (and consume the job row) as soon as
+    // the RPC releases the DO, so a follow-up count read can race it.
+    const scheduled = await agent.triggerFiberRecovery();
+    expect(scheduled.scheduledContinueCount).toBe(1);
     await agent.runScheduledRecoveryContinueForTest();
 
     // Recovery resolved the interrupted turn and left no leaked fiber.

--- a/packages/think/src/tests/streaming-message-id.test.ts
+++ b/packages/think/src/tests/streaming-message-id.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { env, exports } from "cloudflare:workers";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { getAgentByName } from "agents";
 import type { UIMessage } from "ai";
 
@@ -95,30 +95,43 @@ function runTurnAndCollectStartChunks(
 }
 
 describe("Think — streaming assistant message-id alignment", () => {
-  it("stamps the persisted assistant id onto a new turn's start chunk", async () => {
-    const room = crypto.randomUUID();
-    const agent = await getAgentByName(env.ThinkClientToolsAgent, room);
-    await agent.setTextOnlyMode(true);
-    const ws = await connectWS(room);
+  it(
+    "stamps the persisted assistant id onto a new turn's start chunk",
+    {
+      timeout: 15_000
+    },
+    async () => {
+      const room = crypto.randomUUID();
+      const agent = await getAgentByName(env.ThinkClientToolsAgent, room);
+      await agent.setTextOnlyMode(true);
+      const ws = await connectWS(room);
 
-    const startChunks = await runTurnAndCollectStartChunks(ws, "hello");
+      const startChunks = await runTurnAndCollectStartChunks(ws, "hello");
 
-    // A single (non-continuation) turn streams exactly one start chunk.
-    expect(startChunks).toHaveLength(1);
-    const start = startChunks[0];
+      // A single (non-continuation) turn streams exactly one start chunk.
+      expect(startChunks).toHaveLength(1);
+      const start = startChunks[0];
 
-    // The provider emits no id, so Think must have stamped one.
-    expect(typeof start.messageId).toBe("string");
-    expect(start.messageId).toBeTruthy();
+      // The provider emits no id, so Think must have stamped one.
+      expect(typeof start.messageId).toBe("string");
+      expect(start.messageId).toBeTruthy();
 
-    // And it must equal the id the assistant turn was persisted under, so the
-    // client streams and reconciles against a single message.
-    await new Promise((r) => setTimeout(r, 200));
-    const messages = (await agent.getMessages()) as UIMessage[];
-    const assistant = messages.find((m) => m.role === "assistant");
-    expect(assistant).toBeDefined();
-    expect(start.messageId).toBe(assistant?.id);
+      // And it must equal the id the assistant turn was persisted under, so the
+      // client streams and reconciles against a single message. The `done`
+      // broadcast lands BEFORE the assistant message is durably persisted, so
+      // poll for the persisted row instead of betting on a fixed sleep.
+      const assistant = await vi.waitFor(
+        async () => {
+          const messages = (await agent.getMessages()) as UIMessage[];
+          const persisted = messages.find((m) => m.role === "assistant");
+          expect(persisted).toBeDefined();
+          return persisted;
+        },
+        { timeout: 8000, interval: 25 }
+      );
+      expect(start.messageId).toBe(assistant?.id);
 
-    ws.close(1000);
-  });
+      ws.close(1000);
+    }
+  );
 });

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -3374,10 +3374,11 @@ describe("Think — onChatRecovery", () => {
       user: null
     });
 
-    await agent.triggerFiberRecovery();
-    expect(
-      await agent.getScheduledChatRecoveryCountForTest("_chatRecoveryRetry")
-    ).toBe(1);
+    // Assert on the counts returned from inside the trigger RPC: the
+    // zero-delay recovery alarm may fire (and consume the job row) as soon as
+    // the RPC releases the DO, so a follow-up count read can race it.
+    const scheduled = await agent.triggerFiberRecovery();
+    expect(scheduled.scheduledRetryCount).toBe(1);
     await agent.runScheduledRecoveryRetryForTest();
 
     const messages = (await agent.getStoredMessages()) as UIMessage[];
@@ -3440,10 +3441,8 @@ describe("Think — onChatRecovery", () => {
       user: null
     });
 
-    await agent.triggerFiberRecovery();
-    expect(
-      await agent.getScheduledChatRecoveryCountForTest("_chatRecoveryContinue")
-    ).toBe(1);
+    const scheduled = await agent.triggerFiberRecovery();
+    expect(scheduled.scheduledContinueCount).toBe(1);
 
     await agent.setRequestContextForTest({ mode: "stale" }, [
       { name: "staleTool", description: "Stale" }
@@ -3534,10 +3533,8 @@ describe("Think — onChatRecovery", () => {
       user: null
     });
 
-    await agent.triggerFiberRecovery();
-    expect(
-      await agent.getScheduledChatRecoveryCountForTest("_chatRecoveryContinue")
-    ).toBe(1);
+    const scheduled = await agent.triggerFiberRecovery();
+    expect(scheduled.scheduledContinueCount).toBe(1);
     await agent.runScheduledRecoveryContinueForTest();
 
     // Progress was made: the continuation re-ran inference and produced new
@@ -4311,10 +4308,13 @@ describe("Think — onChatRecovery", () => {
     );
     await agent.insertInterruptedFiber("__cf_internal_chat_turn:req-completed");
 
-    await agent.triggerFiberRecovery();
+    const scheduled = await agent.triggerFiberRecovery();
 
     expect(await agent.getTurnCallCount()).toBe(0);
-    expect(await agent.getScheduledChatRecoveryCountForTest()).toBe(0);
+    expect(scheduled).toEqual({
+      scheduledContinueCount: 0,
+      scheduledRetryCount: 0
+    });
 
     const messages = (await agent.getStoredMessages()) as UIMessage[];
     expect(messages).toHaveLength(1);


### PR DESCRIPTION
## What

Hardens the flaky timing-dependent tests in `packages/think/src/tests` (test-only change, no changeset). These tests predate the facilities now available in the installed `@cloudflare/vitest-pool-workers` era (per-file storage isolation, deterministic DO helpers, `vi.waitFor` in the workerd isolate), and several of them used wall-clock sleeps or tight fixed poll budgets as synchronization. Each fix below replaces a race with either polling for the observable effect or an explicit ordering primitive, without weakening what any test proves.

## Fixed races

**1. `waitForAgentToolRun` tight poll budget (`agent-tools.test.ts`)**
`startAgentToolRun` returns `{status: "running"}` immediately and runs the whole child turn detached; the helper polled 20×10ms (~200ms) and then silently returned whatever `inspectAgentToolRun` said — non-terminal or not — so callers' `toMatchObject({status: "completed"})` failed whenever a full child turn took >200ms under CI load. Now `vi.waitFor` with an 8s deadline asserts the status is terminal before returning: free when fast, and a clear timeout instead of a misleading non-terminal snapshot when not. Every caller still asserts the specific terminal status and payload afterward.

**2. `beforeStep` promise gate replaces 5ms-sleep-in-a-50ms-window (`agent-tools.test.ts` × 2, `agents/think-session.ts`)**
The "marks skipped agent-tool turns as errors" and "preserves explicit agent-tool cancellation as aborted" tests parked the child turn on a 50ms `beforeStep` delay and slept 5ms before resetting/cancelling — pure wall-clock ordering with a ~45ms margin. If the isolate stalled, the turn completed first and `resetTurnStateForTest`/`cancelAgentToolRun` no-oped on a sealed row (`completed` instead of `error`/`aborted`). `ThinkTestAgent` now exposes a promise gate (`holdBeforeStepForTest` / `hasEnteredBeforeStepForTest` / `releaseBeforeStepForTest`): the test arms the gate, starts the run, polls until the turn is provably parked inside `beforeStep`, performs the reset/cancel, then releases. Releasing after the reset means the resumed turn observes the generation bump and seals promptly. The cancellation test additionally waits for the released turn's finish path to complete (bookkeeping maps empty) and re-asserts `aborted`, preserving the original coverage that the guarded finalizer (`UPDATE … WHERE completed_at IS NULL`) never clobbers the aborted seal.

**3. WS chat clear used a 200ms sleep (`assistant-agent.test.ts`)**
The clear frame travels the WebSocket while `getMessages()` is an RPC — independent transports with no ordering guarantee, and `_handleClear` awaits `_clearHistory()` server-side. The fixed sleep is now `vi.waitFor` polling until the persisted history reads 0 (messages only reach 0 via the clear, so it cannot pass spuriously; a never-applied clear still fails within 5s).

**4. Assistant-message persistence raced a 200ms sleep (`streaming-message-id.test.ts`)**
Think broadcasts the `done` chat frame before `_persistAssistantMessage` lands, so reading `getMessages()` after a fixed sleep could miss the assistant row. Now the test polls for the persisted assistant message (8s deadline, explicit 15s test timeout) and then asserts the id equality; a wrongly-stamped start id still fails the equality, and a persistence regression fails at the poll deadline.

**5. Scheduled-recovery job counts raced the zero-delay alarm (`channel-recovery`, `agent-tool-reattach-recovery`, `action-pause-recovery`, `run-turn-recovery`, `think-session` tests + both test agents)**
`scheduleRecovery` arms a zero-delay alarm-backed `cf_agents_jobs` row, and the workers pool fires due alarms as soon as the trigger RPC releases the DO — so a follow-up `getScheduledChatRecoveryCountForTest()` RPC could observe the row already consumed and read 0 instead of 1. `triggerFiberRecovery()` now reads and returns the per-callback counts synchronously inside the same RPC invocation (before the DO is released), and the count-after-trigger assertions use the returned value. No test-only alarm suppression was added — the real alarm path stays exactly as `eviction-recovery.test.ts` exercises it, and the manual recovery drivers remain idempotent against an alarm that wins.

**6. Submission-drain alarm probe capped at ~200ms (`agents/think-session.ts`)**
`probeSubmissionAlarmOwnershipForTest` waited at most 20×10ms for the platform-scheduled drain alarm before the test asserted `alarmDrainCalls === 1`; alarm firing latency is not bounded by the probe's timer ticks. The poll now runs up to ~5s (200×25ms), still exiting on the first tick after the alarm fires and still fitting under the 10s test timeout with the follow-up submission wait. The test still proves alarm *ownership* — the platform-scheduled invocation, not an inline path, runs the drain.

## Deliberately not changed

- `retry: 3` in `vitest.config.ts` stays: the review notes for it conflicted (one endorsed lowering to 1, the later one endorsed keeping it for the main lane), and its companion recommendations (a nightly `--retry=0` lane, retry-count reporting, randomizing fixed DO names — claimed at ~65 sites but actually 320 across nine files, many with intentional intra-test reuse) are CI-config or bulk changes beyond this test-only pass.

## Verification

- `pnpm run test:workers` in `packages/think`: two consecutive fully green runs (887/887 both).
- `pnpm run typecheck packages/think`: green.
- `oxfmt --check` and `oxlint` clean on the tests directory.

https://claude.ai/code/session_011QZUJztM1rMTsHEC7mbcbz
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/agents/pull/2192" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->