### PR TITLE
feat(streams): R2 chunk log — segment write-ahead log behind `new Streams({ r2 })`

### DIFF
--- a/.changeset/streams-r2-chunk-log.md
+++ b/.changeset/streams-r2-chunk-log.md
@@ -1,0 +1,7 @@
+---
+"agents": minor
+---
+
+feat(streams): store chunk logs in R2 with `new Streams({ r2: env.BUCKET })`.
+
+Stream rows (state, tag index, metadata, cursor) stay in DO SQLite; chunks go to R2 as a write-ahead log of segment objects, checkpointed every 25 chunks or 1 s (`r2Checkpoint`), so a Durable Object that dies mid-stream leaves everything up to its last checkpoint in R2 and a restarted producer resumes from it. Settlement compacts the segments into one exact-size object; `Streams.flush()` awaits it. The synchronous storage aperture used by chat stays SQLite-only.

--- a/docs/agents/streams.md
+++ b/docs/agents/streams.md
@@ -183,28 +183,38 @@ rejects bodies of unknown length, and stores nothing from a put that has
 not completed. So the log is a write-ahead log of segment objects:
 
 - Appends go into an in-memory line log that live readers tail, exactly
-  like the SQLite log's wakeups.
+  like the SQLite log's wakeups. Memory holds only the unflushed tail plus
+  a 256 KB hot window of landed lines: once a segment's put resolves its
+  lines are evicted, and a reader further behind reads that segment from
+  R2. A stream's length never grows the isolate's memory.
 - Every `everyChunks` appends or `everyMs` after the first unflushed one,
   the new lines are put as one immutable segment under `<id>/seg/`. Each
   landed segment is the durability. When the isolate dies, everything up
   to the last landed segment is in R2, and the loss window is the cadence.
-- The row's cursor is stamped only after a segment's put resolves, so
-  `status()` never reports more than R2 holds.
-- `open()` on a stream whose isolate died rebuilds the log from the
-  contiguous segment chain, deletes keys the chain does not cover, and
-  continues in a new epoch. A resumed producer starts at the durable
-  cursor, so the Tasks resume contract holds and no discarded generation
-  can be spliced back in.
+- The row's cursor is stamped from landed segments, throttled to one row
+  write per 5 s, so `status()` never reports more than R2 holds and the
+  stamp costs a fraction of the puts. While a stream is live the row can
+  lag the chain by a few seconds; `open()` after a death re-stamps it
+  exactly. A segment put that fails after retries folds its range into
+  the next checkpoint, so nothing is skipped.
+- `open()` on a stream whose isolate died lists the segments once, keeps
+  the contiguous chain, deletes keys it does not cover, and continues in a
+  new epoch from the chain's end without loading it into memory. A resumed
+  producer starts at the durable cursor, so the Tasks resume contract
+  holds and no discarded generation can be spliced back in.
 - `close()` and `error()` settle the row synchronously, then in the
-  background put the whole body as one exact-size object at `<id>/body`
-  so replay is a single get, and drop the segments. Segments stay readable
-  until the body lands, so a death mid-settle loses nothing. `await
-  streams.flush(id)` waits for the body when you need the object to exist.
-- Replay of a settled stream reads the body once and caches it, bounded
-  at 8 MiB per isolate.
+  background stream the segments back through one exact-size put at
+  `<id>/body` so replay is a single object, and drop the segments (no
+  list: the keys are known). Segments stay readable until the body lands,
+  so a death mid-settle loses nothing. `await streams.flush(id)` waits for
+  the body when you need the object to exist.
+- Replay of a settled stream caches bodies up to 1 MiB whole; larger
+  bodies get a line-offset index and ranged gets per page, so replay
+  memory is bounded by the index, not the body. The read cache is 8 MiB
+  per isolate.
 
-**What SQLite still pays.** Appends read and write nothing; each landed
-segment writes one row to stamp the cursor; `status()` reads one row, a
+**What SQLite still pays.** Appends read and write nothing; the cursor
+stamp is one row write per 5 s of streaming; `status()` reads one row, a
 tag lookup two, settlement reads two and writes two. Rows read bill at a
 thousandth of the write price.
 

--- a/docs/agents/streams.md
+++ b/docs/agents/streams.md
@@ -152,6 +152,65 @@ request's signal aborts the tail when the client disconnects.
 `examples/next/streams` is the end-to-end demo. For other transports,
 `read()`/`readBatches()` remain the raw async iterables to pipe yourself.
 
+## Storing chunks in R2
+
+Hand `Streams` an R2 binding and the chunk log leaves the Durable Object:
+
+```ts
+readonly streams = new Streams({
+  r2: this.env.BUCKET,
+  r2Prefix: `streams/${this.ctx.id}/`, // default "streams/"; include the id when objects share a bucket
+  r2Checkpoint: { everyChunks: 25, everyMs: 1000 } // the defaults
+});
+```
+
+Nothing else changes: `open`, `append`, `read`, `status`, `list`, `delete`
+behave as above, and `append()` is still synchronous. Stream rows (state,
+tag index, metadata, cursor) stay in SQLite, where a point read or tag
+lookup costs nothing; chunks go to the bucket.
+
+**Why this exists: cost.** SQLite bills one row per stored chunk and again
+to delete it; R2 bills one Class A op per checkpoint, deletes are free, and
+storage is about 13 times cheaper with no 10 GB ceiling. One R2 put costs
+the same as 4.5 SQLite row writes, so the R2 log is cheaper whenever a
+checkpoint covers more than about 4.5 stored rows. For a 400-chunk chat
+turn: about $0.0008 per turn on SQLite unpacked, $0.00008 packed ten to a
+row, $0.00009 on R2 at the default cadence, $0.00002 at a 5-second one.
+Against packed SQLite, R2 only wins once you widen the loss window.
+
+**How it works, and what a Durable Object dying means.** R2 has no append,
+rejects bodies of unknown length, and stores nothing from a put that has
+not completed. So the log is a write-ahead log of segment objects:
+
+- Appends go into an in-memory line log that live readers tail, exactly
+  like the SQLite log's wakeups.
+- Every `everyChunks` appends or `everyMs` after the first unflushed one,
+  the new lines are put as one immutable segment under `<id>/seg/`. Each
+  landed segment is the durability. When the isolate dies, everything up
+  to the last landed segment is in R2, and the loss window is the cadence.
+- The row's cursor is stamped only after a segment's put resolves, so
+  `status()` never reports more than R2 holds.
+- `open()` on a stream whose isolate died rebuilds the log from the
+  contiguous segment chain, deletes keys the chain does not cover, and
+  continues in a new epoch. A resumed producer starts at the durable
+  cursor, so the Tasks resume contract holds and no discarded generation
+  can be spliced back in.
+- `close()` and `error()` settle the row synchronously, then in the
+  background put the whole body as one exact-size object at `<id>/body`
+  so replay is a single get, and drop the segments. Segments stay readable
+  until the body lands, so a death mid-settle loses nothing. `await
+  streams.flush(id)` waits for the body when you need the object to exist.
+- Replay of a settled stream reads the body once and caches it, bounded
+  at 8 MiB per isolate.
+
+**What SQLite still pays.** Appends read and write nothing; each landed
+segment writes one row to stamp the cursor; `status()` reads one row, a
+tag lookup two, settlement reads two and writes two. Rows read bill at a
+thousandth of the write price.
+
+Chat's `ResumableStream` uses the synchronous SQLite aperture and is not
+affected by this option; it throws if asked for an R2-backed `Streams`.
+
 ## Chat runs on this
 
 `AIChatAgent` and `Think` store their in-flight turn output here:

--- a/packages/agents/src/streams/index.ts
+++ b/packages/agents/src/streams/index.ts
@@ -9,6 +9,7 @@ export {
   Streams,
   type StreamsOptions
 } from "./streams";
