### PR TITLE
fix(ci): make import-size reports informational

### DIFF
--- a/.github/workflows/import-sizes.yml
+++ b/.github/workflows/import-sizes.yml
@@ -67,7 +67,6 @@ jobs:
           --output "$RUNNER_TEMP/agents-import-sizes/base.json"
 
       - name: Compare import sizes
-        id: import-sizes
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
@@ -82,7 +81,6 @@ jobs:
           --run-id "$RUN_ID"
           --run-attempt "$RUN_ATTEMPT"
           --threshold 10
-          --github-output "$GITHUB_OUTPUT"
           --github-step-summary "$GITHUB_STEP_SUMMARY"
 
       - name: Upload import-size report
@@ -92,9 +90,3 @@ jobs:
           path: ${{ runner.temp }}/agents-import-sizes/report.json
           if-no-files-found: error
           retention-days: 14
-
-      - name: Enforce import-size limit
-        if: steps.import-sizes.outputs.gate == 'fail'
-        run: |
-          echo "One or more existing imports grew by more than 10%." >&2
-          exit 1

--- a/packages/agents/scripts/import-size-report.ts
+++ b/packages/agents/scripts/import-size-report.ts
@@ -21,7 +21,8 @@ import { gzipSync } from "node:zlib";
 
 const SNAPSHOT_KIND = "agents-import-size-snapshot";
 const REPORT_KIND = "agents-import-size-report";
-const SCHEMA_VERSION = 1;
+const SNAPSHOT_SCHEMA_VERSION = 1;
+const REPORT_SCHEMA_VERSION = 2;
 const MAX_MEASUREMENTS = 1_000;
 const MAX_TEXT_LENGTH = 256;
 