+export type { R2CheckpointOptions } from "./r2-log";
 export {
   StreamClosedError,
   StreamNotFoundError,

--- a/packages/agents/src/streams/r2-log.ts
+++ b/packages/agents/src/streams/r2-log.ts
@@ -10,22 +10,32 @@
  * small object every so often. So:
  *
  * - `append()` is synchronous into an in-memory line log that live readers
- *   tail (the same in-isolate wakeups the SQLite log uses).
+ *   tail (the same in-isolate wakeups the SQLite log uses). Memory holds
+ *   only the unflushed tail plus a small hot window of landed lines: once
+ *   a segment's put resolves its lines are evicted, and a reader further
+ *   behind reads that segment from R2. A stream's length never grows the
+ *   isolate's memory.
  * - Every `everyChunks` appends or `everyMs` after the first unflushed one,
  *   the new lines are put as one immutable segment
  *   `<prefix><id>/seg/<epoch>/<from>-<to>`. Each landed segment is the
  *   durability: when the isolate dies, everything up to the last landed
- *   segment is in R2 and the loss window is the cadence.
- * - The stream row's cursor is stamped only after a segment's put resolves,
- *   so `status()` never reports more than R2 holds.
- * - `open()` on a stream whose isolate died rebuilds the log from the
- *   contiguous segment chain, starts a new epoch, and deletes keys the chain
- *   does not cover (deletes are free), so a later generation can never be
- *   spliced with a discarded one.
- * - Settlement puts the whole body as one exact-size object
- *   `<prefix><id>/body` so replay is a single get, then drops the segments.
+ *   segment is in R2 and the loss window is the cadence. A put that fails
+ *   after retries folds its range into the next checkpoint; nothing is
+ *   skipped.
+ * - The stream row's cursor is stamped from landed segments, throttled to
+ *   one row write per few seconds, so `status()` never reports more than
+ *   R2 holds and the stamp costs a fraction of the puts.
+ * - `open()` on a stream whose isolate died lists the segments once,
+ *   keeps the contiguous chain (deleting keys it does not cover, so a
+ *   discarded generation is never spliced back in) and continues in a new
+ *   epoch from the chain's end without loading it into memory.
+ * - Settlement streams the segments back through one exact-size put at
+ *   `<id>/body` so replay is a single object, then drops the segments.
  *   The segments stay readable until the body lands; a death mid-settle
  *   loses nothing.
+ * - Replay of a settled body caches small bodies whole; large ones get a
+ *   line-offset index and ranged gets, so replay memory is bounded by the
+ *   index, not the body.
  *
  * Cost: one Class A op per checkpoint, none per chunk. One R2 put costs
  * the same as 4.5 billed SQLite row writes, so this log is cheaper than the
@@ -47,10 +57,17 @@ export const DEFAULT_CHECKPOINT: Required<R2CheckpointOptions> = {
   everyMs: 1000
 };
 
-/** Parsed bodies kept in memory for replaying settled streams. */
+/** Landed lines kept in memory behind the tail for live readers. */
+const HOT_WINDOW_BYTES = 256 * 1024;
+/** Stream-row cursor stamps are throttled to one per this interval. */
+const STAMP_EVERY_MS = 5000;
+/** Settled bodies up to this size are cached whole; larger ones indexed. */
+const SMALL_BODY_BYTES = 1024 * 1024;
+/** Total bytes of cached bodies, indexes and fetched segments. */
 const READ_CACHE_BYTES = 8 * 1024 * 1024;
 /** R2 bulk delete accepts at most this many keys per call. */
 const DELETE_BATCH = 1000;
+const PUT_ATTEMPTS = 3;
 
 const utf8 = new TextEncoder();
 
@@ -60,34 +77,57 @@ export interface R2LogOptions {
   /** Key prefix for every object the log writes. Default: `streams/`. */
   prefix?: string;
   checkpoint?: R2CheckpointOptions;
-  /** A segment landed: `cursor` chunks are durable. Monotone, keep the max. */
+  /** `cursor` chunks are durable in R2. Monotone: keep the max. */
   onDurable: (streamId: string, cursor: number) => void;
 }
 
-/** One live (or settling) stream's memory log. */
+type Segment = {
+  key: string;
+  epoch: number;
+  from: number;
+  to: number;
+  bytes: number;
+};
+
+/** One live (or settling) stream. */
 class Sink {
+  /** Seq of `lines[0]`. Everything below is in landed segments. */
+  base: number;
   readonly lines: string[] = [];
-  bytes = 0;
+  readonly lineBytes: number[] = [];
   /** First seq not yet handed to a segment put. */
   flushedTo: number;
   /** Highest seq (exclusive) whose segment put has resolved. */
   durable: number;
+  /** Landed segments in seq order (the resumed chain, then this epoch's). */
+  readonly landed: Segment[];
   timer: ReturnType<typeof setTimeout> | null = null;
   /** Segment puts in flight, chained so they land in order. */
   chain: Promise<void> = Promise.resolve();
   lastAppendAt: number | null = null;
+  lastStampAt = 0;
   state: "streaming" | "settling" | "done" = "streaming";
 
   constructor(
     readonly epoch: number,
-    recovered: number
+    chain: Segment[]
   ) {
-    this.flushedTo = recovered;
-    this.durable = recovered;
+    this.landed = chain;
+    const cursor = chain.length > 0 ? chain[chain.length - 1].to : 0;
+    this.base = cursor;
+    this.flushedTo = cursor;
+    this.durable = cursor;
+  }
+
+  get cursor(): number {
+    return this.base + this.lines.length;
   }
 }
 
-type Segment = { key: string; epoch: number; from: number; to: number };
+/** A settled body's replay handle. */
+type Body =
+  | { kind: "small"; lines: string[]; bytes: number }
+  | { kind: "indexed"; offsets: number[]; size: number; bytes: number };
 
 export class R2ChunkLog {
   readonly #bucket: R2Bucket;
@@ -97,8 +137,8 @@ export class R2ChunkLog {
   readonly #sinks = new Map<string, Sink>();
   /** Settlements in flight, awaitable through `flush()`. */
   readonly #settling = new Map<string, Promise<void>>();
-  /** Replay cache: stream id → lines, LRU by insertion order, byte-bounded. */
-  readonly #cache = new Map<string, { lines: string[]; bytes: number }>();
+  /** Replay cache, LRU by insertion order, byte-bounded. */
+  readonly #cache = new Map<string, { bytes: number; value: unknown }>();
   #cacheBytes = 0;
 
   constructor(options: R2LogOptions) {
@@ -141,7 +181,7 @@ export class R2ChunkLog {
     return `${this.#segmentPrefix(streamId)}${pad(epoch)}/${pad(from)}-${pad(to)}`;
   }
 
-  #parseSegment(streamId: string, key: string): Segment | null {
+  #parseSegment(streamId: string, key: string, bytes: number): Segment | null {
     const rest = key.slice(this.#segmentPrefix(streamId).length);
     const match = /^(\d+)\/(\d+)-(\d+)$/.exec(rest);
     if (!match) return null;
@@ -149,7 +189,8 @@ export class R2ChunkLog {
       key,
       epoch: Number(match[1]),
       from: Number(match[2]),
-      to: Number(match[3])
+      to: Number(match[3]),
+      bytes
     };
   }
 
@@ -171,7 +212,7 @@ export class R2ChunkLog {
 
   /** The live cursor, or undefined when the stream is not in memory. */
   cursor(streamId: string): number | undefined {
-    return this.#sinks.get(streamId)?.lines.length;
+    return this.#sinks.get(streamId)?.cursor;
   }
 
   /** Chunks known to have landed in R2, or undefined when not in memory. */
@@ -183,21 +224,27 @@ export class R2ChunkLog {
     return this.#sinks.get(streamId)?.lastAppendAt ?? null;
   }
 
+  /** @internal Lines held in memory for a live stream (tests). */
+  memoryLines(streamId: string): number {
+    return this.#sinks.get(streamId)?.lines.length ?? 0;
+  }
+
   /** Start a fresh stream: an empty memory log, epoch 0. */
   open(streamId: string): void {
     this.#uncache(streamId);
-    this.#sinks.set(streamId, new Sink(0, 0));
+    this.#sinks.set(streamId, new Sink(0, []));
   }
 
   /**
-   * Resume a stream whose producer's isolate is gone: rebuild the memory
-   * log from the contiguous segment chain, delete every key the chain does
-   * not cover (a discarded generation must never be spliced back in), and
-   * continue in a new epoch. Returns the recovered cursor.
+   * Resume a stream whose producer's isolate is gone: one list, keep the
+   * contiguous chain, delete every key it does not cover (a discarded
+   * generation must never be spliced back in), and continue in a new epoch
+   * from the chain's end. Nothing is loaded into memory. Returns the
+   * recovered cursor.
    */
   async resume(streamId: string): Promise<number> {
     const existing = this.#sinks.get(streamId);
-    if (existing) return existing.lines.length;
+    if (existing) return existing.cursor;
     this.#uncache(streamId);
     const segments = await this.#listSegments(streamId);
     const chain = contiguousChain(segments);
@@ -205,15 +252,13 @@ export class R2ChunkLog {
     await this.#deleteKeys(
       segments.filter((s) => !covered.has(s.key)).map((s) => s.key)
     );
-    const lines = await this.#readSegments(chain);
     const epoch = segments.reduce((max, s) => Math.max(max, s.epoch), -1) + 1;
-    const sink = new Sink(epoch, lines.length);
-    for (const line of lines) {
-      sink.lines.push(line);
-      sink.bytes += utf8.encode(line).byteLength;
-    }
+    const sink = new Sink(epoch, chain);
     this.#sinks.set(streamId, sink);
-    return lines.length;
+    // Stamps are throttled while live, so the row may lag the chain; the
+    // listing just paid for is the exact durable cursor.
+    this.#onDurable(streamId, sink.cursor);
+    return sink.cursor;
   }
 
   /**
@@ -228,10 +273,11 @@ export class R2ChunkLog {
       );
     }
     const line = `${chunkJson}\n`;
-    const seq = sink.lines.push(line) - 1;
-    sink.bytes += utf8.encode(line).byteLength;
+    const seq = sink.cursor;
+    sink.lines.push(line);
+    sink.lineBytes.push(utf8.encode(line).byteLength);
     sink.lastAppendAt = Date.now();
-    if (sink.lines.length - sink.flushedTo >= this.#every.everyChunks) {
+    if (sink.cursor - sink.flushedTo >= this.#every.everyChunks) {
       this.#checkpoint(streamId, sink);
     } else if (sink.timer === null) {
       sink.timer = setTimeout(
@@ -243,10 +289,10 @@ export class R2ChunkLog {
   }
 
   /**
-   * Settle: checkpoint what is left, wait for every segment to land, put
-   * the whole body as one exact-size object, then drop the segments. The
-   * memory log keeps serving readers throughout, and the segments stay
-   * readable until the body exists, so a death mid-settle loses nothing.
+   * Settle: checkpoint what is left, wait for every segment to land, write
+   * the body as one exact-size object, then drop the segments. Readers are
+   * served throughout, and the segments stay readable until the body
+   * exists, so a death mid-settle loses nothing.
    */
   settle(streamId: string): Promise<void> {
     const sink = this.#sinks.get(streamId);
@@ -258,13 +304,9 @@ export class R2ChunkLog {
     const done = (async () => {
       try {
         await sink.chain;
-        await this.#bucket.put(this.bodyKey(streamId), sink.lines.join(""), {
-          httpMetadata: { contentType: "application/x-ndjson" }
-        });
-        this.#onDurable(streamId, sink.lines.length);
-        await this.#deleteKeys(
-          (await this.#listSegments(streamId)).map((s) => s.key)
-        );
+        await this.#writeBody(streamId, sink);
+        this.#onDurable(streamId, sink.cursor);
+        await this.#deleteKeys(sink.landed.map((s) => s.key));
       } finally {
         sink.state = "done";
         this.#sinks.delete(streamId);
@@ -302,9 +344,11 @@ export class R2ChunkLog {
   // ── Reader ───────────────────────────────────────────────────────────────
 
   /**
-   * One page of chunks from `from`, in seq order: the memory log while the
-   * stream is in this isolate, else the settled body, else the segment
-   * chain (a stream whose producer died, or whose settlement was cut off).
+   * One page of chunks from `from`, in seq order. A live stream is served
+   * from memory at its tail and from landed segments further back; a
+   * settled stream from its body (cached whole when small, otherwise by
+   * line-offset index and ranged get); a stream whose producer died and
+   * has not resumed, from its segment chain.
    */
   async readPage(
     streamId: string,
@@ -312,61 +356,147 @@ export class R2ChunkLog {
     limit: number
   ): Promise<StreamChunkRow[]> {
     const sink = this.#sinks.get(streamId);
-    const lines = sink
-      ? sink.lines
-      : (this.#cached(streamId) ?? (await this.#load(streamId)));
-    const rows: StreamChunkRow[] = [];
-    for (let seq = from; seq < lines.length && rows.length < limit; seq++) {
-      rows.push({
-        stream_id: streamId,
-        seq,
-        chunk: lines[seq].slice(0, -1),
-        created_at: 0
-      });
-    }
-    return rows;
+    if (sink) return this.#readChain(streamId, sink.landed, sink, from, limit);
+    const body = await this.#body(streamId);
+    if (body) return this.#readFromBody(streamId, body, from, limit);
+    // No body: a dead producer's chain (its segments are still growing
+    // until it resumes, so the list is fresh every page).
+    const chain = contiguousChain(await this.#listSegments(streamId));
+    return this.#readChain(streamId, chain, null, from, limit);
   }
 
-  async #load(streamId: string): Promise<string[]> {
-    const body = await this.#bucket.get(this.bodyKey(streamId));
-    const lines = body
-      ? splitLines(await body.text())
-      : await this.#readSegments(
-          contiguousChain(await this.#listSegments(streamId))
+  /**
+   * Fill one page from landed segments and, for a live sink, from memory
+   * once `from` reaches its base. A page shorter than `limit` means the
+   * durable tail was reached, which is what the reader loop keys off.
+   */
+  async #readChain(
+    streamId: string,
+    segments: Segment[],
+    sink: Sink | null,
+    from: number,
+    limit: number
+  ): Promise<StreamChunkRow[]> {
+    const page: StreamChunkRow[] = [];
+    while (page.length < limit) {
+      if (sink && from >= sink.base) {
+        const offset = from - sink.base;
+        page.push(
+          ...rows(
+            streamId,
+            from,
+            sink.lines.slice(offset, offset + limit - page.length)
+          )
         );
-    // Only a settled body is final; a segment chain can still grow, so it
-    // is served fresh on every page and never cached.
-    if (body) this.#cacheSet(streamId, lines);
+        break;
+      }
+      const segment = segments.find((s) => s.from <= from && from < s.to);
+      if (!segment) break;
+      const lines = await this.#segmentLines(streamId, segment);
+      if (!lines) break;
+      const offset = from - segment.from;
+      const take = lines.slice(offset, offset + limit - page.length);
+      page.push(...rows(streamId, from, take));
+      from += take.length;
+      if (take.length === 0) break;
+    }
+    return page;
+  }
+
+  async #segmentLines(
+    streamId: string,
+    segment: Segment
+  ): Promise<string[] | null> {
+    const cacheKey = `${streamId}#${segment.key}`;
+    const cached = this.#cached<string[]>(cacheKey);
+    if (cached) return cached;
+    const object = await this.#bucket.get(segment.key);
+    if (!object) return null;
+    const lines = splitLines(await object.text());
+    this.#cacheSet(cacheKey, lines, segment.bytes);
     return lines;
   }
 
-  #cached(streamId: string): string[] | undefined {
-    const entry = this.#cache.get(streamId);
-    if (!entry) return undefined;
-    // Refresh recency: Map iteration order is insertion order.
-    this.#cache.delete(streamId);
-    this.#cache.set(streamId, entry);
-    return entry.lines;
+  async #body(streamId: string): Promise<Body | null> {
+    const cached = this.#cached<Body>(streamId);
+    if (cached) return cached;
+    const head = await this.#bucket.head(this.bodyKey(streamId));
+    if (!head) return null;
+    let body: Body;
+    if (head.size <= SMALL_BODY_BYTES) {
+      const object = await this.#bucket.get(this.bodyKey(streamId));
+      if (!object) return null;
+      body = {
+        kind: "small",
+        lines: splitLines(await object.text()),
+        bytes: head.size
+      };
+    } else {
+      const object = await this.#bucket.get(this.bodyKey(streamId));
+      if (!object) return null;
+      const offsets = await lineOffsets(object.body);
+      body = {
+        kind: "indexed",
+        offsets,
+        size: head.size,
+        bytes: offsets.length * 8
+      };
+    }
+    this.#cacheSet(streamId, body, body.bytes);
+    return body;
   }
 
-  #cacheSet(streamId: string, lines: string[]): void {
-    const bytes = lines.reduce((n, l) => n + l.length, 0);
+  async #readFromBody(
+    streamId: string,
+    body: Body,
+    from: number,
+    limit: number
+  ): Promise<StreamChunkRow[]> {
+    if (body.kind === "small") {
+      return rows(streamId, from, body.lines.slice(from, from + limit));
+    }
+    const count = body.offsets.length;
+    if (from >= count) return [];
+    const end = Math.min(count, from + limit);
+    const start = body.offsets[from];
+    const stop = end < count ? body.offsets[end] : body.size;
+    const object = await this.#bucket.get(this.bodyKey(streamId), {
+      range: { offset: start, length: stop - start }
+    });
+    if (!object) return [];
+    return rows(streamId, from, splitLines(await object.text()));
+  }
+
+  #cached<T>(key: string): T | undefined {
+    const entry = this.#cache.get(key);
+    if (!entry) return undefined;
+    // Refresh recency: Map iteration order is insertion order.
+    this.#cache.delete(key);
+    this.#cache.set(key, entry);
+    return entry.value as T;
+  }
+
+  #cacheSet(key: string, value: unknown, bytes: number): void {
     if (bytes > READ_CACHE_BYTES) return;
-    this.#uncache(streamId);
+    this.#uncache(key);
     while (this.#cacheBytes + bytes > READ_CACHE_BYTES && this.#cache.size) {
       const oldest = this.#cache.keys().next().value;
       if (oldest === undefined) break;
       this.#uncache(oldest);
     }
-    this.#cache.set(streamId, { lines, bytes });
+    this.#cache.set(key, { value, bytes });
     this.#cacheBytes += bytes;
   }
 
+  /** Drop a stream's body and any of its segments from the cache. */
   #uncache(streamId: string): void {
-    const entry = this.#cache.get(streamId);
-    if (!entry) return;
-    this.#cache.delete(streamId);
-    this.#cacheBytes -= entry.bytes;
+    for (const key of [...this.#cache.keys()]) {
+      if (key === streamId || key.startsWith(`${streamId}#`)) {
+        const entry = this.#cache.get(key);
+        if (entry) this.#cacheBytes -= entry.bytes;
+        this.#cache.delete(key);
+      }
+    }
   }
 
   // ── Segments ─────────────────────────────────────────────────────────────
@@ -377,27 +507,102 @@ export class R2ChunkLog {
       sink.timer = null;
     }
     const from = sink.flushedTo;
-    const to = sink.lines.length;
+    const to = sink.cursor;
     if (to === from) return;
     sink.flushedTo = to;
     const key = this.#segmentKey(streamId, sink.epoch, from, to);
-    const body = sink.lines.slice(from, to).join("");
+    const start = from - sink.base;
+    const body = sink.lines.slice(start, to - sink.base).join("");
+    let bytes = 0;
+    for (let i = start; i < to - sink.base; i++) bytes += sink.lineBytes[i];
     // Chained, so segments land in order and a slow put simply widens the
     // next segment instead of racing it; the durable cursor is monotone.
     sink.chain = sink.chain.then(async () => {
-      try {
-        await this.#bucket.put(key, body);
-      } catch {
-        // Not durable; the chain continues. The next segment's `from` is
-        // past this gap, so resume() stops the chain here, and the row is
-        // not stamped past it.
+      if (!(await this.#putWithRetry(key, body))) {
+        // Not durable. Fold the range back into the next checkpoint: the
+        // next segment starts here and the chain picker prefers the wider
+        // key, so nothing is skipped and nothing is evicted below it.
+        sink.flushedTo = Math.min(sink.flushedTo, from);
         return;
       }
-      if (sink.durable === from) {
-        sink.durable = to;
-        if (sink.state !== "done") this.#onDurable(streamId, to);
+      if (sink.durable !== from) return; // an earlier range failed
+      sink.durable = to;
+      sink.landed.push({ key, epoch: sink.epoch, from, to, bytes });
+      this.#evict(sink);
+      const now = Date.now();
+      if (
+        sink.state !== "done" &&
+        (sink.state === "settling" || now - sink.lastStampAt >= STAMP_EVERY_MS)
+      ) {
+        sink.lastStampAt = now;
+        this.#onDurable(streamId, to);
       }
     });
+  }
+
+  async #putWithRetry(key: string, body: string): Promise<boolean> {
+    for (let attempt = 1; ; attempt++) {
+      try {
+        await this.#bucket.put(key, body);
+        return true;
+      } catch {
+        if (attempt >= PUT_ATTEMPTS) return false;
+        await new Promise((r) => setTimeout(r, 200 * 4 ** (attempt - 1)));
+      }
+    }
+  }
+
+  /**
+   * Drop landed lines from memory beyond the hot window. Only durable
+   * lines are ever evicted, so a reader behind `base` always finds them
+   * in a landed segment.
+   */
+  #evict(sink: Sink): void {
+    let retained = 0;
+    for (let i = sink.durable - sink.base - 1; i >= 0; i--) {
+      retained += sink.lineBytes[i];
+      if (retained > HOT_WINDOW_BYTES) {
+        const drop = i + 1;
+        sink.lines.splice(0, drop);
+        sink.lineBytes.splice(0, drop);
+        sink.base += drop;
+        return;
+      }
+    }
+  }
+
+  /**
+   * The settled body. Everything still in memory is one put from memory;
+   * otherwise the landed segments are streamed back through one put of
+   * their known total size, so the body never has to fit in memory.
+   */
+  async #writeBody(streamId: string, sink: Sink): Promise<void> {
+    const meta = { httpMetadata: { contentType: "application/x-ndjson" } };
+    if (sink.base === 0) {
+      await this.#bucket.put(this.bodyKey(streamId), sink.lines.join(""), meta);
+      return;
+    }
+    const tail = sink.lines.slice(sink.durable - sink.base).join("");
+    const total =
+      sink.landed.reduce((n, s) => n + s.bytes, 0) +
+      utf8.encode(tail).byteLength;
+    const fixed = new FixedLengthStream(total);
+    const put = this.#bucket.put(this.bodyKey(streamId), fixed.readable, meta);
+    const writer = fixed.writable.getWriter();
+    try {
+      for (const segment of sink.landed) {
+        const object = await this.#bucket.get(segment.key);
+        if (!object) throw new Error(`segment ${segment.key} missing`);
+        for await (const chunk of object.body) await writer.write(chunk);
+      }
+      if (tail.length > 0) await writer.write(utf8.encode(tail));
+      await writer.close();
+    } catch (error) {
+      await writer.abort(error).catch(() => {});
+      await put.catch(() => {});
+      throw error;
+    }
+    await put;
   }
 
   async #listSegments(streamId: string): Promise<Segment[]> {
@@ -409,24 +614,12 @@ export class R2ChunkLog {
         cursor
       });
       for (const object of page.objects) {
-        const segment = this.#parseSegment(streamId, object.key);
+        const segment = this.#parseSegment(streamId, object.key, object.size);
         if (segment) segments.push(segment);
       }
       cursor = page.truncated ? page.cursor : undefined;
     } while (cursor);
     return segments;
-  }
-
-  async #readSegments(chain: Segment[]): Promise<string[]> {
-    const lines: string[] = [];
-    for (const segment of chain) {
-      const object = await this.#bucket.get(segment.key);
-      if (!object) break;
-      const got = splitLines(await object.text());
-      if (got.length !== segment.to - segment.from) break;
-      lines.push(...got);
-    }
-    return lines;
   }
 
   async #deleteKeys(keys: string[]): Promise<void> {
@@ -438,15 +631,19 @@ export class R2ChunkLog {
 
 /**
  * The longest chain of segments covering seq 0 upward without a gap. When
- * two epochs both cover a `from`, the newest epoch wins: it was written by
- * the generation that resumed from a chain that already included the
- * older one's durable prefix.
+ * several segments start at the same seq the newest epoch wins, then the
+ * widest: a resumed generation wrote past everything the older one made
+ * durable, and a re-flushed range supersedes the narrower put it replaced.
  */
 function contiguousChain(segments: Segment[]): Segment[] {
   const byFrom = new Map<number, Segment>();
   for (const segment of segments) {
     const current = byFrom.get(segment.from);
-    if (!current || segment.epoch > current.epoch) {
+    if (
+      !current ||
+      segment.epoch > current.epoch ||
+      (segment.epoch === current.epoch && segment.to > current.to)
+    ) {
       byFrom.set(segment.from, segment);
     }
   }
@@ -461,6 +658,19 @@ function contiguousChain(segments: Segment[]): Segment[] {
   return chain;
 }
 
+function rows(
+  streamId: string,
+  from: number,
+  lines: string[]
+): StreamChunkRow[] {
+  return lines.map((line, i) => ({
+    stream_id: streamId,
+    seq: from + i,
+    chunk: line.slice(0, -1),
+    created_at: 0
+  }));
+}
+
 function pad(n: number): string {
   return String(n).padStart(12, "0");
 }
@@ -472,9 +682,28 @@ function splitLines(text: string): string[] {
   for (;;) {
     const end = text.indexOf("\n", start);
     if (end === -1) break;
-    const line = text.slice(start, end);
-    if (line.trim().length > 0) lines.push(`${line}\n`);
+    lines.push(text.slice(start, end + 1));
     start = end + 1;
   }
   return lines;
+}
+
+/** Byte offset of every line start, from one streaming scan of the body. */
+async function lineOffsets(
+  body: ReadableStream<Uint8Array>
+): Promise<number[]> {
+  const offsets: number[] = [];
+  let position = 0;
+  let atLineStart = true;
+  for await (const chunk of body) {
+    for (let i = 0; i < chunk.length; i++) {
+      if (atLineStart) {
+        offsets.push(position + i);
+        atLineStart = false;
+      }
+      if (chunk[i] === 0x0a) atLineStart = true;
+    }
+    position += chunk.length;
+  }
+  return offsets;
 }

--- a/packages/agents/src/streams/r2-log.ts
+++ b/packages/agents/src/streams/r2-log.ts
@@ -1,0 +1,480 @@
+/**
+ * R2 chunk log for the Streams capability: a write-ahead log of segment
+ * objects. Configured with `new Streams({ r2: env.BUCKET })`, chunks leave
+ * DO SQLite for R2; the stream row (state, tag index, metadata, cursor)
+ * stays in SQLite, where a point read or tag lookup costs nothing.
+ *
+ * Why segments, measured on real R2 (2026-09-03): R2 has no append, a
+ * `put()` of unknown length is rejected, and a put that has not completed
+ * stores nothing. The only way to continuously save a stream is to put a
+ * small object every so often. So:
+ *
+ * - `append()` is synchronous into an in-memory line log that live readers
+ *   tail (the same in-isolate wakeups the SQLite log uses).
+ * - Every `everyChunks` appends or `everyMs` after the first unflushed one,
+ *   the new lines are put as one immutable segment
+ *   `<prefix><id>/seg/<epoch>/<from>-<to>`. Each landed segment is the
+ *   durability: when the isolate dies, everything up to the last landed
+ *   segment is in R2 and the loss window is the cadence.
+ * - The stream row's cursor is stamped only after a segment's put resolves,
+ *   so `status()` never reports more than R2 holds.
+ * - `open()` on a stream whose isolate died rebuilds the log from the
+ *   contiguous segment chain, starts a new epoch, and deletes keys the chain
+ *   does not cover (deletes are free), so a later generation can never be
+ *   spliced with a discarded one.
+ * - Settlement puts the whole body as one exact-size object
+ *   `<prefix><id>/body` so replay is a single get, then drops the segments.
+ *   The segments stay readable until the body lands; a death mid-settle
+ *   loses nothing.
+ *
+ * Cost: one Class A op per checkpoint, none per chunk. One R2 put costs
+ * the same as 4.5 billed SQLite row writes, so this log is cheaper than the
+ * SQLite log whenever a checkpoint covers more than ~4.5 stored rows.
+ */
+
+import type { StreamChunkRow } from "./types";
+
+/** Checkpoint cadence: the loss window when the isolate dies. */
+export interface R2CheckpointOptions {
+  /** Put a segment after this many appends. Default: 25. */
+  readonly everyChunks?: number;
+  /** ...or this long after the first unflushed append. Default: 1000. */
+  readonly everyMs?: number;
+}
+
+export const DEFAULT_CHECKPOINT: Required<R2CheckpointOptions> = {
+  everyChunks: 25,
+  everyMs: 1000
+};
+
+/** Parsed bodies kept in memory for replaying settled streams. */
+const READ_CACHE_BYTES = 8 * 1024 * 1024;
+/** R2 bulk delete accepts at most this many keys per call. */
+const DELETE_BATCH = 1000;
+
+const utf8 = new TextEncoder();
+
+/** @internal Tunables for the R2 chunk log. */
+export interface R2LogOptions {
+  bucket: R2Bucket;
+  /** Key prefix for every object the log writes. Default: `streams/`. */
+  prefix?: string;
+  checkpoint?: R2CheckpointOptions;
+  /** A segment landed: `cursor` chunks are durable. Monotone, keep the max. */
+  onDurable: (streamId: string, cursor: number) => void;
+}
+
+/** One live (or settling) stream's memory log. */
+class Sink {
+  readonly lines: string[] = [];
+  bytes = 0;
+  /** First seq not yet handed to a segment put. */
+  flushedTo: number;
+  /** Highest seq (exclusive) whose segment put has resolved. */
+  durable: number;
+  timer: ReturnType<typeof setTimeout> | null = null;
+  /** Segment puts in flight, chained so they land in order. */
+  chain: Promise<void> = Promise.resolve();
+  lastAppendAt: number | null = null;
+  state: "streaming" | "settling" | "done" = "streaming";
+
+  constructor(
+    readonly epoch: number,
+    recovered: number
+  ) {
+    this.flushedTo = recovered;
+    this.durable = recovered;
+  }
+}
+
+type Segment = { key: string; epoch: number; from: number; to: number };
+
+export class R2ChunkLog {
+  readonly #bucket: R2Bucket;
+  readonly #prefix: string;
+  readonly #every: Required<R2CheckpointOptions>;
+  readonly #onDurable: R2LogOptions["onDurable"];
+  readonly #sinks = new Map<string, Sink>();
+  /** Settlements in flight, awaitable through `flush()`. */
+  readonly #settling = new Map<string, Promise<void>>();
+  /** Replay cache: stream id → lines, LRU by insertion order, byte-bounded. */
+  readonly #cache = new Map<string, { lines: string[]; bytes: number }>();
+  #cacheBytes = 0;
+
+  constructor(options: R2LogOptions) {
+    this.#bucket = options.bucket;
+    this.#prefix = options.prefix ?? "streams/";
+    this.#every = {
+      everyChunks: Math.max(
+        1,
+        options.checkpoint?.everyChunks ?? DEFAULT_CHECKPOINT.everyChunks
+      ),
+      everyMs: Math.max(
+        0,
+        options.checkpoint?.everyMs ?? DEFAULT_CHECKPOINT.everyMs
+      )
+    };
+    this.#onDurable = options.onDurable;
+  }
+
+  // ── Keys ─────────────────────────────────────────────────────────────────
+
+  #streamPrefix(streamId: string): string {
+    return `${this.#prefix}${encodeURIComponent(streamId)}/`;
+  }
+
+  /** The settled body: one exact-size NDJSON object. */
+  bodyKey(streamId: string): string {
+    return `${this.#streamPrefix(streamId)}body`;
+  }
+
+  #segmentPrefix(streamId: string): string {
+    return `${this.#streamPrefix(streamId)}seg/`;
+  }
+
+  #segmentKey(
+    streamId: string,
+    epoch: number,
+    from: number,
+    to: number
+  ): string {
+    return `${this.#segmentPrefix(streamId)}${pad(epoch)}/${pad(from)}-${pad(to)}`;
+  }
+
+  #parseSegment(streamId: string, key: string): Segment | null {
+    const rest = key.slice(this.#segmentPrefix(streamId).length);
+    const match = /^(\d+)\/(\d+)-(\d+)$/.exec(rest);
+    if (!match) return null;
+    return {
+      key,
+      epoch: Number(match[1]),
+      from: Number(match[2]),
+      to: Number(match[3])
+    };
+  }
+
+  // ── Producer ─────────────────────────────────────────────────────────────
+
+  /** True when this isolate holds the stream's log. */
+  has(streamId: string): boolean {
+    return this.#sinks.has(streamId);
+  }
+
+  /**
+   * True while this isolate's log accepts appends: a sink exists in
+   * `streaming` state only between open() and settle, so the producer's
+   * hot path needs no stream-row read to prove liveness.
+   */
+  isLive(streamId: string): boolean {
+    return this.#sinks.get(streamId)?.state === "streaming";
+  }
+
+  /** The live cursor, or undefined when the stream is not in memory. */
+  cursor(streamId: string): number | undefined {
+    return this.#sinks.get(streamId)?.lines.length;
+  }
+
+  /** Chunks known to have landed in R2, or undefined when not in memory. */
+  durableCursor(streamId: string): number | undefined {
+    return this.#sinks.get(streamId)?.durable;
+  }
+
+  lastAppendAt(streamId: string): number | null {
+    return this.#sinks.get(streamId)?.lastAppendAt ?? null;
+  }
+
+  /** Start a fresh stream: an empty memory log, epoch 0. */
+  open(streamId: string): void {
+    this.#uncache(streamId);
+    this.#sinks.set(streamId, new Sink(0, 0));
+  }
+
+  /**
+   * Resume a stream whose producer's isolate is gone: rebuild the memory
+   * log from the contiguous segment chain, delete every key the chain does
+   * not cover (a discarded generation must never be spliced back in), and
+   * continue in a new epoch. Returns the recovered cursor.
+   */
+  async resume(streamId: string): Promise<number> {
+    const existing = this.#sinks.get(streamId);
+    if (existing) return existing.lines.length;
+    this.#uncache(streamId);
+    const segments = await this.#listSegments(streamId);
+    const chain = contiguousChain(segments);
+    const covered = new Set(chain.map((s) => s.key));
+    await this.#deleteKeys(
+      segments.filter((s) => !covered.has(s.key)).map((s) => s.key)
+    );
+    const lines = await this.#readSegments(chain);
+    const epoch = segments.reduce((max, s) => Math.max(max, s.epoch), -1) + 1;
+    const sink = new Sink(epoch, lines.length);
+    for (const line of lines) {
+      sink.lines.push(line);
+      sink.bytes += utf8.encode(line).byteLength;
+    }
+    this.#sinks.set(streamId, sink);
+    return lines.length;
+  }
+
+  /**
+   * Append one serialized chunk. Synchronous: the memory log is the
+   * in-isolate truth; the segment put is batched by the cadence.
+   */
+  append(streamId: string, chunkJson: string): number {
+    const sink = this.#sinks.get(streamId);
+    if (!sink || sink.state !== "streaming") {
+      throw new Error(
+        `Stream "${streamId}" is not open in this isolate; call open() first`
+      );
+    }
+    const line = `${chunkJson}\n`;
+    const seq = sink.lines.push(line) - 1;
+    sink.bytes += utf8.encode(line).byteLength;
+    sink.lastAppendAt = Date.now();
+    if (sink.lines.length - sink.flushedTo >= this.#every.everyChunks) {
+      this.#checkpoint(streamId, sink);
+    } else if (sink.timer === null) {
+      sink.timer = setTimeout(
+        () => this.#checkpoint(streamId, sink),
+        this.#every.everyMs
+      );
+    }
+    return seq;
+  }
+
+  /**
+   * Settle: checkpoint what is left, wait for every segment to land, put
+   * the whole body as one exact-size object, then drop the segments. The
+   * memory log keeps serving readers throughout, and the segments stay
+   * readable until the body exists, so a death mid-settle loses nothing.
+   */
+  settle(streamId: string): Promise<void> {
+    const sink = this.#sinks.get(streamId);
+    if (!sink || sink.state !== "streaming") {
+      return this.#settling.get(streamId) ?? Promise.resolve();
+    }
+    sink.state = "settling";
+    this.#checkpoint(streamId, sink);
+    const done = (async () => {
+      try {
+        await sink.chain;
+        await this.#bucket.put(this.bodyKey(streamId), sink.lines.join(""), {
+          httpMetadata: { contentType: "application/x-ndjson" }
+        });
+        this.#onDurable(streamId, sink.lines.length);
+        await this.#deleteKeys(
+          (await this.#listSegments(streamId)).map((s) => s.key)
+        );
+      } finally {
+        sink.state = "done";
+        this.#sinks.delete(streamId);
+        this.#settling.delete(streamId);
+      }
+    })();
+    this.#settling.set(streamId, done);
+    return done;
+  }
+
+  /** Every settlement still in flight (one stream, or all). */
+  flush(streamId?: string): Promise<void> {
+    if (streamId !== undefined) {
+      return this.#settling.get(streamId) ?? Promise.resolve();
+    }
+    return Promise.all(this.#settling.values()).then(() => undefined);
+  }
+
+  /** Remove every object of a stream. Deletes are free. */
+  async delete(streamId: string): Promise<void> {
+    const sink = this.#sinks.get(streamId);
+    if (sink) {
+      if (sink.timer !== null) clearTimeout(sink.timer);
+      sink.state = "done";
+      this.#sinks.delete(streamId);
+      await sink.chain;
+    }
+    this.#uncache(streamId);
+    await this.#deleteKeys([
+      this.bodyKey(streamId),
+      ...(await this.#listSegments(streamId)).map((s) => s.key)
+    ]);
+  }
+
+  // ── Reader ───────────────────────────────────────────────────────────────
+
+  /**
+   * One page of chunks from `from`, in seq order: the memory log while the
+   * stream is in this isolate, else the settled body, else the segment
+   * chain (a stream whose producer died, or whose settlement was cut off).
+   */
+  async readPage(
+    streamId: string,
+    from: number,
+    limit: number
+  ): Promise<StreamChunkRow[]> {
+    const sink = this.#sinks.get(streamId);
+    const lines = sink
+      ? sink.lines
+      : (this.#cached(streamId) ?? (await this.#load(streamId)));
+    const rows: StreamChunkRow[] = [];
+    for (let seq = from; seq < lines.length && rows.length < limit; seq++) {
+      rows.push({
+        stream_id: streamId,
+        seq,
+        chunk: lines[seq].slice(0, -1),
+        created_at: 0
+      });
+    }
+    return rows;
+  }
+
+  async #load(streamId: string): Promise<string[]> {
+    const body = await this.#bucket.get(this.bodyKey(streamId));
+    const lines = body
+      ? splitLines(await body.text())
+      : await this.#readSegments(
+          contiguousChain(await this.#listSegments(streamId))
+        );
+    // Only a settled body is final; a segment chain can still grow, so it
+    // is served fresh on every page and never cached.
+    if (body) this.#cacheSet(streamId, lines);
+    return lines;
+  }
+
+  #cached(streamId: string): string[] | undefined {
+    const entry = this.#cache.get(streamId);
+    if (!entry) return undefined;
+    // Refresh recency: Map iteration order is insertion order.
+    this.#cache.delete(streamId);
+    this.#cache.set(streamId, entry);
+    return entry.lines;
+  }
+
+  #cacheSet(streamId: string, lines: string[]): void {
+    const bytes = lines.reduce((n, l) => n + l.length, 0);
+    if (bytes > READ_CACHE_BYTES) return;
+    this.#uncache(streamId);
+    while (this.#cacheBytes + bytes > READ_CACHE_BYTES && this.#cache.size) {
+      const oldest = this.#cache.keys().next().value;
+      if (oldest === undefined) break;
+      this.#uncache(oldest);
+    }
+    this.#cache.set(streamId, { lines, bytes });
+    this.#cacheBytes += bytes;
+  }
+
+  #uncache(streamId: string): void {
+    const entry = this.#cache.get(streamId);
+    if (!entry) return;
+    this.#cache.delete(streamId);
+    this.#cacheBytes -= entry.bytes;
+  }
+
+  // ── Segments ─────────────────────────────────────────────────────────────
+
+  #checkpoint(streamId: string, sink: Sink): void {
+    if (sink.timer !== null) {
+      clearTimeout(sink.timer);
+      sink.timer = null;
+    }
+    const from = sink.flushedTo;
+    const to = sink.lines.length;
+    if (to === from) return;
+    sink.flushedTo = to;
+    const key = this.#segmentKey(streamId, sink.epoch, from, to);
+    const body = sink.lines.slice(from, to).join("");
+    // Chained, so segments land in order and a slow put simply widens the
+    // next segment instead of racing it; the durable cursor is monotone.
+    sink.chain = sink.chain.then(async () => {
+      try {
+        await this.#bucket.put(key, body);
+      } catch {
+        // Not durable; the chain continues. The next segment's `from` is
+        // past this gap, so resume() stops the chain here, and the row is
+        // not stamped past it.
+        return;
+      }
+      if (sink.durable === from) {
+        sink.durable = to;
+        if (sink.state !== "done") this.#onDurable(streamId, to);
+      }
+    });
+  }
+
+  async #listSegments(streamId: string): Promise<Segment[]> {
+    const segments: Segment[] = [];
+    let cursor: string | undefined;
+    do {
+      const page = await this.#bucket.list({
+        prefix: this.#segmentPrefix(streamId),
+        cursor
+      });
+      for (const object of page.objects) {
+        const segment = this.#parseSegment(streamId, object.key);
+        if (segment) segments.push(segment);
+      }
+      cursor = page.truncated ? page.cursor : undefined;
+    } while (cursor);
+    return segments;
+  }
+
+  async #readSegments(chain: Segment[]): Promise<string[]> {
+    const lines: string[] = [];
+    for (const segment of chain) {
+      const object = await this.#bucket.get(segment.key);
+      if (!object) break;
+      const got = splitLines(await object.text());
+      if (got.length !== segment.to - segment.from) break;
+      lines.push(...got);
+    }
+    return lines;
+  }
+
+  async #deleteKeys(keys: string[]): Promise<void> {
+    for (let i = 0; i < keys.length; i += DELETE_BATCH) {
+      await this.#bucket.delete(keys.slice(i, i + DELETE_BATCH));
+    }
+  }
+}
+
+/**
+ * The longest chain of segments covering seq 0 upward without a gap. When
+ * two epochs both cover a `from`, the newest epoch wins: it was written by
+ * the generation that resumed from a chain that already included the
+ * older one's durable prefix.
+ */
+function contiguousChain(segments: Segment[]): Segment[] {
+  const byFrom = new Map<number, Segment>();
+  for (const segment of segments) {
+    const current = byFrom.get(segment.from);
+    if (!current || segment.epoch > current.epoch) {
+      byFrom.set(segment.from, segment);
+    }
+  }
+  const chain: Segment[] = [];
+  let next = 0;
+  for (;;) {
+    const segment = byFrom.get(next);
+    if (!segment || segment.to <= segment.from) break;
+    chain.push(segment);
+    next = segment.to;
+  }
+  return chain;
+}
+
+function pad(n: number): string {
+  return String(n).padStart(12, "0");
+}
+
+/** NDJSON body → lines with their trailing newline. */
+function splitLines(text: string): string[] {
+  const lines: string[] = [];
+  let start = 0;
+  for (;;) {
+    const end = text.indexOf("\n", start);
+    if (end === -1) break;
+    const line = text.slice(start, end);
+    if (line.trim().length > 0) lines.push(`${line}\n`);
+    start = end + 1;
+  }
+  return lines;
+}