@@ -83,7 +84,7 @@ export type ImportSizeSummary = {
 
 /** A PR comparison consumed by CI and the Agent Think GitHub App. */
 export type ImportSizeReport = {
-  readonly schemaVersion: 1;
+  readonly schemaVersion: 2;
   readonly kind: "agents-import-size-report";
   readonly repository: string;
   readonly packageName: string;
@@ -99,7 +100,6 @@ export type ImportSizeReport = {
   readonly thresholdPercent: number;
   readonly metric: "minified-gzip";
   readonly overall: "red" | "yellow" | "green" | "unchanged";
-  readonly gate: "pass" | "fail";
   readonly summary: ImportSizeSummary;
   readonly changes: ReadonlyArray<ImportSizeChange>;
 };
@@ -200,7 +200,7 @@ export async function measurePackageImports(
     }
 
     return {
-      schemaVersion: SCHEMA_VERSION,
+      schemaVersion: SNAPSHOT_SCHEMA_VERSION,
       kind: SNAPSHOT_KIND,
       packageName: manifest.name,
       packageVersion: manifest.version,
@@ -221,7 +221,7 @@ export async function measurePackageImports(
  *
  * @param base - Snapshot measured from the pull request base revision.
  * @param head - Snapshot measured from the pull request head revision.
- * @param options - Pull request identity and failure threshold.
+ * @param options - Pull request identity and red classification threshold.
  * @returns A structured report whose worst import controls the overall colour.
  */
 export function compareImportSizeSnapshots(
@@ -267,7 +267,7 @@ export function compareImportSizeSnapshots(
   const overall = overallStatus(summary);
 
   return {
-    schemaVersion: SCHEMA_VERSION,
+    schemaVersion: REPORT_SCHEMA_VERSION,
     kind: REPORT_KIND,
     repository: options.repository,
     packageName: head.packageName,
@@ -283,7 +283,6 @@ export function compareImportSizeSnapshots(
     thresholdPercent: options.thresholdPercent,
     metric: "minified-gzip",
     overall,
-    gate: overall === "red" ? "fail" : "pass",
     summary,
     changes
   };
@@ -299,8 +298,11 @@ export function parseImportSizeSnapshot(
   value: unknown
 ): ParseResult<ImportSizeSnapshot> {
   if (!isRecord(value)) return invalid("snapshot", "expected an object");
-  if (value.schemaVersion !== SCHEMA_VERSION) {
-    return invalid("snapshot.schemaVersion", `expected ${SCHEMA_VERSION}`);
+  if (value.schemaVersion !== SNAPSHOT_SCHEMA_VERSION) {
+    return invalid(
+      "snapshot.schemaVersion",
+      `expected ${SNAPSHOT_SCHEMA_VERSION}`
+    );
   }
   if (value.kind !== SNAPSHOT_KIND) {
     return invalid("snapshot.kind", `expected ${SNAPSHOT_KIND}`);
@@ -357,7 +359,7 @@ export function parseImportSizeSnapshot(
   return {
     ok: true,
     value: {
-      schemaVersion: SCHEMA_VERSION,
+      schemaVersion: SNAPSHOT_SCHEMA_VERSION,
       kind: SNAPSHOT_KIND,
       packageName,
       packageVersion,

--- a/packages/agents/scripts/import-sizes.ts
+++ b/packages/agents/scripts/import-sizes.ts
@@ -27,7 +27,6 @@ type Command =
       readonly workflowRunId: number;
       readonly workflowRunAttempt: number;
       readonly thresholdPercent: number;
-      readonly githubOutput?: string;
       readonly githubStepSummary?: string;
     };
 
@@ -59,13 +58,6 @@ async function main(): Promise<void> {
   await writeImportSizeJson(command.output, report);
   printReportSummary(report);
 
-  if (command.githubOutput !== undefined) {
-    await appendFile(
-      resolve(command.githubOutput),
-      `gate=${report.gate}\noverall=${report.overall}\n`,
-      "utf8"
-    );
-  }
   if (command.githubStepSummary !== undefined) {
     await appendFile(
       resolve(command.githubStepSummary),
@@ -101,9 +93,6 @@ function parseCommand(args: ReadonlyArray<string>): Command {
         "threshold",
         DEFAULT_THRESHOLD_PERCENT
       ),
-      ...(flags.get("github-output") !== undefined
-        ? { githubOutput: requiredFlag(flags, "github-output") }
-        : {}),
       ...(flags.get("github-step-summary") !== undefined
         ? {
             githubStepSummary: requiredFlag(flags, "github-step-summary")
@@ -218,7 +207,7 @@ function renderStepSummary(report: ImportSizeReport): string {
   return [
     `## ${status} ${report.packageName} import sizes\n`,
     `Measured ${report.summary.total} runtime imports as minified gzip. ` +
-      `Increases above ${formatPercent(report.thresholdPercent)} fail this check.\n`,
+      `Increases above ${formatPercent(report.thresholdPercent)} are marked red; this report is informational.\n`,
     `| Red | Yellow | Green | Unchanged | New | Removed |`,
     `| ---: | -----: | ----: | --------: | --: | ------: |`,
     `| ${report.summary.red} | ${report.summary.yellow} | ${report.summary.green} | ${report.summary.unchanged} | ${report.summary.new} | ${report.summary.removed} |\n`


### PR DESCRIPTION
## Summary

- make package import-size comparisons informational regardless of red/yellow/green classification
- remove the threshold enforcement step and its GitHub output plumbing
- emit report schema v2 without a `gate` field, so the artifact cannot imply a merge-blocking result
- change the job summary to say increases above 10% are marked red rather than failing CI

Build, measurement, report-generation, and artifact-upload failures still fail because no trustworthy report was produced. A measured size increase never fails the run.

This fixes the behavior visible on #2194, where one red import caused run 33635989129 to fail even though the size report itself completed successfully.

Companion Agent Think rollout: https://gitlab.cfdata.org/cloudflare/ai-agents/team-apps/-/merge_requests/8

No changeset is needed; this changes repository CI only.

## Validation

- `pnpm run build`
- `pnpm run check` on Node 24: 121 TypeScript projects
- synthetic 100% import-size increase: red report, process exit 0, schema v2 without `gate`
- schema-v2 report parsed and rendered by the Team Apps consumer as informational

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/agents/pull/2202" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->