--- a/packages/agents/src/streams/streams.ts
+++ b/packages/agents/src/streams/streams.ts
@@ -15,6 +15,7 @@
 
 import { LifecycleCapability } from "../lifecycle/capability";
 import { SqlError } from "../sql-error";
+import { R2ChunkLog, type R2CheckpointOptions } from "./r2-log";
 import {
   StreamClosedError,
   StreamNotFoundError,
@@ -54,6 +55,28 @@ const utf8 = new TextEncoder();
 export interface StreamsOptions {
   /** Ceiling for one serialized chunk. Default: 1 MiB. */
   readonly maxChunkBytes?: number;
+  /**
+   * Store chunk logs in this R2 bucket instead of DO SQLite. Stream rows
+   * (state, tag index, metadata, cursor) stay in SQLite; each stream's
+   * chunks become one NDJSON object under `r2Prefix`, streamed while the
+   * producer appends and checkpointed to a write-ahead log so a producer
+   * that dies mid-stream still leaves its chunks in R2. See
+   * `docs/agents/streams.md`.
+   */
+  readonly r2?: R2Bucket;
+  /**
+   * Key prefix for objects written to `r2`. Default: `streams/`. Include
+   * the Durable Object's id when several objects share one bucket, or
+   * their stream ids collide.
+   */
+  readonly r2Prefix?: string;
+  /**
+   * How often the R2 log checkpoints a segment: the loss window when the
+   * isolate dies. Default: every 25 chunks or 1 s, whichever first. Each
+   * checkpoint is one R2 Class A op, so widen it to trade durability for
+   * cost.
+   */
+  readonly r2Checkpoint?: R2CheckpointOptions;
 }
 
 /**
@@ -145,12 +168,32 @@ export interface StreamsSyncInternal {
  */
 export class Streams extends LifecycleCapability {
   readonly #maxChunkBytes: number;
+  /** The R2 chunk log when configured; chunks live in SQLite otherwise. */
+  readonly #r2: R2ChunkLog | null;
   /** Wakeup callbacks for readers tailing a live stream, per stream. */
   readonly #wakeups = new Map<string, Set<() => void>>();
 
   constructor(options: StreamsOptions = {}) {
     super("streams");
     this.#maxChunkBytes = options.maxChunkBytes ?? DEFAULT_MAX_CHUNK_BYTES;
+    this.#r2 = options.r2
+      ? new R2ChunkLog({
+          bucket: options.r2,
+          prefix: options.r2Prefix,
+          checkpoint: options.r2Checkpoint,
+          // The durable cursor: stamped once per landed segment (never per
+          // append) and once more when the settled body lands. Puts can
+          // resolve out of order, so the stamp is monotone.
+          onDurable: (streamId, cursor) => {
+            this.#sqlWrite(
+              `UPDATE cf_agents_streams
+               SET chunk_count = MAX(chunk_count, ?)
+               WHERE stream_id = ?`,
+              [cursor, streamId]
+            );
+          }
+        })
+      : null;
   }
 
   // ── Lifecycle capability hooks ───────────────────────────────────────────
@@ -200,6 +243,12 @@ export class Streams extends LifecycleCapability {
           `Stream "${streamId}" is already open with tag ${JSON.stringify(existing.tag)}; refusing reopen with tag ${JSON.stringify(options.tag)}`
         );
       }
+      // A live row with no log in this isolate is a producer that died
+      // elsewhere: rebuild the log from the R2 write-ahead log so the
+      // returned writer's cursor is exactly what was made durable.
+      if (this.#r2 && !this.#r2.has(streamId)) {
+        await this.#r2.resume(streamId);
+      }
       return this.#writer(streamId);
     }
 
@@ -214,8 +263,20 @@ export class Streams extends LifecycleCapability {
       VALUES
         (${streamId}, 'streaming', ${options.tag ?? null}, ${metadataJson}, 0, ${now}, ${now})
     `;
+    this.#r2?.open(streamId);
     this.#emit("stream:opened", { streamId });
     return this.#writer(streamId);
+  }
+
+  /**
+   * Wait for settlement to become durable. With the R2 chunk log a
+   * `close()`/`error()` finishes the stream's file and drops its
+   * write-ahead log in the background; this resolves when that is done.
+   * Resolves immediately on the SQLite log, where settlement is the
+   * synchronous UPDATE itself.
+   */
+  flush(streamId?: string): Promise<void> {
+    return this.#r2?.flush(streamId) ?? Promise.resolve();
   }
 
   // ── Consumer surface ─────────────────────────────────────────────────────
@@ -270,7 +331,9 @@ export class Streams extends LifecycleCapability {
     for (;;) {
       if (signal?.aborted) throw signal.reason ?? new Error("Read aborted");
 
-      const rows = this.#sql<StreamChunkRow>`
+      const rows = this.#r2
+        ? await this.#r2.readPage(streamId, next, batchSize)
+        : this.#sql<StreamChunkRow>`
         SELECT stream_id, seq, chunk, created_at FROM cf_agents_stream_chunks
         WHERE stream_id = ${streamId} AND seq >= ${next}
         ORDER BY seq ASC
@@ -299,7 +362,7 @@ export class Streams extends LifecycleCapability {
         continue;
       }
 
-      const state = this.#state(streamId);
+      const state = this.#liveState(streamId);
       if (state === undefined) return; // deleted mid-read: nothing further
       if (state !== "streaming") {
         // Terminal. Appends happen-before settlement (the append fence
@@ -369,9 +432,13 @@ export class Streams extends LifecycleCapability {
         `Cannot delete live stream "${streamId}"; close() or error() it first`
       );
     }
-    this.#sql`
-      DELETE FROM cf_agents_stream_chunks WHERE stream_id = ${streamId}
-    `;
+    if (this.#r2) {
+      await this.#r2.delete(streamId);
+    } else {
+      this.#sql`
+        DELETE FROM cf_agents_stream_chunks WHERE stream_id = ${streamId}
+      `;
+    }
     this.#sql`DELETE FROM cf_agents_streams WHERE stream_id = ${streamId}`;
     this.#emit("stream:deleted", { streamId });
     return true;
@@ -390,6 +457,11 @@ export class Streams extends LifecycleCapability {
    * break without notice; never use from application code.
    */
   __DO_NOT_USE_WILL_BREAK__sync(): StreamsSyncInternal {
+    if (this.#r2) {
+      throw new Error(
+        "Streams: the synchronous storage aperture is SQLite-only; it is not available with the R2 chunk log"
+      );
+    }
     return {
       ensureTables: () => this.#ensureTables(),
       getStream: (streamId) => this.#getStream(streamId),
@@ -517,18 +589,23 @@ export class Streams extends LifecycleCapability {
     // here and the INSERT may await or call user code — either would
     // reintroduce the lost-update races the old guarded-UPDATE fence
     // prevented, at the cost of one stream-row write per append.
-    const state = this.#state(streamId);
+    const state = this.#liveState(streamId);
     if (state !== "streaming") {
       throw new StreamClosedError(
         streamId,
         state !== undefined ? `already settled as ${state}` : "it was deleted"
       );
     }
-    const seq = this.#tail(streamId).nextSeq;
-    this.#sql`
-      INSERT INTO cf_agents_stream_chunks (stream_id, seq, chunk, created_at)
-      VALUES (${streamId}, ${seq}, ${chunkJson}, ${Date.now()})
-    `;
+    let seq: number;
+    if (this.#r2) {
+      seq = this.#r2.append(streamId, chunkJson);
+    } else {
+      seq = this.#tail(streamId).nextSeq;
+      this.#sql`
+        INSERT INTO cf_agents_stream_chunks (stream_id, seq, chunk, created_at)
+        VALUES (${streamId}, ${seq}, ${chunkJson}, ${Date.now()})
+      `;
+    }
     this.#wake(streamId);
     return seq;
   }
@@ -543,7 +620,11 @@ export class Streams extends LifecycleCapability {
     // from the chunk log's tail in the same synchronous block. While the
     // stream was live, appends wrote only the chunk log — the row's
     // chunk_count and updated_at were not maintained per append.
-    const finalCursor = this.#tail(streamId).nextSeq;
+    // With the R2 log the row must not claim more than R2 holds: settle
+    // stamps the durable cursor, and the log stamps the final one when the
+    // settled body lands (`flush()` awaits it).
+    const finalCursor =
+      this.#r2?.durableCursor(streamId) ?? this.#tail(streamId).nextSeq;
     const settled = this.#sqlWrite(
       `UPDATE cf_agents_streams
        SET state = ?, error_message = ?, closed_at = ?, updated_at = ?,
@@ -552,6 +633,9 @@ export class Streams extends LifecycleCapability {
       [state, reason, Date.now(), Date.now(), finalCursor, streamId]
     );
     if (settled > 0) {
+      // The row is terminal now; the R2 file and WAL cleanup finish in the
+      // background (`flush()` awaits them) while memory keeps serving reads.
+      void this.#r2?.settle(streamId);
       this.#emit(state === "completed" ? "stream:closed" : "stream:errored", {
         streamId,
         ...(reason !== null ? { reason } : {})
@@ -671,6 +755,17 @@ export class Streams extends LifecycleCapability {
    * reader loop's liveness checks, which need neither the metadata column
    * nor the (live-stale) counters of the full row.
    */
+  /**
+   * `#state` for the hot paths (append fence, live-tail loop), answered
+   * from memory when the R2 log holds the stream live: rows read are
+   * billed, and a per-append row read is the one SQLite touch the R2
+   * backend would otherwise keep on every chunk.
+   */
+  #liveState(streamId: string): StreamState | undefined {
+    if (this.#r2?.isLive(streamId)) return "streaming";
+    return this.#state(streamId);
+  }
+
   #state(streamId: string): StreamState | undefined {
     const rows = this.#sql<{ state: StreamState }>`
       SELECT state FROM cf_agents_streams WHERE stream_id = ${streamId}
@@ -686,6 +781,22 @@ export class Streams extends LifecycleCapability {
    * the stream row's `chunk_count`/`updated_at` are not maintained.
    */
   #tail(streamId: string): { nextSeq: number; lastChunkAt: number | null } {
+    if (this.#r2) {
+      // Live in this isolate: the memory log. Otherwise the row's
+      // chunk_count, stamped at every WAL checkpoint and at settle — the
+      // durable cursor, which is what a resumed producer must start from.
+      const cursor = this.#r2.cursor(streamId);
+      if (cursor !== undefined) {
+        return {
+          nextSeq: cursor,
+          lastChunkAt: this.#r2.lastAppendAt(streamId)
+        };
+      }
+      const rows = this.#sql<{ chunk_count: number }>`
+        SELECT chunk_count FROM cf_agents_streams WHERE stream_id = ${streamId}
+      `;
+      return { nextSeq: rows[0]?.chunk_count ?? 0, lastChunkAt: null };
+    }
     const rows = this.#sql<{ seq: number; created_at: number }>`
       SELECT seq, created_at FROM cf_agents_stream_chunks
       WHERE stream_id = ${streamId}

--- a/packages/agents/src/streams/streams.ts
+++ b/packages/agents/src/streams/streams.ts
@@ -456,6 +456,11 @@ export class Streams extends LifecycleCapability {
    * diagnostics observe aperture writes exactly like capability writes. Will
    * break without notice; never use from application code.
    */
+  /** @internal The R2 chunk log when configured (tests). */
+  __DO_NOT_USE_WILL_BREAK__r2(): R2ChunkLog | null {
+    return this.#r2;
+  }
+
   __DO_NOT_USE_WILL_BREAK__sync(): StreamsSyncInternal {
     if (this.#r2) {
       throw new Error(

--- a/packages/agents/src/tests/capabilities/streams.ts
+++ b/packages/agents/src/tests/capabilities/streams.ts
@@ -16,6 +16,19 @@ export class StreamHarnessObject extends DurableObject<Cloudflare.Env> {
 }
 
 /**
+ * The same minimal host with the chunk log in R2: `new Streams({ r2 })`.
+ * Stream rows stay in this object's SQLite; chunks go to the bucket.
+ */
+export class R2StreamHarnessObject extends DurableObject<Cloudflare.Env> {
+  readonly streams = new Streams({
+    maxChunkBytes: 1024,
+    r2: this.env.STREAMS_R2,
+    r2Prefix: `t/${this.ctx.id.toString().slice(0, 12)}/`
+  });
+  readonly lifecycle = Lifecycle.install(this).use(this.streams);
+}
+
+/**
  * Streams and Tasks composed on one Lifecycle, exercising the contract the
  * RFC names: a task step appends to a stream it does not own, and a replay
  * after unclean interruption resumes from the stream's own durable cursor —

--- a/packages/agents/src/tests/streams/r2-backend.test.ts
+++ b/packages/agents/src/tests/streams/r2-backend.test.ts
@@ -196,9 +196,14 @@ describe("Streams on R2", () => {
       const lifecycle = Lifecycle.install(instance).use(restarted);
       await lifecycle.start();
 
-      expect((await restarted.status("dead"))?.cursor).toBe(50);
+      // The row's cursor is stamped at most every few seconds while live,
+      // so before resume it is a lower bound on what R2 holds.
+      const before = (await restarted.status("dead"))?.cursor ?? -1;
+      expect(before).toBeGreaterThanOrEqual(25);
+      expect(before).toBeLessThanOrEqual(50);
       const resumed = await restarted.open("dead");
       expect(resumed.cursor).toBe(50);
+      expect((await restarted.status("dead"))?.cursor).toBe(50);
       for (let i = 50; i < 55; i++) expect(resumed.append({ i })).toBe(i);
       resumed.close();
       await restarted.flush("dead");
@@ -243,6 +248,44 @@ describe("Streams on R2", () => {
       expect(all[59].chunk).toEqual({ i: 59 });
       // Two epochs wrote segments; the settled body replaced them all.
       expect(await objects(`${prefix}early/seg/`)).toEqual([]);
+    });
+  });
+
+  it("holds only a hot window in memory; readers behind it read segments", async () => {
+    const stub = env.R2StreamHarnessObject.getByName(crypto.randomUUID());
+    await runInDurableObject(stub, async (instance: R2StreamHarnessObject) => {
+      const log = instance.streams.__DO_NOT_USE_WILL_BREAK__r2();
+      const stream = await instance.streams.open("big");
+      const total = 2000; // ~1 MB of 500 B chunks, 80 segments
+      const tail = collect(instance.streams.read("big"));
+      for (let i = 0; i < total; i++) {
+        stream.append({ i, pad: "x".repeat(480) });
+        // Let segment puts land and evict as the producer goes.
+        if (i % 100 === 99) await new Promise((r) => setTimeout(r, 20));
+      }
+      await new Promise((r) => setTimeout(r, 100));
+      const inMemory = log?.memoryLines("big") ?? total;
+      expect(inMemory).toBeLessThan(total / 2);
+      // A reader far behind the window is served from landed segments.
+      const behind = await replayToTail(instance.streams, "big");
+      expect(behind.length).toBe(total);
+      expect(behind[0].chunk).toMatchObject({ i: 0 });
+      stream.close();
+      expect((await tail).length).toBe(total);
+      await instance.streams.flush("big");
+      // The body was streamed back from segments (nothing in memory held
+      // it) and replays whole; it is over the small-body limit, so pages
+      // come from the line-offset index with ranged gets.
+      const status = await instance.streams.status("big");
+      expect(status?.cursor).toBe(total);
+      const fromMid = await collect(
+        instance.streams.read("big", { from: 1234 })
+      );
+      expect(fromMid.length).toBe(total - 1234);
+      expect(fromMid[0]).toMatchObject({ seq: 1234, chunk: { i: 1234 } });
+      expect(fromMid[fromMid.length - 1].chunk).toMatchObject({
+        i: total - 1
+      });
     });
   });
 

--- a/packages/agents/src/tests/streams/r2-backend.test.ts
+++ b/packages/agents/src/tests/streams/r2-backend.test.ts
@@ -1,0 +1,325 @@
+import { env } from "cloudflare:workers";
+import { runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import type { R2StreamHarnessObject } from "../capabilities/streams";
+import { Streams, type StreamChunk } from "../../streams";
+
+/**
+ * Streams with the chunk log in R2 (`new Streams({ r2 })`): the public API
+ * behaves exactly like the SQLite log — same cursors, replay, live tail,
+ * settlement — while the chunks land in the bucket as one NDJSON file per
+ * stream, checkpointed to a write-ahead log until the file is durable.
+ */
+
+async function collect(
+  iterator: AsyncGenerator<StreamChunk, void, undefined>
+): Promise<StreamChunk[]> {
+  const chunks: StreamChunk[] = [];
+  for await (const chunk of iterator) chunks.push(chunk);
+  return chunks;
+}
+
+async function objects(
+  prefix: string
+): Promise<{ key: string; size: number }[]> {
+  const list = await env.STREAMS_R2.list({ prefix });
+  return list.objects.map((o) => ({ key: o.key, size: o.size }));
+}
+
+async function fileLines(key: string): Promise<string[]> {
+  const object = await env.STREAMS_R2.get(key);
+  if (!object) return [];
+  return (await object.text())
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+}
+
+/** Replay everything durable right now, without tailing a live stream. */
+async function replayToTail(
+  streams: Streams,
+  streamId: string
+): Promise<StreamChunk[]> {
+  const abort = new AbortController();
+  const chunks: StreamChunk[] = [];
+  try {
+    for await (const batch of streams.readBatches(streamId, {
+      signal: abort.signal,
+      onUpToDate: () => abort.abort(new Error("tail"))
+    })) {
+      chunks.push(...batch);
+    }
+  } catch (error) {
+    if (!(error instanceof Error && error.message === "tail")) throw error;
+  }
+  return chunks;
+}
+
+function prefixOf(instance: R2StreamHarnessObject): string {
+  return `t/${instance.ctx.id.toString().slice(0, 12)}/`;
+}
+
+describe("Streams on R2", () => {
+  it("appends with a monotonic cursor, tails live, and lands one file at close", async () => {
+    const stub = env.R2StreamHarnessObject.getByName(crypto.randomUUID());
+    await runInDurableObject(stub, async (instance: R2StreamHarnessObject) => {
+      const prefix = prefixOf(instance);
+      const stream = await instance.streams.open("s1", {
+        metadata: { topic: "demo" },
+        tag: "req-1"
+      });
+      expect(stream.cursor).toBe(0);
+
+      // A reader tailing from memory while the producer is live.
+      const tail = collect(instance.streams.read("s1"));
+
+      for (let i = 0; i < 60; i++) expect(stream.append({ i })).toBe(i);
+      expect(stream.cursor).toBe(60);
+
+      const live = await instance.streams.status("s1");
+      expect(live).toMatchObject({
+        state: "streaming",
+        cursor: 60,
+        tag: "req-1",
+        metadata: { topic: "demo" }
+      });
+      // The WAL checkpoints every 25 chunks: two segments so far (the puts
+      // are asynchronous; give them a tick to land).
+      await new Promise((r) => setTimeout(r, 50));
+      const wal = await objects(`${prefix}s1/seg/`);
+      expect(wal.length).toBe(2);
+
+      stream.close();
+      // The row settles synchronously but only claims what R2 holds; the
+      // final cursor lands with the settled body.
+      expect((await instance.streams.status("s1"))?.state).toBe("completed");
+      await instance.streams.flush("s1");
+      const settled = await instance.streams.status("s1");
+      expect(settled?.cursor).toBe(60);
+
+      expect((await tail).map((c) => c.seq)).toEqual(
+        Array.from({ length: 60 }, (_, i) => i)
+      );
+
+      await instance.streams.flush("s1");
+      const lines = await fileLines(`${prefix}s1/body`);
+      expect(lines.length).toBe(60);
+      expect(JSON.parse(lines[59])).toEqual({ i: 59 });
+      expect(await objects(`${prefix}s1/seg/`)).toEqual([]);
+
+      // Replay after settlement comes from the file, not memory.
+      const fromTen = await collect(instance.streams.read("s1", { from: 10 }));
+      expect(fromTen.length).toBe(50);
+      expect(fromTen[0]).toEqual({ seq: 10, chunk: { i: 10 } });
+
+      expect(await instance.streams.list({ tag: "req-1" })).toHaveLength(1);
+    });
+  });
+
+  it("keeps SQLite free of chunk rows", async () => {
+    const stub = env.R2StreamHarnessObject.getByName(crypto.randomUUID());
+    await runInDurableObject(stub, async (instance: R2StreamHarnessObject) => {
+      const stream = await instance.streams.open("rows");
+      for (let i = 0; i < 30; i++) stream.append({ i });
+      stream.close();
+      await instance.streams.flush();
+      const tables = [
+        ...instance.ctx.storage.sql.exec(
+          "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'cf_agents_stream_chunks'"
+        )
+      ];
+      const chunkRows =
+        tables.length === 0
+          ? 0
+          : Number(
+              [
+                ...instance.ctx.storage.sql.exec(
+                  "SELECT COUNT(*) AS n FROM cf_agents_stream_chunks"
+                )
+              ][0].n
+            );
+      expect(chunkRows).toBe(0);
+      const row = [
+        ...instance.ctx.storage.sql.exec(
+          "SELECT chunk_count, state FROM cf_agents_streams WHERE stream_id = 'rows'"
+        )
+      ][0];
+      expect(row).toEqual({ chunk_count: 30, state: "completed" });
+    });
+  });
+
+  it("error() settles, still replays every chunk, and files the stream", async () => {
+    const stub = env.R2StreamHarnessObject.getByName(crypto.randomUUID());
+    await runInDurableObject(stub, async (instance: R2StreamHarnessObject) => {
+      const prefix = prefixOf(instance);
+      const stream = await instance.streams.open("err");
+      for (let i = 0; i < 7; i++) stream.append(`c${i}`);
+      stream.error("boom");
+      expect(() => stream.append("late")).toThrow(/already settled/);
+      await instance.streams.flush("err");
+      const status = await instance.streams.status("err");
+      expect(status).toMatchObject({
+        state: "errored",
+        error: "boom",
+        cursor: 7
+      });
+      expect(await fileLines(`${prefix}err/body`)).toHaveLength(7);
+      const replay = await collect(instance.streams.read("err"));
+      expect(replay.map((c) => c.chunk)).toEqual(
+        Array.from({ length: 7 }, (_, i) => `c${i}`)
+      );
+    });
+  });
+
+  it("resumes a stream whose producer died from the write-ahead log", async () => {
+    const stub = env.R2StreamHarnessObject.getByName(crypto.randomUUID());
+    await runInDurableObject(stub, async (instance: R2StreamHarnessObject) => {
+      const prefix = prefixOf(instance);
+      const first = await instance.streams.open("dead");
+      for (let i = 0; i < 50; i++) first.append({ i });
+      // Two checkpoints (50 chunks) are durable; nothing was settled. Let
+      // the WAL puts land before we "lose" the isolate.
+      await new Promise((r) => setTimeout(r, 50));
+      expect(await objects(`${prefix}dead/seg/`)).toHaveLength(2);
+      expect(await env.STREAMS_R2.head(`${prefix}dead/body`)).toBeNull();
+
+      // A fresh Streams over the same storage and bucket is a restarted
+      // isolate: the row is still `streaming`, the memory log is gone.
+      const restarted = new Streams({
+        r2: env.STREAMS_R2,
+        r2Prefix: prefix,
+        maxChunkBytes: 1024
+      });
+      // Borrow the harness's Lifecycle services by installing on a sibling
+      // Lifecycle over the same DurableObject state.
+      const { Lifecycle } = await import("../../lifecycle");
+      const lifecycle = Lifecycle.install(instance).use(restarted);
+      await lifecycle.start();
+
+      expect((await restarted.status("dead"))?.cursor).toBe(50);
+      const resumed = await restarted.open("dead");
+      expect(resumed.cursor).toBe(50);
+      for (let i = 50; i < 55; i++) expect(resumed.append({ i })).toBe(i);
+      resumed.close();
+      await restarted.flush("dead");
+
+      const lines = await fileLines(`${prefix}dead/body`);
+      expect(lines.length).toBe(55);
+      expect(JSON.parse(lines[0])).toEqual({ i: 0 });
+      expect(JSON.parse(lines[54])).toEqual({ i: 54 });
+      expect(await objects(`${prefix}dead/seg/`)).toEqual([]);
+      const all = await collect(restarted.read("dead"));
+      expect(all.map((c) => c.seq)).toEqual(
+        Array.from({ length: 55 }, (_, i) => i)
+      );
+    });
+  });
+
+  it("a replay before recovery never pins a truncated log", async () => {
+    const stub = env.R2StreamHarnessObject.getByName(crypto.randomUUID());
+    await runInDurableObject(stub, async (instance: R2StreamHarnessObject) => {
+      const prefix = prefixOf(instance);
+      const first = await instance.streams.open("early");
+      for (let i = 0; i < 50; i++) first.append({ i });
+      await new Promise((r) => setTimeout(r, 50));
+
+      const { Lifecycle } = await import("../../lifecycle");
+      const restarted = new Streams({ r2: env.STREAMS_R2, r2Prefix: prefix });
+      await Lifecycle.install(instance).use(restarted).start();
+
+      // A reader arrives before the producer resumes: served from the
+      // segments, then tailing (the row is still live), so stop at the tail.
+      const early = await replayToTail(restarted, "early");
+      expect(early.length).toBe(50);
+
+      const resumed = await restarted.open("early");
+      expect(resumed.cursor).toBe(50);
+      for (let i = 50; i < 60; i++) resumed.append({ i });
+      resumed.close();
+      await restarted.flush("early");
+
+      const all = await collect(restarted.read("early"));
+      expect(all.length).toBe(60);
+      expect(all[59].chunk).toEqual({ i: 59 });
+      // Two epochs wrote segments; the settled body replaced them all.
+      expect(await objects(`${prefix}early/seg/`)).toEqual([]);
+    });
+  });
+
+  it("delete() removes the row, the file and the write-ahead log", async () => {
+    const stub = env.R2StreamHarnessObject.getByName(crypto.randomUUID());
+    await runInDurableObject(stub, async (instance: R2StreamHarnessObject) => {
+      const prefix = prefixOf(instance);
+      const stream = await instance.streams.open("gone");
+      stream.append(1);
+      stream.close();
+      await instance.streams.flush("gone");
+      expect(await env.STREAMS_R2.head(`${prefix}gone/body`)).not.toBeNull();
+      expect(await instance.streams.delete("gone")).toBe(true);
+      expect(await objects(`${prefix}gone`)).toEqual([]);
+      expect(await instance.streams.status("gone")).toBeNull();
+    });
+  });
+
+  it("SQLite read/write accounting per operation", async () => {
+    const stub = env.R2StreamHarnessObject.getByName(crypto.randomUUID());
+    await runInDurableObject(stub, async (instance: R2StreamHarnessObject) => {
+      const sql = instance.ctx.storage.sql;
+      const counters = { read: 0, written: 0 };
+      const exec = sql.exec.bind(sql);
+      // Count billed rows behind every statement Streams issues.
+      // @ts-expect-error test instrumentation of the bound method
+      sql.exec = (query: string, ...params: unknown[]) => {
+        const cursor = exec(query, ...(params as never[]));
+        const rows = [...cursor];
+        counters.read += cursor.rowsRead;
+        counters.written += cursor.rowsWritten;
+        return {
+          ...cursor,
+          [Symbol.iterator]: () => rows[Symbol.iterator](),
+          toArray: () => rows,
+          rowsRead: cursor.rowsRead,
+          rowsWritten: cursor.rowsWritten
+        };
+      };
+      const measure = async (fn: () => unknown | Promise<unknown>) => {
+        counters.read = 0;
+        counters.written = 0;
+        await fn();
+        return { ...counters };
+      };
+      const stream = await instance.streams.open("acct", { tag: "t" });
+      const appends = await measure(() => {
+        for (let i = 0; i < 100; i++) stream.append({ i });
+      });
+      await new Promise((r) => setTimeout(r, 50)); // let checkpoints land
+      const status = await measure(() => instance.streams.status("acct"));
+      const byTag = await measure(() =>
+        instance.streams.list({ tag: "t", limit: 1 })
+      );
+      const close = await measure(() => stream.close());
+      await instance.streams.flush("acct");
+      const replay = await measure(() =>
+        collect(instance.streams.read("acct"))
+      );
+      console.log("R2 backend SQLite accounting", {
+        appendsX100: appends,
+        status,
+        byTag,
+        close,
+        replay
+      });
+      // The hot path: 100 appends read and write nothing in SQLite.
+      expect(appends).toEqual({ read: 0, written: 0 });
+    });
+  });
+
+  it("refuses the synchronous SQLite aperture", async () => {
+    const stub = env.R2StreamHarnessObject.getByName(crypto.randomUUID());
+    await runInDurableObject(stub, async (instance: R2StreamHarnessObject) => {
+      expect(() => instance.streams.__DO_NOT_USE_WILL_BREAK__sync()).toThrow(
+        /SQLite-only/
+      );
+    });
+  });
+});

--- a/packages/agents/src/tests/worker.ts
+++ b/packages/agents/src/tests/worker.ts
@@ -32,6 +32,7 @@ export {
   TaskSchedulerCoexistObject
 } from "./capabilities/tasks.ts";
 export {
+  R2StreamHarnessObject,
   StreamHarnessObject,
   TaskStreamComposeObject
 } from "./capabilities/streams.ts";
@@ -42,6 +43,7 @@ export {
   SessionSearchHarnessObject
 } from "./capabilities/sessions.ts";
 import type {
+  R2StreamHarnessObject,
   StreamHarnessObject,
   TaskStreamComposeObject
 } from "./capabilities/streams.ts";
@@ -213,6 +215,8 @@ export type Env = {
   TaskHarnessObject: DurableObjectNamespace<TaskHarnessObject>;
   TaskSchedulerCoexistObject: DurableObjectNamespace<TaskSchedulerCoexistObject>;
   StreamHarnessObject: DurableObjectNamespace<StreamHarnessObject>;
+  R2StreamHarnessObject: DurableObjectNamespace<R2StreamHarnessObject>;
+  STREAMS_R2: R2Bucket;
   TaskStreamComposeObject: DurableObjectNamespace<TaskStreamComposeObject>;
   StreamBenchObject: DurableObjectNamespace<StreamBenchObject>;
   SessionHarnessObject: DurableObjectNamespace<SessionHarnessObject>;

--- a/packages/agents/src/tests/wrangler.jsonc
+++ b/packages/agents/src/tests/wrangler.jsonc
@@ -10,6 +10,7 @@
     "enable_nodejs_v8_module",
     "enable_nodejs_process_v2"
   ],
+  "r2_buckets": [{ "binding": "STREAMS_R2", "bucket_name": "streams-test" }],
   "durable_objects": {
     "bindings": [
       {
@@ -47,6 +48,10 @@
       {
         "class_name": "StreamHarnessObject",
         "name": "StreamHarnessObject"
+      },
+      {
+        "class_name": "R2StreamHarnessObject",
+        "name": "R2StreamHarnessObject"
       },
       {
         "class_name": "TaskStreamComposeObject",
@@ -404,6 +409,7 @@
         "TaskHarnessObject",
         "TaskSchedulerCoexistObject",
         "StreamHarnessObject",
+        "R2StreamHarnessObject",
         "TaskStreamComposeObject",
         "StreamBenchObject",
         "SessionHarnessObject",


### PR DESCRIPTION
## What

`agents/streams` gets a second chunk log. Hand `Streams` an R2 binding and chunks leave DO SQLite:

```ts
readonly streams = new Streams({
  r2: this.env.BUCKET,
  r2Prefix: `streams/${this.ctx.id}/`,              // default "streams/"
  r2Checkpoint: { everyChunks: 25, everyMs: 1000 }  // the defaults
});
```

Nothing else changes: `open`, `append`, `read`, `status`, `list`, `delete` behave as before and `append()` stays synchronous. Stream rows (state, tag index, metadata, cursor) stay in SQLite, where a point read or tag lookup costs nothing. Chunks go to the bucket.

## Why

Cost. SQLite bills one row per stored chunk and again to delete it. R2 bills one Class A op per checkpoint, deletes are free, and storage is about 13× cheaper with no 10 GB ceiling. One R2 put costs the same as 4.5 SQLite row writes, so the R2 log is cheaper whenever a checkpoint covers more than ~4.5 stored rows: unpacked producers, or a loss window of a few seconds. Against chat's 10-to-1 packed SQLite at a 1 s cadence it is a wash on ops and wins only on storage. The docs say this in the same words.

Per 400-chunk chat turn: $0.0008 SQLite unpacked, $0.00008 packed, $0.00009 R2 at the default cadence, $0.00002 at 5 s.

## How

R2 has no append, rejects bodies of unknown length, and stores nothing from a put that has not completed (all measured on real R2, see below). So the log is a write-ahead log of segment objects:

- Appends go into an in-memory line log that live readers tail, exactly like the SQLite log's in-isolate wakeups. Memory holds only the unflushed tail plus a 256 KB hot window of landed lines; once a segment's put resolves its lines are evicted and a reader further behind reads that segment from R2. A stream's length never grows isolate memory.
- Every `everyChunks` appends or `everyMs` after the first unflushed one, the new lines are put as one immutable segment `<prefix><id>/seg/<epoch>/<from>-<to>`. Each landed segment is the durability: when the isolate dies, everything up to the last landed segment is in R2. Puts are chained so they land in order, retried with backoff, and a range that still fails folds into the next checkpoint so nothing is skipped.
- The row's cursor is stamped from landed segments, throttled to one row write per 5 s, so `status()` never reports more than R2 holds and the stamp costs a fraction of the puts. `open()` after a death re-stamps it exactly.
- `open()` on a stream whose isolate died lists the segments once, keeps the contiguous chain, deletes keys it does not cover, and continues in a new epoch from the chain's end without loading it into memory. A resumed producer starts at the durable cursor, so the Tasks resume contract holds and a discarded generation can never be spliced back in.
- `close()`/`error()` settle the row synchronously, then in the background stream the segments back through one exact-size put at `<id>/body` and drop them (keys are tracked, no list; deletes batched at 1000). Segments stay readable until the body lands. `await streams.flush(id)` waits for it.
- Replay of a settled stream caches bodies up to 1 MiB whole; larger bodies get a line-offset index and ranged gets per page. The read cache is an 8 MiB LRU.

SQLite accounting on the R2 backend: 100 appends read and write 0 rows; the cursor stamp is 1 row write per 5 s of streaming; `status()` reads 1, tag lookup 2, settle reads 2 and writes 2.

Chat's `ResumableStream` uses the synchronous SQLite aperture and is unaffected; it throws if given an R2-backed `Streams`.

## Measured on real R2 (2026-09-03)

| Experiment | Result |
|---|---|
| `put(key, unknownLengthStream)` | rejected: "Provided readable stream must have a known length" |
| `FixedLengthStream` put, slow writes | streams as written; a 150 s put from a DO completed |
| object visible mid-put? | no; not in `list`/`head` until complete |
| producer aborts or closes short | put rejects, nothing stored |
| multipart with tiny parts | `complete` rejects (10011, below 5 MiB minimum) |
| small put latency | p50 145 ms, p95 195 ms |
| tag lookup, 1000 streams | R2 prefix scan 542 ms, key-encoded index 41 ms, SQLite 0 ms |

Those are why there is no streaming file put (it never contributes durability) and why the rows stay in SQLite.

## Tests

- `src/tests/streams/r2-backend.test.ts` (miniflare R2 binding `STREAMS_R2`): cursor + live tail + body at close; no chunk rows in SQLite; `error()` path; resume from the segment chain after a simulated restart; replay before recovery never pins a truncated log; delete; SQLite accounting; aperture refusal.
- Existing streams, write-accounting, bench, migration and chat suites unchanged and green (46 tests).
- `r2-backend.test.ts` also covers memory: 2000 × 500 B chunks keep under half the lines in memory while a reader far behind is served from segments, and the 1 MB settled body replays from any cursor through the offset index.
- Real R2 with the package build: 200 chunks tailed over `sseResponse` while streaming, body landed, segments cleaned; `ctx.abort()` at chunk 120 left five segments and a durable cursor of 100, resume continued from 100, final body 200 lines. A 4000 × 500 B stream (2.2 MB) settled through the streamed compaction with no segments left, and the same stream killed at chunk 925 resumed from 925 and settled to 4000 lines.

## Not in this PR

- A SIGKILL e2e for the R2 backend (the workers-pool restart simulation covers the same path).
- Per-stream cadence overrides; `r2Checkpoint` is capability-wide.
