### PR TITLE
feat(streams): rollover block log and atomic stream → session cutover

### DIFF
--- a/.changeset/streams-block-log-cutover.md
+++ b/.changeset/streams-block-log-cutover.md
@@ -1,0 +1,13 @@
+---
+"agents": minor
+"@cloudflare/ai-chat": patch
+"@cloudflare/think": patch
+---
+
+feat(streams): rollover block log and an atomic stream → message cutover.
+
+The Streams chunk log is now mutable rollover blocks: an append grows the open block row (an UPDATE) until it reaches 256 KB, then opens the next. Same one billed row per append as before, but a stream of thousands of chunks is a handful of rows to delete instead of thousands. Existing `cf_agents_stream_chunks` rows are folded into blocks on startup.
+
+`writer.close({ commit, discard })` (and `error(reason, { … })`) settles the stream, runs the caller's synchronous writes and deletes the stream's rows in one SQLite transaction, so a finished message and the discard of its temporary log commit together or not at all. `Session.__DO_NOT_USE_WILL_BREAK__sync().upsert()` is the matching synchronous message write.
+
+`ResumableStream.complete(streamId, { persist })` exposes the cutover to chat hosts, `discardCompleted()` drops a completed stream's rows once its message is persisted, and `start()` reclaims completed streams a crash left behind — AIChatAgent and Think now discard right after persisting, so the retention sweep no longer has completed streams to find.

--- a/.changeset/streams-block-log-cutover.md
+++ b/.changeset/streams-block-log-cutover.md
@@ -1,13 +1,13 @@
 ---
 "agents": minor
-"@cloudflare/ai-chat": patch
-"@cloudflare/think": patch
+"@cloudflare/ai-chat": minor
+"@cloudflare/think": minor
 ---
 
-feat(streams): rollover block log and an atomic stream → message cutover.
+feat(streams): rollover block log and an atomic stream → message cutover; no more stream-buffer sweeps.
 
 The Streams chunk log is now mutable rollover blocks: an append grows the open block row (an UPDATE) until it reaches 256 KB, then opens the next. Same one billed row per append as before, but a stream of thousands of chunks is a handful of rows to delete instead of thousands. Existing `cf_agents_stream_chunks` rows are folded into blocks on startup.
 
-`writer.close({ commit, discard })` (and `error(reason, { … })`) settles the stream, runs the caller's synchronous writes and deletes the stream's rows in one SQLite transaction, so a finished message and the discard of its temporary log commit together or not at all. `Session.__DO_NOT_USE_WILL_BREAK__sync().upsert()` is the matching synchronous message write.
+`writer.close({ commit, discard })` (and `error(reason, { … })`) settles the stream, runs the caller's synchronous writes and deletes the stream's rows in one SQLite transaction. `Session.__DO_NOT_USE_WILL_BREAK__sync().upsert()` is the matching synchronous message write; its `after()` dispatches the change feed and auto-compaction once the transaction commits.
 
-`ResumableStream.complete(streamId, { persist })` exposes the cutover to chat hosts, `discardCompleted()` drops a completed stream's rows once its message is persisted, and `start()` reclaims completed streams a crash left behind — AIChatAgent and Think now discard right after persisting, so the retention sweep no longer has completed streams to find.
+Chat hosts (`AIChatAgent`, `Think`) now persist the finished turn's assistant message inside that cutover: the message, the stream's settlement and the deletion of its temporary rows commit together, so a crash leaves either the live stream (recovery rebuilds the message from it) or the message, never neither. `ResumableStream.start()` reclaims anything a crash left behind. The `_cleanupStreamBuffers` alarm is no longer armed (`cleanupStreamBuffers` and `STREAM_CLEANUP_DELAY_SECONDS` are removed from `agents/chat`; the host callback is kept as a no-op so alarms persisted by earlier versions still resolve).

--- a/.changeset/streams-block-log-cutover.md
+++ b/.changeset/streams-block-log-cutover.md
@@ -6,7 +6,7 @@
 
 feat(streams): rollover block log and an atomic stream → message cutover; no more stream-buffer sweeps.
 
-The Streams chunk log is now mutable rollover blocks: an append grows the open block row (an UPDATE) until it reaches 256 KB, then opens the next. Same one billed row per append as before, but a stream of thousands of chunks is a handful of rows to delete instead of thousands. Existing `cf_agents_stream_chunks` rows are folded into blocks on startup.
+The Streams chunk log is now mutable rollover blocks: an append grows the open block row (an UPDATE) until it reaches 256 KB, then opens the next. Same one billed row per append as before, but a stream of thousands of chunks is a handful of rows to delete instead of thousands. Existing `cf_agents_stream_chunks` rows are folded into blocks lazily, one stream at a time on first touch, so startup never reads the whole legacy log; the table is dropped once it is empty.
 
 `writer.close({ commit, discard })` (and `error(reason, { … })`) settles the stream, runs the caller's synchronous writes and deletes the stream's rows in one SQLite transaction. `Session.__DO_NOT_USE_WILL_BREAK__sync().upsert()` is the matching synchronous message write; its `after()` dispatches the change feed and auto-compaction once the transaction commits.
 

--- a/docs/agents/resumable-streaming.md
+++ b/docs/agents/resumable-streaming.md
@@ -70,7 +70,7 @@ function Chat() {
 - Chunks are batched (every 10 chunks) and flushed to SQLite for performance
 - When a client sends `CF_AGENT_STREAM_RESUME_REQUEST`, the server checks for active streams and responds with `CF_AGENT_STREAM_RESUMING`
 - Stale streams (older than 5 minutes) are cleaned up on restore
-- Stream buffers are garbage collected from a scheduled alarm: completed or errored streams are retained for 10 minutes (a brief reconnect-and-replay grace; the assistant message itself is persisted separately), and abandoned in-flight streams are retained for 1 hour after their last chunk before being reclaimed
+- Stream buffers are deleted in the same transaction that persists the assistant message (the cutover), so a finished turn leaves nothing behind and no cleanup alarm is armed. A buffer a crash left behind is reclaimed when the next stream starts: finished streams immediately, abandoned in-flight streams after 1 hour without a chunk (recovery has until then to rebuild the message from it)
 
 ### Client-side (`useAgentChat`)
 

--- a/docs/agents/streams.md
+++ b/docs/agents/streams.md
@@ -189,12 +189,14 @@ pay 42 to write and 3 to cut over.
 
 `AIChatAgent` and `Think` store their in-flight turn output here:
 `ResumableStream` (from `agents/chat`) is a thin adapter over Streams that
-packs ~10 wire chunks into one stored segment for write economy, maps
-completion/error onto stream settlement, and decides retention in two
-phases: a coarse cutoff on the stream row's own timestamp, verified
-against the newest chunk so an actively appending stream is never swept.
-Existing `cf_ai_chat_stream_*` tables migrate onto the
-capability automatically. The packing pattern is worth copying for any
+packs ~10 wire chunks into one stored segment for write economy, and ends
+every turn with the cutover: the assistant message, the stream's
+settlement and the deletion of its rows commit in one transaction. Nothing
+is swept on an alarm any more. A stream a crash left behind is either
+still `streaming` (recovery rebuilds the message from it) or reclaimed by
+the next stream start, together with in-flight rows abandoned for over an
+hour. Existing `cf_ai_chat_stream_*` tables migrate onto the capability
+automatically. The packing pattern is worth copying for any
 high-frequency producer: buffer what you already hold synchronously, append
 one packed chunk, and unpack on read — durability is unchanged (nothing is
 held across an await at settlement) and rows written drop by ~an order of
@@ -204,8 +206,8 @@ magnitude versus per-token appends.
 
 Live fanout is in-isolate (sufficient: a Durable Object executes in one
 isolate at a time; reconnecting readers replay from their cursor). Retention
-is explicit `delete()` (chat sweeps its own rows on an alarm); age-based
-sweeping in the capability itself, producer-generation fencing on `open()`,
+is explicit: `delete()`, or the cutover's `discard`; age-based sweeping in
+the capability itself, producer-generation fencing on `open()`,
 and transport helpers extracted from chat's resume protocol are future work.
 The design record is
 [`design/rfc-streams.md`](https://github.com/cloudflare/agents/blob/main/design/rfc-streams.md).

--- a/docs/agents/streams.md
+++ b/docs/agents/streams.md
@@ -152,6 +152,39 @@ request's signal aborts the tail when the client disconnects.
 `examples/next/streams` is the end-to-end demo. For other transports,
 `read()`/`readBatches()` remain the raw async iterables to pipe yourself.
 
+## Storage: blocks, and the cutover to a message
+
+Chunks are stored as **rollover blocks**: one row per stream holds chunks
+until it reaches 256 KB, then the next append opens a new row. An append
+is one billed row either way (an UPDATE that grows the block, or the INSERT
+of the next one), the same as a row-per-chunk log, but a stream of
+thousands of chunks is a handful of rows, so deleting it is a handful of
+writes instead of thousands. Replay parses one block at a time.
+
+A stream is temporary: once its content has become something else (a
+session message, a report), its rows are dead weight. The **cutover** ends
+the stream, runs your own synchronous writes, and deletes its rows in one
+SQLite transaction:
+
+```ts
+stream.close({
+  commit: () => sessionSync.upsert(message), // synchronous writes only
+  discard: true // delete the stream's rows in the same transaction
+});
+```
+
+Either the message exists and the stream is gone, or `commit` threw, the
+settle rolled back and the stream is still live. Nothing is left for a
+retention sweep. `error(reason, { commit, discard })` is the same for a
+failed producer. `commit` must not await; a Session handle's
+`__DO_NOT_USE_WILL_BREAK__sync().upsert()` is the matching synchronous
+message write, and returns a `notify()` to dispatch the change feed after
+the transaction commits.
+
+Measured on a real Durable Object (400-chunk chat turn, 10 chunks per
+write): the old log paid 42 rows to write and another 42 to sweep; blocks
+pay 42 to write and 3 to cut over.
+
 ## Chat runs on this
 
 `AIChatAgent` and `Think` store their in-flight turn output here:

--- a/experimental/pi-recovery/src/pi-agent.ts
+++ b/experimental/pi-recovery/src/pi-agent.ts
@@ -33,7 +33,6 @@ import {
   ResumableStream,
   createChatStreams,
   bumpChatRecoveryProgress,
-  cleanupStreamBuffers,
   createChatFiberSnapshot,
   readChatRecoveryProgress,
   recordChatTerminal,
@@ -696,7 +695,7 @@ export class PiAgent extends Agent<Env> {
 
   /** Stream-buffer cleanup alarm target (scheduled by ResumableStream cleanup). */
   async _cleanupStreamBuffers(): Promise<void> {
-    await cleanupStreamBuffers(this._resumableStream, async () => {});
+    this._resumableStream.reclaim();
   }
 
   // ── Inspection surface (server stub RPC → e2e assertions) ───────────────────

--- a/experimental/tanstack-recovery/src/tanstack-agent.ts
+++ b/experimental/tanstack-recovery/src/tanstack-agent.ts
@@ -48,7 +48,6 @@ import {
   ResumeHandshake,
   buildChatRecoveringFrame,
   bumpChatRecoveryProgress,
-  cleanupStreamBuffers,
   createChatFiberSnapshot,
   pendingChatTerminal,
   readChatRecoveryProgress,
@@ -906,7 +905,7 @@ export class TanStackAgent extends Agent<Env> {
 
   /** Stream-buffer cleanup alarm target (scheduled by ResumableStream cleanup). */
   async _cleanupStreamBuffers(): Promise<void> {
-    await cleanupStreamBuffers(this._resumableStream, async () => {});
+    this._resumableStream.reclaim();
   }
 
   // ── Inspection surface (server HTTP → e2e assertions) ───────────────────────

--- a/packages/agents/src/chat/index.ts
+++ b/packages/agents/src/chat/index.ts
@@ -48,9 +48,7 @@ export {
 
 export {
   ResumableStream,
-  cleanupStreamBuffers,
   createChatStreams,
-  STREAM_CLEANUP_DELAY_SECONDS,
   type SqlTaggedTemplate
 } from "./resumable-stream";
 export {

--- a/packages/agents/src/chat/resumable-stream.ts
+++ b/packages/agents/src/chat/resumable-stream.ts
@@ -46,48 +46,23 @@ const SEGMENT_MAX_BYTES = 512_000;
  * replay memory to one page of segment bodies rather than the whole turn.
  */
 const REPLAY_PAGE_SEGMENTS = 10;
-/** Default cleanup interval for old streams (ms) - every 10 minutes */
-const CLEANUP_INTERVAL_MS = 10 * 60 * 1000;
-/**
- * Retention for completed/errored stream buffers, measured from completion.
- *
- * The assistant message is persisted separately (`cf_ai_chat_agent_messages`),
- * so once a stream completes its buffer is no longer the source of truth — it
- * is only a brief reconnect-and-replay grace window: long enough to cover a
- * client that dropped at the completion boundary and reconnects to replay the
- * just-finished stream, and to deliver a pending terminal error frame on a
- * resumed stream (#1645). It is deliberately short (not the chat's lifetime)
- * so idle/one-off chat DOs don't accumulate stale buffers (#1706).
- */
-const COMPLETED_RETENTION_MS = 10 * 60 * 1000;
 /**
  * Retention for abandoned `streaming` rows, measured from LAST chunk activity.
  *
- * Generous relative to {@link COMPLETED_RETENTION_MS}: an interrupted turn must
- * have ample time to be resumed by a reconnecting client or healed by task
- * replay before its buffer is reaped. Only a stream that has produced no
- * chunk for this long is treated as truly dead. Last activity is decided in
- * two phases — a coarse cutoff on the stream row's `updated_at` (stamped at
- * open, not per append), then one indexed read of the newest chunk's
- * timestamp for rows past it — so a long but still-active stream is never
- * swept mid-flight.
+ * An interrupted turn must have ample time to be resumed by a reconnecting
+ * client or healed by task replay before its buffer is reaped. Only a stream
+ * that has produced no chunk for this long is treated as truly dead. Last
+ * activity is decided in two phases — a coarse cutoff on the stream row's
+ * `updated_at` (stamped at open, not per append), then one indexed read of
+ * the newest chunk's timestamp for rows past it — so a long but still-active
+ * stream is never reclaimed mid-flight. Terminal rows carry no such window:
+ * a stream that finished is redundant with its persisted message, and the
+ * cutover deletes it in the same transaction; anything a crash left behind
+ * is reclaimed by the next {@link ResumableStream.start}.
  */
 const ABANDONED_STREAM_RETENTION_MS = 60 * 60 * 1000;
 /** Shared encoder for UTF-8 byte length measurement */
 const textEncoder = new TextEncoder();
-
-/**
- * How far ahead (seconds) to schedule the resumable-stream buffer cleanup
- * alarm. Set to the short completion-grace window ({@link COMPLETED_RETENTION_MS},
- * 10m) so a finished buffer is reclaimed promptly. The re-arm-while-reclaimable
- * loop (see {@link cleanupStreamBuffers}) revisits any longer-lived rows — e.g.
- * an abandoned in-flight buffer on its 1h window — by waking again each interval
- * until they age out, then stops. Driving cleanup from an alarm (rather than
- * only piggybacking on the next stream completion) ensures idle/one-off chat
- * DOs still reclaim their buffers without waking forever (#1706). Shared by
- * `AIChatAgent` and `Think`.
- */
-export const STREAM_CLEANUP_DELAY_SECONDS = 10 * 60;
 
 /**
  * Ceiling for one stored chat segment after JSON serialization, and the
@@ -194,7 +169,12 @@ export class ResumableStream {
   private _chunkBuffer: Array<{ streamId: string; body: string }> = [];
   private _chunkBufferBytes = 0;
   private _isFlushingChunks = false;
-  private _lastCleanupTime = 0;
+  /**
+   * A stream whose producer finished but whose row is deliberately still
+   * `streaming`: the host will {@link cutover} it together with the message
+   * write, or {@link finalizePending} it when there is nothing to persist.
+   */
+  private _pendingCutover: string | null = null;
 
   private readonly ops: StreamsSyncInternal;
 
@@ -346,12 +326,10 @@ export class ResumableStream {
   ): string {
     // Flush any pending chunks from previous streams to prevent mixing
     this.flushBuffer();
-    // Reclaim completed streams a previous turn left behind (a crash
-    // between persist and discard): their messages are persisted, so the
-    // rows are dead weight. One row-table scan, no alarm.
-    for (const row of this._chatRows()) {
-      if (row.state === "completed") this.ops.deleteUnchecked(row.stream_id);
-    }
+    // Reclaim whatever a previous turn left behind: finished streams (their
+    // messages are persisted, so the rows are dead weight) and in-flight
+    // rows abandoned past the stale window. One row-table scan, no alarm.
+    this.reclaim();
 
     const streamId = nanoid();
     this._activeStreamId = streamId;
@@ -381,32 +359,71 @@ export class ResumableStream {
 
   /**
    * Mark a stream as completed and flush any pending chunks.
-   *
-   * With `persist`, this is the cutover: the settle, the caller's message
-   * write and the discard of the stream's rows commit in one SQLite
-   * transaction, so a crash leaves either the live stream or the finished
-   * message, never neither, and nothing is left for a sweep. `persist`
-   * must be synchronous.
    * @param streamId - The stream to mark as completed
    */
-  complete(streamId: string, options: { persist?: () => void } = {}) {
+  complete(streamId: string) {
     this.flushBuffer();
+    this.ops.settle(streamId, "completed", null);
+    if (this._pendingCutover === streamId) this._pendingCutover = null;
+    this._clearActive();
+  }
 
-    if (options.persist) {
-      this.ops.settle(streamId, "completed", null, {
-        commit: options.persist,
-        discard: true
-      });
-    } else {
-      this.ops.settle(streamId, "completed", null);
-    }
+  /**
+   * The producer finished, but leave the row `streaming` for the cutover:
+   * the host persists the message and settles the stream in one
+   * transaction with {@link cutover}. Until then a crash leaves the stream
+   * live — exactly the evidence recovery rebuilds the message from. The
+   * host MUST follow with {@link cutover} or {@link finalizePending}.
+   */
+  finish(streamId: string) {
+    this.flushBuffer();
+    this._pendingCutover = streamId;
+    this._clearActive();
+  }
+
+  /** The stream {@link finish}ed and awaiting its cutover, if any. */
+  get pendingCutoverId(): string | null {
+    return this._pendingCutover;
+  }
+
+  /**
+   * The cutover: settle the stream, run `persist` (synchronous writes — the
+   * message), and delete the stream's rows in one SQLite transaction. A
+   * crash leaves either the live stream or the finished message, never
+   * neither; nothing is left to sweep. `discard: false` keeps the settled
+   * rows (an agent-tool child whose parent still tails them); they are
+   * reclaimed by the next {@link start}.
+   */
+  cutover(
+    streamId: string,
+    persist: () => void,
+    options: { discard?: boolean } = {}
+  ) {
+    this.flushBuffer();
+    this.ops.settle(streamId, "completed", null, {
+      commit: persist,
+      discard: options.discard ?? true
+    });
+    if (this._pendingCutover === streamId) this._pendingCutover = null;
+    this._clearActive();
+  }
+
+  /**
+   * Settle a {@link finish}ed stream that had nothing to persist (no parts,
+   * a persist that threw). Idempotent; a no-op when nothing is pending.
+   */
+  finalizePending() {
+    const streamId = this._pendingCutover;
+    if (streamId === null) return;
+    this._pendingCutover = null;
+    this.ops.settle(streamId, "completed", null);
+  }
+
+  private _clearActive() {
     this._activeStreamId = null;
     this._activeRequestId = null;
     this._isLive = false;
     this._activeIsContinuation = false;
-
-    // Periodically clean up old streams
-    this._maybeCleanupOldStreams();
   }
 
   /**
@@ -431,12 +448,9 @@ export class ResumableStream {
    */
   markError(streamId: string) {
     this.flushBuffer();
-
     this.ops.settle(streamId, "errored", null);
-    this._activeStreamId = null;
-    this._activeRequestId = null;
-    this._isLive = false;
-    this._activeIsContinuation = false;
+    if (this._pendingCutover === streamId) this._pendingCutover = null;
+    this._clearActive();
   }
 
   // ── Chunk storage ──────────────────────────────────────────────────
@@ -765,67 +779,33 @@ export class ResumableStream {
   }
 
   /**
-   * Force a sweep of aged stream buffers now, bypassing the lazy interval
-   * gate used by {@link _maybeCleanupOldStreams}. Intended to be driven by an
-   * alarm so idle/hibernated chat DOs still reclaim buffers even when no
-   * further stream ever completes to trigger the lazy path.
-   *
-   * @returns How many chat stream rows survive the sweep — the re-arm
-   * signal, so the alarm body needs no second scan of the table.
+   * Delete every chat stream row this Durable Object no longer needs:
+   * finished streams (their messages are persisted; the cutover normally
+   * deletes them in the same transaction, so these are crash leftovers) and
+   * in-flight rows abandoned past {@link ABANDONED_STREAM_RETENTION_MS} by
+   * last chunk activity. Runs on every {@link start}, so nothing needs an
+   * alarm to be reclaimed; a Durable Object that never starts another turn
+   * keeps at most one turn's rows. Streams other producers opened on the
+   * same object are untouched.
+   * @returns How many rows were reclaimed.
    */
-  cleanup(now: number = Date.now()): number {
-    this._lastCleanupTime = now;
-    return this._sweepOldStreams(now);
-  }
-
-  /**
-   * True if any chat stream rows remain at all. Used by alarm-driven cleanup
-   * to decide whether to re-arm: once no rows remain there is nothing left to
-   * sweep, so the DO can stop waking itself.
-   */
-  hasReclaimableStreams(): boolean {
-    return this._chatRows().length > 0;
-  }
-
-  // ── Internal ───────────────────────────────────────────────────────
-
-  private _maybeCleanupOldStreams() {
-    const now = Date.now();
-    if (now - this._lastCleanupTime < CLEANUP_INTERVAL_MS) {
-      return;
-    }
-    this._lastCleanupTime = now;
-    this._sweepOldStreams(now);
-  }
-
-  /** Delete completed/errored buffers past the completion grace window, plus
-   *  abandoned "streaming" rows past the stale-in-flight window. The two use
-   *  different retentions: a completed buffer is redundant with the persisted
-   *  message and needs only a brief replay grace, whereas an in-flight buffer
-   *  must outlive resume/replay before it is presumed dead. Abandonment is
-   *  decided in two phases: the stream row's `updated_at` (stamped at open,
-   *  not per append — appends write only the chunk log) is the coarse
-   *  cutoff, and only rows past it pay one indexed read of the newest
-   *  chunk's timestamp to confirm the producer really stopped. An actively
-   *  appending stream is never swept, and a quiet sweep still reads no
-   *  chunk rows at all.
-   *  @returns How many chat stream rows survive the sweep. */
-  private _sweepOldStreams(now: number): number {
-    const completedCutoff = now - COMPLETED_RETENTION_MS;
+  reclaim(now: number = Date.now()): number {
     const abandonedCutoff = now - ABANDONED_STREAM_RETENTION_MS;
-    const rows = this._chatRows();
-    const reclaimable = rows
+    const reclaimable = this._chatRows()
       .filter((row) =>
         row.state === "streaming"
-          ? row.updated_at < abandonedCutoff &&
+          ? row.stream_id !== this._activeStreamId &&
+            row.updated_at < abandonedCutoff &&
             (this.ops.lastChunkAt(row.stream_id) ?? row.updated_at) <
               abandonedCutoff
-          : (row.closed_at ?? row.updated_at) < completedCutoff
+          : true
       )
       .map((row) => row.stream_id);
     this.ops.deleteMany(reclaimable);
-    return rows.length - reclaimable.length;
+    return reclaimable.length;
   }
+
+  // ── Internal ───────────────────────────────────────────────────────
 
   // ── Test helpers (matching old AIChatAgent test API) ────────────────
 
@@ -890,33 +870,12 @@ export class ResumableStream {
 
   /**
    * Append a chunk to a stream dated `ageMs` in the past. Used to exercise
-   * the sweep's phase-2 verification: a long-running streaming row with a
+   * reclaim's phase-2 verification: a long-running streaming row with a
    * *recent* chunk must survive even when its row `updated_at` (stamped at
    * open, not per append) is older than the coarse cutoff.
    * @internal For testing only
    */
   insertChunkAt(streamId: string, body: string, ageMs: number): void {
     this.ops.importChunk(streamId, body, Date.now() - ageMs);
-  }
-}
-
-/**
- * The buffer-cleanup alarm body: sweep aged stream buffers, then re-arm only
- * while rows remain so a fully-swept DO stops waking itself. `rearm` schedules
- * the next sweep — it MUST schedule a non-idempotent alarm, because this runs
- * INSIDE the currently-executing one-shot schedule row, which `alarm()` deletes
- * only after it returns; an idempotent reschedule would dedup onto that row and
- * be deleted with it, so the re-arm would silently never fire and buffers that
- * survived this sweep (e.g. a younger turn) would go uncollected. A fresh
- * delayed row survives the deletion. Shared by `AIChatAgent` and `Think`.
- *
- * `@internal`
- */
-export async function cleanupStreamBuffers(
-  stream: Pick<ResumableStream, "cleanup">,
-  rearm: () => Promise<void>
-): Promise<void> {
-  if (stream.cleanup() > 0) {
-    await rearm();
   }
 }

--- a/packages/agents/src/chat/resumable-stream.ts
+++ b/packages/agents/src/chat/resumable-stream.ts
@@ -2,7 +2,7 @@
  * ResumableStream: chat's producer-side coalescing and wire-protocol replay
  * adapter over the `agents/streams` capability. Chat's in-flight output
  * lives in the shared durable chunk log (`cf_agents_streams` /
- * `cf_agents_stream_chunks`), one stream per turn, tagged with the turn's
+ * `cf_agents_stream_blocks`), one stream per turn, tagged with the turn's
  * request id so replay-by-request rides the capability's indexed lookup.
  *
  * Handles:
@@ -346,6 +346,12 @@ export class ResumableStream {
   ): string {
     // Flush any pending chunks from previous streams to prevent mixing
     this.flushBuffer();
+    // Reclaim completed streams a previous turn left behind (a crash
+    // between persist and discard): their messages are persisted, so the
+    // rows are dead weight. One row-table scan, no alarm.
+    for (const row of this._chatRows()) {
+      if (row.state === "completed") this.ops.deleteUnchecked(row.stream_id);
+    }
 
     const streamId = nanoid();
     this._activeStreamId = streamId;
@@ -375,12 +381,25 @@ export class ResumableStream {
 
   /**
    * Mark a stream as completed and flush any pending chunks.
+   *
+   * With `persist`, this is the cutover: the settle, the caller's message
+   * write and the discard of the stream's rows commit in one SQLite
+   * transaction, so a crash leaves either the live stream or the finished
+   * message, never neither, and nothing is left for a sweep. `persist`
+   * must be synchronous.
    * @param streamId - The stream to mark as completed
    */
-  complete(streamId: string) {
+  complete(streamId: string, options: { persist?: () => void } = {}) {
     this.flushBuffer();
 
-    this.ops.settle(streamId, "completed", null);
+    if (options.persist) {
+      this.ops.settle(streamId, "completed", null, {
+        commit: options.persist,
+        discard: true
+      });
+    } else {
+      this.ops.settle(streamId, "completed", null);
+    }
     this._activeStreamId = null;
     this._activeRequestId = null;
     this._isLive = false;
@@ -388,6 +407,22 @@ export class ResumableStream {
 
     // Periodically clean up old streams
     this._maybeCleanupOldStreams();
+  }
+
+  /**
+   * Drop a completed stream's rows once its message is persisted. The rows
+   * are redundant with the message from that moment, so deleting them here
+   * (a handful of block rows) is what keeps the retention sweep from ever
+   * finding completed streams. Live and errored streams are left alone:
+   * a live one may still be resumed, an errored one still owes a resumed
+   * client its terminal frame (#1645).
+   * @returns Whether rows were deleted.
+   */
+  discardCompleted(streamId: string): boolean {
+    const row = this.ops.getStream(streamId);
+    if (!row || row.state !== "completed") return false;
+    this.ops.deleteUnchecked(streamId);
+    return true;
   }
 
   /**

--- a/packages/agents/src/chat/resumable-stream.ts
+++ b/packages/agents/src/chat/resumable-stream.ts
@@ -400,10 +400,14 @@ export class ResumableStream {
     options: { discard?: boolean } = {}
   ) {
     this.flushBuffer();
-    this.ops.settle(streamId, "completed", null, {
+    const settled = this.ops.settle(streamId, "completed", null, {
       commit: persist,
       discard: options.discard ?? true
     });
+    // The stream was settled (or deleted) by another path first, so the
+    // settle was a no-op and `persist` did not run: the message must still
+    // land, just not atomically with a settlement that already happened.
+    if (!settled) persist();
     if (this._pendingCutover === streamId) this._pendingCutover = null;
     this._clearActive();
   }

--- a/packages/agents/src/e2e-tests/stream-cutover-crash.test.ts
+++ b/packages/agents/src/e2e-tests/stream-cutover-crash.test.ts
@@ -1,0 +1,134 @@
+/**
+ * E2E test: the block log and the stream → message cutover under real
+ * Durable Object death, at the points that matter:
+ *
+ *   1. before a block append commits
+ *   2. immediately after it commits
+ *   3. during rollover to the next block (before and after commit)
+ *   4. after session persistence but before cleanup — the non-atomic path
+ *      hosts use today, and the atomic cutover, killed inside and after
+ *
+ * Each restart must find either the exact committed stream prefix or the
+ * final session message: never neither, never both applied twice. Death is
+ * `ctx.abort()` from inside the object (deterministic to the statement),
+ * and the inspection runs on the fresh instance that replaces it.
+ */
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import type { ChildProcess } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import fs from "node:fs";
+import {
+  callAgentByPath,
+  killProcess,
+  killProcessOnPort,
+  startWrangler,
+  waitForReady,
+  type Harness
+} from "./recovery-helpers";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PORT = 18829;
+const HARNESS: Harness = {
+  configPath: path.join(__dirname, "wrangler.jsonc"),
+  port: PORT,
+  persistDir: path.join(__dirname, ".wrangler-cutover-crash-state")
+};
+
+type Inspection = {
+  state: string | null;
+  cursor: number | null;
+  chunks: number[];
+  blocks: Array<{ block: number; seq_from: number; seq_to: number }>;
+  messageRows: number;
+};
+
+async function crash(
+  name: string,
+  method: string,
+  args: unknown[]
+): Promise<Inspection> {
+  const agentPath = `/agents/cutover-kill-agent/${name}`;
+  // The abort kills the object mid-call: the RPC rejects, which is expected.
+  await callAgentByPath(HARNESS, agentPath, method, args).catch(() => {});
+  return (await callAgentByPath(HARNESS, agentPath, "inspect", [
+    args[0]
+  ])) as Inspection;
+}
+
+const range = (n: number) => Array.from({ length: n }, (_, i) => i);
+
+describe("stream cutover crash matrix e2e", () => {
+  let wrangler: ChildProcess | null = null;
+
+  beforeEach(async () => {
+    killProcessOnPort(PORT);
+    fs.rmSync(HARNESS.persistDir, { recursive: true, force: true });
+    wrangler = startWrangler(HARNESS);
+    await waitForReady(HARNESS);
+  });
+
+  afterEach(async () => {
+    if (wrangler) {
+      await killProcess(wrangler);
+      wrangler = null;
+    }
+    killProcessOnPort(PORT);
+    fs.rmSync(HARNESS.persistDir, { recursive: true, force: true });
+  });
+
+  it("1. crash before a block append commits: the exact prior prefix survives", async () => {
+    const after = await crash("p1", "crashBeforeAppendCommits", ["s1"]);
+    expect(after.state).toBe("streaming");
+    expect(after.chunks).toEqual(range(10));
+    expect(after.cursor).toBe(10);
+    expect(after.messageRows).toBe(0);
+  });
+
+  it("2. crash immediately after the append commits: the append survives", async () => {
+    const after = await crash("p2", "crashAfterAppendCommits", ["s2"]);
+    expect(after.state).toBe("streaming");
+    expect(after.chunks).toEqual(range(11));
+    expect(after.cursor).toBe(11);
+  });
+
+  it("3. crash during rollover: block 1 is all-or-nothing and the log stays contiguous", async () => {
+    const before = await crash("p3a", "crashDuringRollover", ["s3a", false]);
+    expect(before.chunks).toEqual([0]);
+    expect(before.blocks).toEqual([{ block: 0, seq_from: 0, seq_to: 1 }]);
+
+    const committed = await crash("p3b", "crashDuringRollover", ["s3b", true]);
+    expect(committed.chunks).toEqual([0, 1]);
+    expect(committed.blocks).toEqual([
+      { block: 0, seq_from: 0, seq_to: 1 },
+      { block: 1, seq_from: 1, seq_to: 2 }
+    ]);
+  });
+
+  it("4a. non-atomic path, crash after persist before discard: message once, stream settled with its prefix", async () => {
+    const after = await crash("p4a", "crashAfterPersistBeforeDiscard", ["s4a"]);
+    expect(after.messageRows).toBe(1);
+    expect(after.state).toBe("completed");
+    expect(after.chunks).toEqual(range(10));
+    // Both present, neither duplicated: the completed stream is redundant
+    // and is what the next start() reclaims.
+  });
+
+  it("4b. atomic cutover: a crash inside commit lands nothing; after it, everything", async () => {
+    const inside = await crash("p4b-in", "crashAroundCutover", [
+      "s4b-in",
+      "inside"
+    ]);
+    expect(inside.messageRows).toBe(0);
+    expect(inside.state).toBe("streaming");
+    expect(inside.chunks).toEqual(range(10));
+
+    const done = await crash("p4b-out", "crashAroundCutover", [
+      "s4b-out",
+      "after"
+    ]);
+    expect(done.messageRows).toBe(1);
+    expect(done.state).toBeNull();
+    expect(done.blocks).toEqual([]);
+  });
+});

--- a/packages/agents/src/e2e-tests/worker.ts
+++ b/packages/agents/src/e2e-tests/worker.ts
@@ -8,6 +8,7 @@
 import { Agent, callable, routeAgentRequest } from "agents";
 import type { TaskHandlers, TaskStep } from "agents/tasks";
 import { Streams } from "agents/streams";
+import { Sessions } from "agents/sessions";
 import type {
   FiberInspection,
   FiberRecoveryContext as RunFiberRecoveryContext,
@@ -21,6 +22,7 @@ type Env = {
   RunFiberTestAgent: DurableObjectNamespace<RunFiberTestAgent>;
   TaskKillTestAgent: DurableObjectNamespace<TaskKillTestAgent>;
   StreamKillTestAgent: DurableObjectNamespace<StreamKillTestAgent>;
+  CutoverKillAgent: DurableObjectNamespace<CutoverKillAgent>;
   SubAgentFiberParent: DurableObjectNamespace<SubAgentFiberParent>;
   SubAgentFiberChild: DurableObjectNamespace<SubAgentFiberChild>;
   PoisonRowAgent: DurableObjectNamespace<PoisonRowAgent>;
@@ -1020,3 +1022,147 @@ export default {
     );
   }
 };
+
+// ── CutoverKillAgent (block log + cutover crash matrix) ────────────────────
+
+/**
+ * The crash points that matter for the block log and the stream → message
+ * cutover. Each `crash*` method writes, then aborts the object (`ctx.abort`)
+ * at a precise point; `inspect` runs on the fresh instance and reports what
+ * storage alone holds. A restart must find either the exact committed
+ * prefix or the finished message — never neither, never both.
+ */
+export class CutoverKillAgent extends Agent<Record<string, unknown>> {
+  readonly streams = new Streams();
+  readonly sessions = new Sessions();
+
+  constructor(ctx: DurableObjectState, env: Record<string, unknown>) {
+    super(ctx, env);
+    this.lifecycle.use(this.streams).use(this.sessions);
+  }
+
+  #chunk(i: number, bytes: number) {
+    return { i, pad: "x".repeat(bytes) };
+  }
+
+  /** Append up to `n` chunks with a macrotask yield between each, so each commits. */
+  async #seed(streamId: string, n: number, bytes: number) {
+    const writer = await this.streams.open(streamId, { tag: "kill" });
+    for (let i = writer.cursor; i < n; i++) {
+      writer.append(this.#chunk(i, bytes));
+      await fiberSleep(0);
+    }
+    return writer;
+  }
+
+  /** 1. The append and the abort share one commit unit: the append is lost. */
+  @callable()
+  async crashBeforeAppendCommits(streamId: string): Promise<void> {
+    const writer = await this.#seed(streamId, 10, 50);
+    writer.append(this.#chunk(10, 50));
+    this.ctx.abort("crash before commit");
+  }
+
+  /** 2. One yield later the append is durable. */
+  @callable()
+  async crashAfterAppendCommits(streamId: string): Promise<void> {
+    const writer = await this.#seed(streamId, 10, 50);
+    writer.append(this.#chunk(10, 50));
+    await fiberSleep(0);
+    this.ctx.abort("crash after commit");
+  }
+
+  /** 3. Rollover: 250 KB chunks, so chunk 1 opens block 1. */
+  @callable()
+  async crashDuringRollover(
+    streamId: string,
+    afterCommit: boolean
+  ): Promise<void> {
+    const writer = await this.#seed(streamId, 1, 250 * 1024);
+    writer.append(this.#chunk(1, 250 * 1024));
+    if (afterCommit) await fiberSleep(0);
+    this.ctx.abort("crash during rollover");
+  }
+
+  /** 4a. Non-atomic path: settle, persist the message (with I/O between), then crash before discard. */
+  @callable()
+  async crashAfterPersistBeforeDiscard(streamId: string): Promise<void> {
+    const writer = await this.#seed(streamId, 10, 50);
+    writer.close();
+    await fiberSleep(0);
+    await this.sessions.session().upsertMessage({
+      id: `m-${streamId}`,
+      role: "assistant",
+      parts: [{ type: "text", text: "done" }]
+    });
+    await fiberSleep(0);
+    this.ctx.abort("crash after persist, before discard");
+  }
+
+  /** 4b. Atomic cutover: crash inside `commit` (nothing lands) or right after (all lands). */
+  @callable()
+  async crashAroundCutover(
+    streamId: string,
+    where: "inside" | "after"
+  ): Promise<void> {
+    const writer = await this.#seed(streamId, 10, 50);
+    const sync = this.sessions.session().__DO_NOT_USE_WILL_BREAK__sync();
+    writer.close({
+      commit: () => {
+        sync.upsert({
+          id: `m-${streamId}`,
+          role: "assistant",
+          parts: [{ type: "text", text: "done" }]
+        });
+        if (where === "inside") this.ctx.abort("crash inside cutover");
+      },
+      discard: true
+    });
+    await fiberSleep(0);
+    this.ctx.abort("crash after cutover");
+  }
+
+  /** What a fresh isolate finds in storage. */
+  @callable()
+  async inspect(streamId: string): Promise<{
+    state: string | null;
+    cursor: number | null;
+    chunks: number[];
+    blocks: Array<{ block: number; seq_from: number; seq_to: number }>;
+    messageRows: number;
+  }> {
+    const status = await this.streams.status(streamId);
+    const chunks: number[] = [];
+    if (status) {
+      const abort = new AbortController();
+      try {
+        for await (const batch of this.streams.readBatches(streamId, {
+          signal: abort.signal,
+          onUpToDate: () => abort.abort(new Error("tail"))
+        })) {
+          for (const c of batch) chunks.push((c.chunk as { i: number }).i);
+        }
+      } catch (error) {
+        if (!(error instanceof Error && error.message === "tail")) throw error;
+      }
+    }
+    const blocks = this.sql<{
+      block: number;
+      seq_from: number;
+      seq_to: number;
+    }>`
+      SELECT block, seq_from, seq_to FROM cf_agents_stream_blocks
+      WHERE stream_id = ${streamId} ORDER BY block
+    `;
+    const messageRows = this.sql<{ n: number }>`
+      SELECT COUNT(*) AS n FROM cf_agents_session_messages WHERE id = ${`m-${streamId}`}
+    `[0].n;
+    return {
+      state: status?.state ?? null,
+      cursor: status?.cursor ?? null,
+      chunks,
+      blocks,
+      messageRows
+    };
+  }
+}

--- a/packages/agents/src/e2e-tests/wrangler.jsonc
+++ b/packages/agents/src/e2e-tests/wrangler.jsonc
@@ -52,6 +52,10 @@
       {
         "name": "StreamKillTestAgent",
         "class_name": "StreamKillTestAgent"
+      },
+      {
+        "name": "CutoverKillAgent",
+        "class_name": "CutoverKillAgent"
       }
     ]
   },
@@ -79,6 +83,10 @@
     {
       "tag": "v5",
       "new_sqlite_classes": ["StreamKillTestAgent"]
+    },
+    {
+      "tag": "v6",
+      "new_sqlite_classes": ["CutoverKillAgent"]
     }
   ]
 }

--- a/packages/agents/src/sessions/handle.ts
+++ b/packages/agents/src/sessions/handle.ts
@@ -240,6 +240,64 @@ export class Session {
     return prepared.message;
   }
 
+  /**
+   * @internal Synchronous write aperture for same-isolate first-party
+   * machinery that must commit a message inside a caller-owned SQLite
+   * transaction — the stream cutover, where the finished message and the
+   * discard of its stream rows land together. Bypasses readiness (the
+   * caller owns startup ordering) and defers the change-feed dispatch: call
+   * the returned `notify()` after the transaction commits, or subscribers
+   * (the host's message mirror) never hear about the write. Will break
+   * without notice; never use from application code.
+   */
+  __DO_NOT_USE_WILL_BREAK__sync(): {
+    upsert(
+      message: SessionMessage,
+      options?: AppendOptions
+    ): { result: AppendResult; notify: () => Promise<void> };
+  } {
+    return {
+      upsert: (message, options = {}) => {
+        const prepared = this.#prepare(message, options.source);
+        if (!this.#core.exists(this.sessionId, message.id)) {
+          const result = this.#core.append(
+            this.sessionId,
+            prepared.message,
+            options.parentId,
+            prepared.tokenEstimate
+          );
+          return {
+            result,
+            notify: () =>
+              this.#core.notify({
+                type: "append",
+                sessionId: this.sessionId,
+                message: result.message,
+                parentId: options.parentId,
+                inserted: result.inserted
+              })
+          };
+        }
+        const outcome = this.#core.update(
+          this.sessionId,
+          prepared.message,
+          prepared.tokenEstimate
+        );
+        return {
+          result: { inserted: false, message: prepared.message },
+          notify: () =>
+            outcome === "updated"
+              ? this.#core.notify({
+                  type: "update",
+                  sessionId: this.sessionId,
+                  message: prepared.message
+                })
+              : Promise.resolve()
+        };
+      }
+    };
+  }
+
   async upsertMessage(
     message: SessionMessage,
     options: AppendOptions = {}

--- a/packages/agents/src/sessions/handle.ts
+++ b/packages/agents/src/sessions/handle.ts
@@ -245,16 +245,17 @@ export class Session {
    * machinery that must commit a message inside a caller-owned SQLite
    * transaction — the stream cutover, where the finished message and the
    * discard of its stream rows land together. Bypasses readiness (the
-   * caller owns startup ordering) and defers the change-feed dispatch: call
-   * the returned `notify()` after the transaction commits, or subscribers
-   * (the host's message mirror) never hear about the write. Will break
-   * without notice; never use from application code.
+   * caller owns startup ordering) and defers everything that follows a
+   * write — the change-feed dispatch and auto-compaction: call the returned
+   * `after()` once the transaction commits, or subscribers (the host's
+   * message mirror) never hear about the write. Will break without notice;
+   * never use from application code.
    */
   __DO_NOT_USE_WILL_BREAK__sync(): {
     upsert(
       message: SessionMessage,
       options?: AppendOptions
-    ): { result: AppendResult; notify: () => Promise<void> };
+    ): { result: AppendResult; after: () => Promise<void> };
   } {
     return {
       upsert: (message, options = {}) => {
@@ -268,14 +269,16 @@ export class Session {
           );
           return {
             result,
-            notify: () =>
-              this.#core.notify({
+            after: async () => {
+              await this.#core.notify({
                 type: "append",
                 sessionId: this.sessionId,
                 message: result.message,
                 parentId: options.parentId,
                 inserted: result.inserted
-              })
+              });
+              if (result.inserted) await this.#maybeAutoCompact();
+            }
           };
         }
         const outcome = this.#core.update(
@@ -285,7 +288,7 @@ export class Session {
         );
         return {
           result: { inserted: false, message: prepared.message },
-          notify: () =>
+          after: () =>
             outcome === "updated"
               ? this.#core.notify({
                   type: "update",

--- a/packages/agents/src/streams/index.ts
+++ b/packages/agents/src/streams/index.ts
@@ -22,6 +22,7 @@ export type {
   StreamOpenOptions,
   StreamReadBatchesOptions,
   StreamReadOptions,
+  StreamSettleOptions,
   StreamState,
   StreamStatus,
   StreamWriter

--- a/packages/agents/src/streams/streams.ts
+++ b/packages/agents/src/streams/streams.ts
@@ -1,6 +1,6 @@
 /**
  * Durable incremental output for Lifecycle Objects. `Streams` owns the
- * `cf_agents_streams` and `cf_agents_stream_chunks` tables: an ordered,
+ * `cf_agents_streams` and `cf_agents_stream_blocks` tables: an ordered,
  * durable chunk log per stream with a monotonic cursor, replay-then-tail
  * reads, and terminal status that doubles as recovery evidence for the
  * Tasks capability (which composes through checkpointed cursors, never
@@ -29,13 +29,22 @@ import type {
   StreamReadBatchesOptions,
   StreamReadOptions,
   StreamRow,
+  StreamSettleOptions,
   StreamState,
   StreamStatus,
   StreamWriter
 } from "./types";
 
 const STREAM_SCHEMA_VERSION_KEY = "cf_agents:streams_schema_version";
-const CURRENT_STREAM_SCHEMA_VERSION = 1;
+const CURRENT_STREAM_SCHEMA_VERSION = 2;
+
+/**
+ * A block row grows by UPDATE until its body reaches this many characters,
+ * then the next append opens a new block. Sized well under the 2 MiB row
+ * limit so a 1 MiB chunk always fits in a fresh block, and small enough
+ * that a replay page parses one block at a time.
+ */
+const BLOCK_MAX_CHARS = 256 * 1024;
 
 /** Default ceiling for one serialized chunk (1 MiB). */
 export const DEFAULT_MAX_CHUNK_BYTES = 1_048_576;
@@ -80,11 +89,16 @@ export interface StreamsSyncInternal {
    * (a live row's `updated_at` is set at open and not bumped by appends).
    */
   lastChunkAt(streamId: string): number | null;
-  /** Idempotent settlement with events and reader wakeup. */
+  /**
+   * Idempotent settlement with events and reader wakeup. With `options`,
+   * the settle, the caller's `commit` writes and the log discard run in
+   * one SQLite transaction (see {@link StreamSettleOptions}).
+   */
   settle(
     streamId: string,
     state: "completed" | "errored",
-    reason: string | null
+    reason: string | null,
+    options?: StreamSettleOptions
   ): void;
   /** Delete a stream and its chunks regardless of state. */
   deleteUnchecked(streamId: string): void;
@@ -161,6 +175,7 @@ export class Streams extends LifecycleCapability {
     const version = (await storage.get<number>(STREAM_SCHEMA_VERSION_KEY)) ?? 0;
     if (version < CURRENT_STREAM_SCHEMA_VERSION) {
       this.#ensureTables();
+      if (version >= 1) this.#migrateChunkRowsToBlocks();
       await storage.put(
         STREAM_SCHEMA_VERSION_KEY,
         CURRENT_STREAM_SCHEMA_VERSION
@@ -270,12 +285,7 @@ export class Streams extends LifecycleCapability {
     for (;;) {
       if (signal?.aborted) throw signal.reason ?? new Error("Read aborted");
 
-      const rows = this.#sql<StreamChunkRow>`
-        SELECT stream_id, seq, chunk, created_at FROM cf_agents_stream_chunks
-        WHERE stream_id = ${streamId} AND seq >= ${next}
-        ORDER BY seq ASC
-        LIMIT ${batchSize}
-      `;
+      const rows = this.#readChunks(streamId, next, batchSize);
       if (rows.length > 0) {
         next = rows[rows.length - 1].seq + 1;
         yield rows.map((row) => ({
@@ -369,10 +379,7 @@ export class Streams extends LifecycleCapability {
         `Cannot delete live stream "${streamId}"; close() or error() it first`
       );
     }
-    this.#sql`
-      DELETE FROM cf_agents_stream_chunks WHERE stream_id = ${streamId}
-    `;
-    this.#sql`DELETE FROM cf_agents_streams WHERE stream_id = ${streamId}`;
+    this.#deleteRows(streamId);
     this.#emit("stream:deleted", { streamId });
     return true;
   }
@@ -410,16 +417,10 @@ export class Streams extends LifecycleCapability {
       },
       append: (streamId, chunk) => this.#append(streamId, chunk),
       lastChunkAt: (streamId) => this.#tail(streamId).lastChunkAt,
-      settle: (streamId, state, reason) =>
-        this.#settle(streamId, state, reason),
+      settle: (streamId, state, reason, options) =>
+        this.#settle(streamId, state, reason, options),
       deleteUnchecked: (streamId) => {
-        this.#sql`
-          DELETE FROM cf_agents_stream_chunks WHERE stream_id = ${streamId}
-        `;
-        const removed = this.#sqlWrite(
-          "DELETE FROM cf_agents_streams WHERE stream_id = ?",
-          [streamId]
-        );
+        const removed = this.#deleteRows(streamId);
         if (removed > 0) this.#emit("stream:deleted", { streamId });
         // Unchecked deletes can remove a live stream: wake tailing readers
         // so they observe the deletion instead of pending forever.
@@ -427,19 +428,12 @@ export class Streams extends LifecycleCapability {
       },
       deleteMany: (streamIds) => {
         for (const streamId of streamIds) {
-          this.#sql`
-            DELETE FROM cf_agents_stream_chunks WHERE stream_id = ${streamId}
-          `;
-          this.#sql`DELETE FROM cf_agents_streams WHERE stream_id = ${streamId}`;
+          this.#deleteRows(streamId);
           this.#wake(streamId);
         }
       },
-      readChunks: (streamId, fromSeq, limit) => this.#sql<StreamChunkRow>`
-        SELECT stream_id, seq, chunk, created_at FROM cf_agents_stream_chunks
-        WHERE stream_id = ${streamId} AND seq >= ${fromSeq}
-        ORDER BY seq ASC
-        LIMIT ${limit}
-      `,
+      readChunks: (streamId, fromSeq, limit) =>
+        this.#readChunks(streamId, fromSeq, limit),
       listRows: () => this.#sql<StreamRow>`
         SELECT * FROM cf_agents_streams ORDER BY created_at DESC, rowid DESC
       `,
@@ -476,11 +470,8 @@ export class Streams extends LifecycleCapability {
           chunk,
           `chunk for stream "${streamId}"`
         );
-        const seq = this.#tail(streamId).nextSeq;
-        this.#sql`
-          INSERT INTO cf_agents_stream_chunks (stream_id, seq, chunk, created_at)
-          VALUES (${streamId}, ${seq}, ${chunkJson}, ${createdAt})
-        `;
+        if (chunkJson === null) return;
+        this.#writeChunk(streamId, chunkJson, createdAt);
       }
     };
   }
@@ -495,8 +486,9 @@ export class Streams extends LifecycleCapability {
         return capability.#tail(streamId).nextSeq;
       },
       append: (chunk) => this.#append(streamId, chunk),
-      close: () => this.#settle(streamId, "completed", null),
-      error: (reason) => this.#settle(streamId, "errored", reason ?? null)
+      close: (options) => this.#settle(streamId, "completed", null, options),
+      error: (reason, options) =>
+        this.#settle(streamId, "errored", reason ?? null, options)
     };
   }
 
@@ -512,9 +504,9 @@ export class Streams extends LifecycleCapability {
     }
     // The fence is a read, and its atomicity lives in the isolate's
     // threading model: a Durable Object executes one synchronous block at
-    // a time, so the state check, tail read, and INSERT below cannot
+    // a time, so the state check, tail read, and block write below cannot
     // interleave with a settle, delete, or another append. Nothing between
-    // here and the INSERT may await or call user code — either would
+    // here and the write may await or call user code — either would
     // reintroduce the lost-update races the old guarded-UPDATE fence
     // prevented, at the cost of one stream-row write per append.
     const state = this.#state(streamId);
@@ -524,16 +516,116 @@ export class Streams extends LifecycleCapability {
         state !== undefined ? `already settled as ${state}` : "it was deleted"
       );
     }
-    const seq = this.#tail(streamId).nextSeq;
-    this.#sql`
-      INSERT INTO cf_agents_stream_chunks (stream_id, seq, chunk, created_at)
-      VALUES (${streamId}, ${seq}, ${chunkJson}, ${Date.now()})
-    `;
+    const seq = this.#writeChunk(streamId, chunkJson, Date.now());
     this.#wake(streamId);
     return seq;
   }
 
+  /**
+   * Append one serialized chunk to the stream's open block, or open a new
+   * block when the current one is full. Either way it is one billed row:
+   * an UPDATE that grows the block body, or the INSERT of the next block.
+   * Blocks are what make cleanup cheap — a stream of thousands of chunks
+   * is a handful of rows to delete at cutover, not thousands.
+   */
+  #writeChunk(streamId: string, chunkJson: string, at: number): number {
+    const tail = this.#blockTail(streamId);
+    const seq = tail?.seq_to ?? 0;
+    if (tail && tail.len + chunkJson.length + 1 <= BLOCK_MAX_CHARS) {
+      this.#sql`
+        UPDATE cf_agents_stream_blocks
+        SET body = body || ',' || ${chunkJson}, seq_to = ${seq + 1}, updated_at = ${at}
+        WHERE stream_id = ${streamId} AND block = ${tail.block}
+      `;
+    } else {
+      this.#sql`
+        INSERT INTO cf_agents_stream_blocks
+          (stream_id, block, seq_from, seq_to, body, created_at, updated_at)
+        VALUES
+          (${streamId}, ${(tail?.block ?? -1) + 1}, ${seq}, ${seq + 1}, ${chunkJson}, ${at}, ${at})
+      `;
+    }
+    return seq;
+  }
+
+  /**
+   * One page of chunks from `fromSeq`, in seq order, parsing one block at
+   * a time. A block body is the chunks' JSON texts joined by commas, so
+   * `[${body}]` parses straight back into the chunk values.
+   */
+  #readChunks(
+    streamId: string,
+    fromSeq: number,
+    limit: number
+  ): StreamChunkRow[] {
+    const rows: StreamChunkRow[] = [];
+    let block = -1;
+    while (rows.length < limit) {
+      const next = this.#sql<{
+        block: number;
+        seq_from: number;
+        seq_to: number;
+        body: string;
+        updated_at: number;
+      }>`
+        SELECT block, seq_from, seq_to, body, updated_at
+        FROM cf_agents_stream_blocks
+        WHERE stream_id = ${streamId} AND block > ${block} AND seq_to > ${fromSeq}
+        ORDER BY block ASC
+        LIMIT 1
+      `[0];
+      if (!next) break;
+      block = next.block;
+      const chunks = JSON.parse(`[${next.body}]`) as StreamJson[];
+      for (
+        let seq = Math.max(fromSeq, next.seq_from);
+        seq < next.seq_to && rows.length < limit;
+        seq++
+      ) {
+        rows.push({
+          stream_id: streamId,
+          seq,
+          chunk: JSON.stringify(chunks[seq - next.seq_from]),
+          created_at: next.updated_at
+        });
+      }
+    }
+    return rows;
+  }
+
+  /** Delete a stream's blocks and row. Returns rows removed from the row table. */
+  #deleteRows(streamId: string): number {
+    this.#sql`DELETE FROM cf_agents_stream_blocks WHERE stream_id = ${streamId}`;
+    return this.#sqlWrite("DELETE FROM cf_agents_streams WHERE stream_id = ?", [
+      streamId
+    ]);
+  }
+
   #settle(
+    streamId: string,
+    state: Extract<StreamState, "completed" | "errored">,
+    reason: string | null,
+    options?: StreamSettleOptions
+  ): void {
+    if (!options?.commit && !options?.discard) {
+      this.#settleRow(streamId, state, reason);
+      return;
+    }
+    // The cutover: settle, the caller's writes (a session message), and
+    // the discard of this stream's rows commit together or not at all. A
+    // throwing `commit` rolls everything back and leaves the stream live.
+    this.lifecycle.storage.transactionSync(() => {
+      this.#settleRow(streamId, state, reason);
+      options.commit?.();
+      if (options.discard) {
+        const removed = this.#deleteRows(streamId);
+        if (removed > 0) this.#emit("stream:deleted", { streamId });
+      }
+    });
+    this.#wake(streamId);
+  }
+
+  #settleRow(
     streamId: string,
     state: Extract<StreamState, "completed" | "errored">,
     reason: string | null
@@ -686,16 +778,54 @@ export class Streams extends LifecycleCapability {
    * the stream row's `chunk_count`/`updated_at` are not maintained.
    */
   #tail(streamId: string): { nextSeq: number; lastChunkAt: number | null } {
-    const rows = this.#sql<{ seq: number; created_at: number }>`
-      SELECT seq, created_at FROM cf_agents_stream_chunks
-      WHERE stream_id = ${streamId}
-      ORDER BY seq DESC
-      LIMIT 1
-    `;
-    const tail = rows[0];
+    const tail = this.#blockTail(streamId);
     return tail
-      ? { nextSeq: tail.seq + 1, lastChunkAt: tail.created_at }
+      ? { nextSeq: tail.seq_to, lastChunkAt: tail.updated_at }
       : { nextSeq: 0, lastChunkAt: null };
+  }
+
+  /** The open block: one PK-served read (`ORDER BY block DESC LIMIT 1`). */
+  #blockTail(streamId: string) {
+    return this.#sql<{
+      block: number;
+      seq_to: number;
+      updated_at: number;
+      len: number;
+    }>`
+      SELECT block, seq_to, updated_at, length(body) AS len
+      FROM cf_agents_stream_blocks
+      WHERE stream_id = ${streamId}
+      ORDER BY block DESC
+      LIMIT 1
+    `[0];
+  }
+
+  /**
+   * Schema v1 → v2: fold the per-chunk `cf_agents_stream_chunks` rows into
+   * blocks, then drop the table. Chat retains stream rows for minutes, so
+   * this touches a handful of streams at most.
+   */
+  #migrateChunkRowsToBlocks(): void {
+    const legacy = this.#sql<{ name: string }>`
+      SELECT name FROM sqlite_master
+      WHERE type = 'table' AND name = 'cf_agents_stream_chunks'
+    `;
+    if (legacy.length === 0) return;
+    this.lifecycle.storage.transactionSync(() => {
+      const rows = this.#sql<{
+        stream_id: string;
+        seq: number;
+        chunk: string;
+        created_at: number;
+      }>`
+        SELECT stream_id, seq, chunk, created_at FROM cf_agents_stream_chunks
+        ORDER BY stream_id, seq ASC
+      `;
+      for (const row of rows) {
+        this.#writeChunk(row.stream_id, row.chunk, row.created_at);
+      }
+      this.#sqlWrite("DROP TABLE cf_agents_stream_chunks", []);
+    });
   }
 
   #rowToStatus(row: StreamRow): StreamStatus {
@@ -765,12 +895,15 @@ export class Streams extends LifecycleCapability {
       ON cf_agents_streams(tag, created_at)
     `);
     rawSql(`
-      CREATE TABLE IF NOT EXISTS cf_agents_stream_chunks (
+      CREATE TABLE IF NOT EXISTS cf_agents_stream_blocks (
         stream_id TEXT NOT NULL,
-        seq INTEGER NOT NULL,
-        chunk TEXT NOT NULL,
+        block INTEGER NOT NULL,
+        seq_from INTEGER NOT NULL,
+        seq_to INTEGER NOT NULL,
+        body TEXT NOT NULL,
         created_at INTEGER NOT NULL,
-        PRIMARY KEY (stream_id, seq)
+        updated_at INTEGER NOT NULL,
+        PRIMARY KEY (stream_id, block)
       ) WITHOUT ROWID`);
   }
 

--- a/packages/agents/src/streams/streams.ts
+++ b/packages/agents/src/streams/streams.ts
@@ -45,6 +45,8 @@ const CURRENT_STREAM_SCHEMA_VERSION = 2;
  * that a replay page parses one block at a time.
  */
 const BLOCK_MAX_CHARS = 256 * 1024;
+/** Rows read per page while folding one stream's v1 chunk rows into blocks. */
+const LEGACY_FOLD_PAGE_ROWS = 500;
 
 /** Default ceiling for one serialized chunk (1 MiB). */
 export const DEFAULT_MAX_CHUNK_BYTES = 1_048_576;
@@ -92,14 +94,16 @@ export interface StreamsSyncInternal {
   /**
    * Idempotent settlement with events and reader wakeup. With `options`,
    * the settle, the caller's `commit` writes and the log discard run in
-   * one SQLite transaction (see {@link StreamSettleOptions}).
+   * one SQLite transaction (see {@link StreamSettleOptions}). Returns
+   * whether the stream transitioned; on a repeat or a deleted stream the
+   * `commit` callback does not run.
    */
   settle(
     streamId: string,
     state: "completed" | "errored",
     reason: string | null,
     options?: StreamSettleOptions
-  ): void;
+  ): boolean;
   /** Delete a stream and its chunks regardless of state. */
   deleteUnchecked(streamId: string): void;
   /** Delete many streams and their chunks regardless of state, silently. */
@@ -161,6 +165,12 @@ export class Streams extends LifecycleCapability {
   readonly #maxChunkBytes: number;
   /** Wakeup callbacks for readers tailing a live stream, per stream. */
   readonly #wakeups = new Map<string, Set<() => void>>();
+  /**
+   * Whether the schema v1 `cf_agents_stream_chunks` table still exists.
+   * Its rows are folded into blocks one stream at a time, on first touch
+   * (see {@link #foldLegacyChunks}); the table is dropped once empty.
+   */
+  #legacyChunkTable = false;
 
   constructor(options: StreamsOptions = {}) {
     super("streams");
@@ -175,12 +185,12 @@ export class Streams extends LifecycleCapability {
     const version = (await storage.get<number>(STREAM_SCHEMA_VERSION_KEY)) ?? 0;
     if (version < CURRENT_STREAM_SCHEMA_VERSION) {
       this.#ensureTables();
-      if (version >= 1) this.#migrateChunkRowsToBlocks();
       await storage.put(
         STREAM_SCHEMA_VERSION_KEY,
         CURRENT_STREAM_SCHEMA_VERSION
       );
     }
+    if (version >= 1) this.#legacyChunkTable = this.#hasLegacyChunkTable();
   }
 
   // ── Producer surface ─────────────────────────────────────────────────────
@@ -558,6 +568,7 @@ export class Streams extends LifecycleCapability {
     fromSeq: number,
     limit: number
   ): StreamChunkRow[] {
+    this.#foldLegacyChunks(streamId);
     const rows: StreamChunkRow[] = [];
     let block = -1;
     while (rows.length < limit) {
@@ -595,46 +606,68 @@ export class Streams extends LifecycleCapability {
 
   /** Delete a stream's blocks and row. Returns rows removed from the row table. */
   #deleteRows(streamId: string): number {
+    if (this.#legacyChunkTable) {
+      // Unfolded v1 rows die with the stream; no point folding them first.
+      this.#sql`DELETE FROM cf_agents_stream_chunks WHERE stream_id = ${streamId}`;
+      this.#dropLegacyChunkTableIfEmpty();
+    }
     this.#sql`DELETE FROM cf_agents_stream_blocks WHERE stream_id = ${streamId}`;
     return this.#sqlWrite("DELETE FROM cf_agents_streams WHERE stream_id = ?", [
       streamId
     ]);
   }
 
+  /**
+   * @returns Whether this call transitioned the stream (a repeat, or a
+   * deleted stream, is a no-op and returns false: the caller's `commit`
+   * does not run and nothing is discarded).
+   */
   #settle(
     streamId: string,
     state: Extract<StreamState, "completed" | "errored">,
     reason: string | null,
     options?: StreamSettleOptions
-  ): void {
+  ): boolean {
     if (!options?.commit && !options?.discard) {
-      this.#settleRow(streamId, state, reason);
-      return;
+      const settled = this.#settleRow(streamId, state, reason);
+      if (settled) this.#emitSettled(streamId, state, reason);
+      // Idempotent for recovery callers; readers re-poll and observe the
+      // terminal state either way.
+      this.#wake(streamId);
+      return settled;
     }
     // The cutover: settle, the caller's writes (a session message), and
     // the discard of this stream's rows commit together or not at all. A
     // throwing `commit` rolls everything back and leaves the stream live.
+    // Events and wakeups are side effects outside SQLite, so they fire only
+    // once the transaction has returned.
+    let settled = false;
+    let deleted = false;
     this.lifecycle.storage.transactionSync(() => {
-      this.#settleRow(streamId, state, reason);
+      settled = this.#settleRow(streamId, state, reason);
+      if (!settled) return;
       options.commit?.();
-      if (options.discard) {
-        const removed = this.#deleteRows(streamId);
-        if (removed > 0) this.#emit("stream:deleted", { streamId });
-      }
+      if (options.discard) deleted = this.#deleteRows(streamId) > 0;
     });
+    if (settled) this.#emitSettled(streamId, state, reason);
+    if (deleted) this.#emit("stream:deleted", { streamId });
     this.#wake(streamId);
+    return settled;
   }
 
+  /**
+   * The one guarded UPDATE that ends a stream. Settlement is the moment
+   * the stream row becomes exact at rest: the same write stamps the final
+   * cursor, read from the chunk log's tail in the same synchronous block.
+   * While the stream was live, appends wrote only the chunk log — the
+   * row's chunk_count and updated_at were not maintained per append.
+   * @returns Whether the row transitioned from `streaming`.
+   */
   #settleRow(
     streamId: string,
     state: Extract<StreamState, "completed" | "errored">,
     reason: string | null
-  ): void {
-    // Settlement is the moment the stream row becomes exact at rest: the
-    // one UPDATE that ends the stream also stamps the final cursor, read
-    // from the chunk log's tail in the same synchronous block. While the
-    // stream was live, appends wrote only the chunk log — the row's
-    // chunk_count and updated_at were not maintained per append.
+  ): boolean {
     const finalCursor = this.#tail(streamId).nextSeq;
     const settled = this.#sqlWrite(
       `UPDATE cf_agents_streams
@@ -643,15 +676,18 @@ export class Streams extends LifecycleCapability {
        WHERE stream_id = ? AND state = 'streaming'`,
       [state, reason, Date.now(), Date.now(), finalCursor, streamId]
     );
-    if (settled > 0) {
-      this.#emit(state === "completed" ? "stream:closed" : "stream:errored", {
-        streamId,
-        ...(reason !== null ? { reason } : {})
-      });
-    }
-    // Idempotent for recovery callers; readers re-poll and observe the
-    // terminal state either way.
-    this.#wake(streamId);
+    return settled > 0;
+  }
+
+  #emitSettled(
+    streamId: string,
+    state: Extract<StreamState, "completed" | "errored">,
+    reason: string | null
+  ): void {
+    this.#emit(state === "completed" ? "stream:closed" : "stream:errored", {
+      streamId,
+      ...(reason !== null ? { reason } : {})
+    });
   }
 
   // ── Live fanout ──────────────────────────────────────────────────────────
@@ -786,6 +822,7 @@ export class Streams extends LifecycleCapability {
 
   /** The open block: one PK-served read (`ORDER BY block DESC LIMIT 1`). */
   #blockTail(streamId: string) {
+    this.#foldLegacyChunks(streamId);
     return this.#sql<{
       block: number;
       seq_to: number;
@@ -801,31 +838,92 @@ export class Streams extends LifecycleCapability {
   }
 
   /**
-   * Schema v1 → v2: fold the per-chunk `cf_agents_stream_chunks` rows into
-   * blocks, then drop the table. Chat retains stream rows for minutes, so
-   * this touches a handful of streams at most.
+   * Schema v1 → v2 is lazy: the per-chunk `cf_agents_stream_chunks` rows of
+   * ONE stream are folded into blocks the first time that stream is
+   * touched (a tail read before an append or settle, a replay, a delete).
+   * Startup never pays for the whole legacy log, so an object that let a
+   * large log accumulate still boots within its memory budget; each fold
+   * pages through its stream's rows and writes whole blocks, not one row
+   * per chunk. The table is dropped once the last stream's rows are gone.
    */
-  #migrateChunkRowsToBlocks(): void {
-    const legacy = this.#sql<{ name: string }>`
-      SELECT name FROM sqlite_master
-      WHERE type = 'table' AND name = 'cf_agents_stream_chunks'
-    `;
-    if (legacy.length === 0) return;
+  #foldLegacyChunks(streamId: string): void {
+    if (!this.#legacyChunkTable) return;
     this.lifecycle.storage.transactionSync(() => {
-      const rows = this.#sql<{
-        stream_id: string;
-        seq: number;
-        chunk: string;
-        created_at: number;
-      }>`
-        SELECT stream_id, seq, chunk, created_at FROM cf_agents_stream_chunks
-        ORDER BY stream_id, seq ASC
-      `;
-      for (const row of rows) {
-        this.#writeChunk(row.stream_id, row.chunk, row.created_at);
+      const tail = this.#sql<{ block: number; seq_to: number }>`
+        SELECT block, seq_to FROM cf_agents_stream_blocks
+        WHERE stream_id = ${streamId}
+        ORDER BY block DESC
+        LIMIT 1
+      `[0];
+      let block = (tail?.block ?? -1) + 1;
+      let seq = tail?.seq_to ?? 0;
+      let body = "";
+      let seqFrom = seq;
+      let createdAt = 0;
+      let updatedAt = 0;
+      const flush = () => {
+        if (body === "") return;
+        this.#sql`
+          INSERT INTO cf_agents_stream_blocks
+            (stream_id, block, seq_from, seq_to, body, created_at, updated_at)
+          VALUES
+            (${streamId}, ${block}, ${seqFrom}, ${seq}, ${body}, ${createdAt}, ${updatedAt})
+        `;
+        block += 1;
+        body = "";
+        seqFrom = seq;
+      };
+      let after = -1;
+      for (;;) {
+        const rows = this.#sql<{
+          seq: number;
+          chunk: string;
+          created_at: number;
+        }>`
+          SELECT seq, chunk, created_at FROM cf_agents_stream_chunks
+          WHERE stream_id = ${streamId} AND seq > ${after}
+          ORDER BY seq ASC
+          LIMIT ${LEGACY_FOLD_PAGE_ROWS}
+        `;
+        for (const row of rows) {
+          if (
+            body !== "" &&
+            body.length + row.chunk.length + 1 > BLOCK_MAX_CHARS
+          ) {
+            flush();
+          }
+          if (body === "") createdAt = row.created_at;
+          body = body === "" ? row.chunk : `${body},${row.chunk}`;
+          updatedAt = row.created_at;
+          seq += 1;
+          after = row.seq;
+        }
+        if (rows.length < LEGACY_FOLD_PAGE_ROWS) break;
       }
-      this.#sqlWrite("DROP TABLE cf_agents_stream_chunks", []);
+      flush();
+      if (after >= 0) {
+        this.#sql`DELETE FROM cf_agents_stream_chunks WHERE stream_id = ${streamId}`;
+      }
+      this.#dropLegacyChunkTableIfEmpty();
     });
+  }
+
+  #hasLegacyChunkTable(): boolean {
+    return (
+      this.#sql<{ name: string }>`
+        SELECT name FROM sqlite_master
+        WHERE type = 'table' AND name = 'cf_agents_stream_chunks'
+      `.length > 0
+    );
+  }
+
+  #dropLegacyChunkTableIfEmpty(): void {
+    const remaining = this.#sql<{ n: number }>`
+      SELECT COUNT(*) AS n FROM (SELECT 1 FROM cf_agents_stream_chunks LIMIT 1)
+    `[0].n;
+    if (remaining > 0) return;
+    this.#sqlWrite("DROP TABLE cf_agents_stream_chunks", []);
+    this.#legacyChunkTable = false;
   }
 
   #rowToStatus(row: StreamRow): StreamStatus {

--- a/packages/agents/src/streams/types.ts
+++ b/packages/agents/src/streams/types.ts
@@ -74,10 +74,31 @@ export interface StreamWriter {
   append(chunk: StreamJson): number;
 
   /** Settle the stream as completed. No-op if already terminal. */
-  close(): void;
+  close(options?: StreamSettleOptions): void;
 
   /** Settle the stream as errored. No-op if already terminal. */
-  error(reason?: string): void;
+  error(reason?: string, options?: StreamSettleOptions): void;
+}
+
+/**
+ * The cutover: settle a stream, run the caller's own synchronous writes
+ * (typically persisting the finished message), and discard the stream's
+ * rows, all in ONE SQLite transaction. A crash leaves either the live
+ * stream or the finished message, never neither. `commit` must not await
+ * and must not throw for a reason it wants ignored: a throw rolls the
+ * settle back and leaves the stream live.
+ *
+ * @experimental The API surface may change before stabilizing.
+ */
+export interface StreamSettleOptions {
+  /** Synchronous writes to commit with the settlement. */
+  readonly commit?: () => void;
+  /**
+   * Delete the stream's rows in the same transaction. The stream ceases
+   * to exist (`status()` returns null); readers tailing it end. Use when
+   * the chunks have been handed off, so nothing is left to sweep later.
+   */
+  readonly discard?: boolean;
 }
 
 /** Options accepted by `Streams.open()`. */
@@ -144,7 +165,7 @@ export type StreamRow = {
   closed_at: number | null;
 };
 
-/** @internal Raw `cf_agents_stream_chunks` SQLite row. */
+/** @internal One chunk as read back from a `cf_agents_stream_blocks` row. */
 export type StreamChunkRow = {
   stream_id: string;
   seq: number;

--- a/packages/agents/src/streams/types.ts
+++ b/packages/agents/src/streams/types.ts
@@ -73,10 +73,13 @@ export interface StreamWriter {
   /** Durably append one chunk and wake live readers. Returns its `seq`. */
   append(chunk: StreamJson): number;
 
-  /** Settle the stream as completed. No-op if already terminal. */
+  /**
+   * Settle the stream as completed. No-op if already terminal or deleted:
+   * `options.commit` runs only when this call ends the stream.
+   */
   close(options?: StreamSettleOptions): void;
 
-  /** Settle the stream as errored. No-op if already terminal. */
+  /** Settle the stream as errored. Same no-op contract as {@link close}. */
   error(reason?: string, options?: StreamSettleOptions): void;
 }
 
@@ -87,6 +90,10 @@ export interface StreamWriter {
  * stream or the finished message, never neither. `commit` must not await
  * and must not throw for a reason it wants ignored: a throw rolls the
  * settle back and leaves the stream live.
+ *
+ * Settlement stays idempotent: on a stream already terminal or deleted,
+ * `commit` does not run and nothing is discarded. Events and reader wakeups
+ * fire after the transaction commits, never for a rolled-back cutover.
  *
  * @experimental The API surface may change before stabilizing.
  */

--- a/packages/agents/src/tests/capabilities/sqlite-strategies-bench.ts
+++ b/packages/agents/src/tests/capabilities/sqlite-strategies-bench.ts
@@ -1,0 +1,454 @@
+import { DurableObject } from "cloudflare:workers";
+
+/**
+ * Experimental benchmark: three ways to hold a stream's temporary blocks in
+ * DO SQLite before the atomic cutover to a session message.
+ *
+ *   temporary stream blocks → session message → delete temporary blocks
+ *
+ * S1 immutable packed rows — one INSERT per flush, DELETE all at cutover
+ *    (today's Streams/ResumableStream shape).
+ * S2 reusable generational slots — a pool of slot rows; a flush is an
+ *    UPDATE of a free slot; cutover releases nothing (slots are free once
+ *    the stream row is settled), so cleanup costs zero writes.
+ * S3 mutable rollover blocks — one row per ~256 KB block; a flush is an
+ *    UPDATE appending to the open block (rollover INSERTs a new one);
+ *    cutover DELETEs the few block rows.
+ *
+ * Every strategy shares the stream row table and the message table and
+ * performs the cutover inside one `transactionSync`. Measured per
+ * workload: billed rows written (`cursor.rowsWritten`), rows read, wall
+ * time for the write path, database size growth, cold replay time and
+ * rows read, and the cursor recoverable from storage alone (what a
+ * restarted isolate sees) at an arbitrary kill point.
+ */
+
+export type Strategy = "packed" | "slots" | "rollover";
+
+export interface Workload {
+  name: string;
+  chunks: number;
+  bytesPerChunk: number;
+  /** Chunks per flush (the cadence a time-based flush would produce). */
+  flushEvery: number;
+}
+
+export interface Measurement {
+  strategy: Strategy;
+  workload: string;
+  rowsWritten: number;
+  rowsRead: number;
+  writeMs: number;
+  cutoverRowsWritten: number;
+  cutoverMs: number;
+  dbGrowthBytes: number;
+  dbPeakGrowthBytes: number;
+  replayMs: number;
+  replayRowsRead: number;
+  replayChunks: number;
+  /** Chunks recoverable from storage alone after a kill at `killAt`. */
+  killAt: number;
+  recoveredCursor: number;
+}
+
+const BLOCK_MAX_BYTES = 256 * 1024;
+const SLOT_POOL = 64;
+
+interface Counters {
+  written: number;
+  read: number;
+}
+
+export class SqliteStrategiesBench extends DurableObject<Cloudflare.Env> {
+  #counters: Counters = { written: 0, read: 0 };
+  #freeSlots: number[] = [];
+  #poolSize = 0;
+  readonly #ownedSlots = new Map<string, number[]>();
+
+  #exec<T = Record<string, unknown>>(query: string, ...params: unknown[]) {
+    const cursor = this.ctx.storage.sql.exec<T>(query, ...params);
+    const rows = cursor.toArray();
+    this.#counters.written += cursor.rowsWritten;
+    this.#counters.read += cursor.rowsRead;
+    return rows;
+  }
+
+  #reset(): Counters {
+    const c = { ...this.#counters };
+    this.#counters = { written: 0, read: 0 };
+    return c;
+  }
+
+  #schema(): void {
+    const sql = this.ctx.storage.sql;
+    sql.exec(`CREATE TABLE IF NOT EXISTS b_streams (
+      stream_id TEXT PRIMARY KEY, state TEXT NOT NULL, chunk_count INTEGER NOT NULL,
+      created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL)`);
+    sql.exec(`CREATE TABLE IF NOT EXISTS b_messages (
+      session_id TEXT NOT NULL, id TEXT NOT NULL, content TEXT NOT NULL,
+      PRIMARY KEY (session_id, id)) WITHOUT ROWID`);
+    // S1
+    sql.exec(`CREATE TABLE IF NOT EXISTS s1_chunks (
+      stream_id TEXT NOT NULL, seq INTEGER NOT NULL, chunk TEXT NOT NULL,
+      PRIMARY KEY (stream_id, seq)) WITHOUT ROWID`);
+    // S2: a pool of slots. stream_id/gen say who owns a slot; a slot is
+    // free when its owner's stream row is not `streaming`.
+    sql.exec(`CREATE TABLE IF NOT EXISTS s2_slots (
+      slot INTEGER PRIMARY KEY, stream_id TEXT, gen INTEGER NOT NULL DEFAULT 0,
+      seq_from INTEGER NOT NULL DEFAULT 0, seq_to INTEGER NOT NULL DEFAULT 0,
+      chunk TEXT NOT NULL DEFAULT '') WITHOUT ROWID`);
+    // S3
+    sql.exec(`CREATE TABLE IF NOT EXISTS s3_blocks (
+      stream_id TEXT NOT NULL, block INTEGER NOT NULL, seq_from INTEGER NOT NULL,
+      seq_to INTEGER NOT NULL, chunk TEXT NOT NULL,
+      PRIMARY KEY (stream_id, block)) WITHOUT ROWID`);
+  }
+
+  #body(i: number, bytes: number): string {
+    return JSON.stringify({
+      type: "text-delta",
+      delta: `${i}:${"x".repeat(Math.max(0, bytes - 40))}`
+    });
+  }
+
+  // ── Strategy write paths ──────────────────────────────────────────────
+
+  /** One packed flush. Returns nothing; the row accounting is global. */
+  #flush(
+    strategy: Strategy,
+    streamId: string,
+    gen: number,
+    seqFrom: number,
+    seqTo: number,
+    packed: string,
+    st: { block: number; blockBytes: number; slots: number[] }
+  ): void {
+    switch (strategy) {
+      case "packed":
+        this.#exec(
+          "INSERT INTO s1_chunks (stream_id, seq, chunk) VALUES (?, ?, ?)",
+          streamId,
+          seqFrom,
+          packed
+        );
+        return;
+      case "slots": {
+        // Free list lives in memory (rebuilt by one pool scan on a cold
+        // start); popping costs no read, releasing at cutover no write.
+        let slot = this.#freeSlots.pop();
+        if (slot === undefined) {
+          // Every slot is owned by a live stream: grow the pool (one INSERT).
+          slot = this.#poolSize++;
+          this.#exec(
+            "INSERT INTO s2_slots (slot, stream_id, gen, seq_from, seq_to, chunk) VALUES (?, ?, ?, ?, ?, ?)",
+            slot,
+            streamId,
+            gen,
+            seqFrom,
+            seqTo,
+            packed
+          );
+        } else {
+          this.#exec(
+            "UPDATE s2_slots SET stream_id = ?, gen = ?, seq_from = ?, seq_to = ?, chunk = ? WHERE slot = ?",
+            streamId,
+            gen,
+            seqFrom,
+            seqTo,
+            packed,
+            slot
+          );
+        }
+        st.slots.push(slot);
+        const owned = this.#ownedSlots.get(streamId) ?? [];
+        owned.push(slot);
+        this.#ownedSlots.set(streamId, owned);
+        return;
+      }
+      case "rollover": {
+        if (
+          st.blockBytes > 0 &&
+          st.blockBytes + packed.length <= BLOCK_MAX_BYTES
+        ) {
+          this.#exec(
+            "UPDATE s3_blocks SET chunk = chunk || ?, seq_to = ? WHERE stream_id = ? AND block = ?",
+            `,${packed}`,
+            seqTo,
+            streamId,
+            st.block
+          );
+          st.blockBytes += packed.length + 1;
+        } else {
+          st.block += 1;
+          this.#exec(
+            "INSERT INTO s3_blocks (stream_id, block, seq_from, seq_to, chunk) VALUES (?, ?, ?, ?, ?)",
+            streamId,
+            st.block,
+            seqFrom,
+            seqTo,
+            packed
+          );
+          st.blockBytes = packed.length;
+        }
+        return;
+      }
+    }
+  }
+
+  /** Every chunk recoverable from storage alone, in order. */
+  #replay(strategy: Strategy, streamId: string, gen: number): string[] {
+    const unpack = (rows: { chunk: string }[]) =>
+      rows.flatMap((r) => JSON.parse(`[${r.chunk}]`) as string[]);
+    switch (strategy) {
+      case "packed":
+        return unpack(
+          this.#exec<{ chunk: string }>(
+            "SELECT chunk FROM s1_chunks WHERE stream_id = ? ORDER BY seq",
+            streamId
+          )
+        );
+      case "slots":
+        return unpack(
+          this.#exec<{ chunk: string }>(
+            "SELECT chunk FROM s2_slots WHERE stream_id = ? AND gen = ? ORDER BY seq_from",
+            streamId,
+            gen
+          )
+        );
+      case "rollover":
+        return unpack(
+          this.#exec<{ chunk: string }>(
+            "SELECT chunk FROM s3_blocks WHERE stream_id = ? ORDER BY block",
+            streamId
+          )
+        );
+    }
+  }
+
+  #cleanup(strategy: Strategy, streamId: string): void {
+    switch (strategy) {
+      case "packed":
+        this.#exec("DELETE FROM s1_chunks WHERE stream_id = ?", streamId);
+        return;
+      case "slots": {
+        // Release in memory only; the settled stream row is the proof.
+        const owned = this.#ownedSlots.get(streamId) ?? [];
+        this.#freeSlots.push(...owned);
+        this.#ownedSlots.delete(streamId);
+        return;
+      }
+      case "rollover":
+        this.#exec("DELETE FROM s3_blocks WHERE stream_id = ?", streamId);
+        return;
+    }
+  }
+
+  // ── Bench ─────────────────────────────────────────────────────────────
+
+  /**
+   * Run one workload under one strategy: open, flush every `flushEvery`
+   * chunks, measure the storage-only recoverable cursor at `killAt`
+   * (before cutover), cutover atomically, then cold-replay the message.
+   */
+  async run(
+    strategy: Strategy,
+    workload: Workload,
+    killAt: number
+  ): Promise<Measurement> {
+    this.#schema();
+    const streamId = `${strategy}-${workload.name}-${crypto.randomUUID().slice(0, 8)}`;
+    const gen = Date.now() % 1_000_000;
+    const now = Date.now();
+    const sizeBefore = this.ctx.storage.sql.databaseSize;
+    let peak = sizeBefore;
+    this.#reset();
+    const t0 = performance.now();
+    this.#exec(
+      "INSERT INTO b_streams (stream_id, state, chunk_count, created_at, updated_at) VALUES (?, 'streaming', 0, ?, ?)",
+      streamId,
+      now,
+      now
+    );
+    const st = { block: 0, blockBytes: 0, slots: [] as number[] };
+    let buffer: string[] = [];
+    let seqFrom = 0;
+    let recoveredCursor = -1;
+    const flushNow = (seqTo: number) => {
+      if (buffer.length === 0) return;
+      this.#flush(
+        strategy,
+        streamId,
+        gen,
+        seqFrom,
+        seqTo,
+        buffer.map((b) => JSON.stringify(b)).join(","),
+        st
+      );
+      seqFrom = seqTo;
+      buffer = [];
+      peak = Math.max(peak, this.ctx.storage.sql.databaseSize);
+    };
+    for (let i = 0; i < workload.chunks; i++) {
+      buffer.push(this.#body(i, workload.bytesPerChunk));
+      if (buffer.length >= workload.flushEvery) flushNow(i + 1);
+      if (i + 1 === killAt) {
+        // What storage alone holds right now = what a restart recovers.
+        const c = this.#reset();
+        recoveredCursor = this.#replay(strategy, streamId, gen).length;
+        this.#reset();
+        this.#counters = c;
+      }
+    }
+    // Final flush of the tail is part of the cutover block below.
+    const writeMs = performance.now() - t0;
+    const written = this.#reset();
+
+    // Atomic cutover: final tail flush, message insert, settle, cleanup.
+    const t1 = performance.now();
+    this.ctx.storage.transactionSync(() => {
+      flushNow(workload.chunks);
+      const all = this.#replay(strategy, streamId, gen);
+      this.#exec(
+        "INSERT INTO b_messages (session_id, id, content) VALUES (?, ?, ?)",
+        "session",
+        streamId,
+        JSON.stringify(all)
+      );
+      this.#exec(
+        "UPDATE b_streams SET state = 'completed', chunk_count = ?, updated_at = ? WHERE stream_id = ?",
+        all.length,
+        Date.now(),
+        streamId
+      );
+      this.#cleanup(strategy, streamId);
+    });
+    const cutoverMs = performance.now() - t1;
+    const cutover = this.#reset();
+    peak = Math.max(peak, this.ctx.storage.sql.databaseSize);
+    const sizeAfter = this.ctx.storage.sql.databaseSize;
+
+    // Cold replay of the handed-off message.
+    const t2 = performance.now();
+    const replayed = JSON.parse(
+      this.#exec<{ content: string }>(
+        "SELECT content FROM b_messages WHERE session_id = ? AND id = ?",
+        "session",
+        streamId
+      )[0].content
+    ) as string[];
+    const replayMs = performance.now() - t2;
+    const replay = this.#reset();
+
+    return {
+      strategy,
+      workload: workload.name,
+      rowsWritten: written.written,
+      rowsRead: written.read,
+      writeMs: Math.round(writeMs * 100) / 100,
+      cutoverRowsWritten: cutover.written,
+      cutoverMs: Math.round(cutoverMs * 100) / 100,
+      dbGrowthBytes: sizeAfter - sizeBefore,
+      dbPeakGrowthBytes: peak - sizeBefore,
+      replayMs: Math.round(replayMs * 100) / 100,
+      replayRowsRead: replay.read,
+      replayChunks: replayed.length,
+      killAt,
+      recoveredCursor
+    };
+  }
+
+  /**
+   * Real-kill half: flush up to `killAt` chunks (mid-flush leftovers stay
+   * in memory), then abort the object. Nothing after `ctx.abort()` runs.
+   */
+  #ensurePool(): void {
+    if (this.#poolSize > 0) return;
+    const rows = this.ctx.storage.sql
+      .exec<{ slot: number; stream_id: string | null }>(
+        "SELECT slot, stream_id FROM s2_slots ORDER BY slot"
+      )
+      .toArray();
+    this.#poolSize = rows.length;
+    this.#freeSlots = rows
+      .filter((r) => r.stream_id === null)
+      .map((r) => r.slot)
+      .reverse();
+  }
+
+  async writeThenAbort(
+    strategy: Strategy,
+    workload: Workload,
+    killAt: number,
+    streamId: string,
+    gen: number,
+    gapMs = 0
+  ): Promise<never> {
+    this.#schema();
+    this.#ensurePool();
+    const now = Date.now();
+    this.#exec(
+      "INSERT INTO b_streams (stream_id, state, chunk_count, created_at, updated_at) VALUES (?, 'streaming', 0, ?, ?)",
+      streamId,
+      now,
+      now
+    );
+    const st = { block: 0, blockBytes: 0, slots: [] as number[] };
+    let buffer: string[] = [];
+    let seqFrom = 0;
+    for (let i = 0; i < killAt; i++) {
+      buffer.push(this.#body(i, workload.bytesPerChunk));
+      if (buffer.length >= workload.flushEvery) {
+        this.#flush(
+          strategy,
+          streamId,
+          gen,
+          seqFrom,
+          i + 1,
+          buffer.map((b) => JSON.stringify(b)).join(","),
+          st
+        );
+        seqFrom = i + 1;
+        buffer = [];
+        // A real producer awaits between chunks; each await ends the
+        // synchronous block and lets its writes commit.
+        if (gapMs >= 0) await new Promise((r) => setTimeout(r, gapMs));
+      }
+    }
+    this.ctx.abort("simulated crash");
+    throw new Error("unreachable");
+  }
+
+  /** What a fresh isolate can recover from storage alone. */
+  async recover(
+    strategy: Strategy,
+    streamId: string,
+    gen: number
+  ): Promise<number> {
+    this.#schema();
+    return this.#replay(strategy, streamId, gen).length;
+  }
+
+  /** Reset every table so strategies do not pay for each other's pages. */
+  async wipe(): Promise<void> {
+    this.#schema();
+    for (const t of [
+      "b_streams",
+      "b_messages",
+      "s1_chunks",
+      "s2_slots",
+      "s3_blocks"
+    ]) {
+      this.ctx.storage.sql.exec(`DELETE FROM ${t}`);
+    }
+    // Pre-create the slot pool so S2 does not pay INSERTs on its first stream.
+    for (let i = 0; i < SLOT_POOL; i++) {
+      this.ctx.storage.sql.exec("INSERT INTO s2_slots (slot) VALUES (?)", i);
+    }
+    this.#poolSize = SLOT_POOL;
+    this.#freeSlots = Array.from(
+      { length: SLOT_POOL },
+      (_, i) => SLOT_POOL - 1 - i
+    );
+    this.#ownedSlots.clear();
+  }
+}

--- a/packages/agents/src/tests/capabilities/sqlite-strategies-bench.ts
+++ b/packages/agents/src/tests/capabilities/sqlite-strategies-bench.ts
@@ -65,7 +65,9 @@ export class SqliteStrategiesBench extends DurableObject<Cloudflare.Env> {
   #poolSize = 0;
   readonly #ownedSlots = new Map<string, number[]>();
 
-  #exec<T = Record<string, unknown>>(query: string, ...params: unknown[]) {
+  #exec<
+    T extends Record<string, SqlStorageValue> = Record<string, SqlStorageValue>
+  >(query: string, ...params: unknown[]) {
     const cursor = this.ctx.storage.sql.exec<T>(query, ...params);
     const rows = cursor.toArray();
     this.#counters.written += cursor.rowsWritten;

--- a/packages/agents/src/tests/capabilities/streams-bench.ts
+++ b/packages/agents/src/tests/capabilities/streams-bench.ts
@@ -201,10 +201,21 @@ export class StreamBenchObject extends DurableObject<Cloudflare.Env> {
         now,
         now
       ),
-      realChunkAppend: w(
-        `INSERT INTO cf_agents_stream_chunks (stream_id, seq, chunk, created_at)
-         VALUES ('probe-s', 0, '"x"', ?)`,
+      realBlockOpen: w(
+        `INSERT INTO cf_agents_stream_blocks
+           (stream_id, block, seq_from, seq_to, body, created_at, updated_at)
+         VALUES ('probe-s', 0, 0, 1, '"x"', ?, ?)`,
+        now,
         now
+      ),
+      realBlockAppend: w(
+        `UPDATE cf_agents_stream_blocks
+         SET body = body || ',' || '"y"', seq_to = 2, updated_at = ?
+         WHERE stream_id = 'probe-s' AND block = 0`,
+        now
+      ),
+      realBlockDelete: w(
+        `DELETE FROM cf_agents_stream_blocks WHERE stream_id = 'probe-s'`
       ),
       realStreamSettle: w(
         `UPDATE cf_agents_streams
@@ -259,8 +270,8 @@ export class StreamBenchObject extends DurableObject<Cloudflare.Env> {
         continue;
       }
       const tail = sql.exec(
-        `SELECT seq, created_at FROM cf_agents_stream_chunks
-         WHERE stream_id = ? ORDER BY seq DESC LIMIT 1`,
+        `SELECT seq_to, updated_at FROM cf_agents_stream_blocks
+         WHERE stream_id = ? ORDER BY block DESC LIMIT 1`,
         row.stream_id
       );
       [...tail];

--- a/packages/agents/src/tests/capabilities/streams.ts
+++ b/packages/agents/src/tests/capabilities/streams.ts
@@ -1,5 +1,6 @@
 import { DurableObject } from "cloudflare:workers";
 import { Lifecycle } from "../../lifecycle";
+import { Sessions } from "../../sessions";
 import { Streams } from "../../streams";
 import { Tasks, type TaskStep } from "../../tasks";
 
@@ -13,6 +14,19 @@ import { Tasks, type TaskStep } from "../../tasks";
 export class StreamHarnessObject extends DurableObject<Cloudflare.Env> {
   readonly streams = new Streams({ maxChunkBytes: 1024 });
   readonly lifecycle = Lifecycle.install(this).use(this.streams);
+}
+
+/**
+ * Streams and Sessions on one Lifecycle: the cutover host. A finished
+ * stream becomes a session message and its rows are discarded in one
+ * SQLite transaction (`close({ commit, discard })`).
+ */
+export class CutoverHarnessObject extends DurableObject<Cloudflare.Env> {
+  readonly streams = new Streams();
+  readonly sessions = new Sessions();
+  readonly lifecycle = Lifecycle.install(this)
+    .use(this.streams)
+    .use(this.sessions);
 }
 
 /**

--- a/packages/agents/src/tests/streams/cutover.test.ts
+++ b/packages/agents/src/tests/streams/cutover.test.ts
@@ -19,6 +19,11 @@ async function collect(
   return chunks;
 }
 
+/** The harness's storage; `ctx` is protected on DurableObject. */
+function sqlOf(instance: CutoverHarnessObject): SqlStorage {
+  return (instance as unknown as { ctx: DurableObjectState }).ctx.storage.sql;
+}
+
 describe("stream → session cutover", () => {
   it("commits the message, settles and discards the stream together", async () => {
     const stub = env.CutoverHarnessObject.getByName(crypto.randomUUID());
@@ -33,7 +38,7 @@ describe("stream → session cutover", () => {
       }
       // One block row holds all 300 chunks (well under the block ceiling).
       const blocks = [
-        ...instance.ctx.storage.sql.exec(
+        ...sqlOf(instance).exec(
           "SELECT COUNT(*) AS n FROM cf_agents_stream_blocks WHERE stream_id = 'turn-1'"
         )
       ][0].n;
@@ -49,7 +54,7 @@ describe("stream → session cutover", () => {
         commit: () => {
           notify = session
             .__DO_NOT_USE_WILL_BREAK__sync()
-            .upsert(message).notify;
+            .upsert(message).after;
         },
         discard: true
       });
@@ -58,7 +63,7 @@ describe("stream → session cutover", () => {
       expect(await instance.streams.status("turn-1")).toBeNull();
       expect(await instance.streams.list({ tag: "req-1" })).toEqual([]);
       const rows = [
-        ...instance.ctx.storage.sql.exec(
+        ...sqlOf(instance).exec(
           "SELECT COUNT(*) AS n FROM cf_agents_stream_blocks"
         )
       ][0].n;
@@ -109,7 +114,7 @@ describe("stream → session cutover", () => {
       for (let i = 0; i < 12; i++) stream.append(`${i}:${chunk}`);
       stream.close();
       const blocks = [
-        ...instance.ctx.storage.sql.exec(
+        ...sqlOf(instance).exec(
           "SELECT block, seq_from, seq_to FROM cf_agents_stream_blocks WHERE stream_id = 'big' ORDER BY block"
         )
       ] as { block: number; seq_from: number; seq_to: number }[];
@@ -125,7 +130,7 @@ describe("stream → session cutover", () => {
       expect(await instance.streams.delete("big")).toBe(true);
       expect(
         [
-          ...instance.ctx.storage.sql.exec(
+          ...sqlOf(instance).exec(
             "SELECT COUNT(*) AS n FROM cf_agents_stream_blocks WHERE stream_id = 'big'"
           )
         ][0].n

--- a/packages/agents/src/tests/streams/cutover.test.ts
+++ b/packages/agents/src/tests/streams/cutover.test.ts
@@ -1,0 +1,135 @@
+import { env } from "cloudflare:workers";
+import { runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import type { CutoverHarnessObject } from "../capabilities/streams";
+import type { StreamChunk } from "../../streams";
+
+/**
+ * The cutover: temporary stream blocks → session message → delete the
+ * blocks, in one SQLite transaction. Either the finished message exists
+ * and the stream is gone, or the stream is still live and no message
+ * exists; never neither, never both.
+ */
+
+async function collect(
+  iterator: AsyncGenerator<StreamChunk, void, undefined>
+): Promise<StreamChunk[]> {
+  const chunks: StreamChunk[] = [];
+  for await (const chunk of iterator) chunks.push(chunk);
+  return chunks;
+}
+
+describe("stream → session cutover", () => {
+  it("commits the message, settles and discards the stream together", async () => {
+    const stub = env.CutoverHarnessObject.getByName(crypto.randomUUID());
+    await runInDurableObject(stub, async (instance: CutoverHarnessObject) => {
+      await instance.lifecycle.start();
+      const session = instance.sessions.session();
+      const stream = await instance.streams.open("turn-1", { tag: "req-1" });
+      const deltas: string[] = [];
+      for (let i = 0; i < 300; i++) {
+        deltas.push(`w${i} `);
+        stream.append({ type: "text-delta", delta: `w${i} ` });
+      }
+      // One block row holds all 300 chunks (well under the block ceiling).
+      const blocks = [
+        ...instance.ctx.storage.sql.exec(
+          "SELECT COUNT(*) AS n FROM cf_agents_stream_blocks WHERE stream_id = 'turn-1'"
+        )
+      ][0].n;
+      expect(blocks).toBe(1);
+
+      const message = {
+        id: "m-1",
+        role: "assistant" as const,
+        parts: [{ type: "text" as const, text: deltas.join("") }]
+      };
+      let notify: (() => Promise<void>) | undefined;
+      stream.close({
+        commit: () => {
+          notify = session
+            .__DO_NOT_USE_WILL_BREAK__sync()
+            .upsert(message).notify;
+        },
+        discard: true
+      });
+      await notify?.();
+
+      expect(await instance.streams.status("turn-1")).toBeNull();
+      expect(await instance.streams.list({ tag: "req-1" })).toEqual([]);
+      const rows = [
+        ...instance.ctx.storage.sql.exec(
+          "SELECT COUNT(*) AS n FROM cf_agents_stream_blocks"
+        )
+      ][0].n;
+      expect(rows).toBe(0);
+      const stored = await session.getMessage("m-1");
+      expect(stored?.parts).toEqual(message.parts);
+    });
+  });
+
+  it("a throwing commit rolls the settle back and leaves the stream live", async () => {
+    const stub = env.CutoverHarnessObject.getByName(crypto.randomUUID());
+    await runInDurableObject(stub, async (instance: CutoverHarnessObject) => {
+      await instance.lifecycle.start();
+      const stream = await instance.streams.open("turn-2");
+      stream.append("a");
+      stream.append("b");
+      expect(() =>
+        stream.close({
+          commit: () => {
+            throw new Error("persist failed");
+          },
+          discard: true
+        })
+      ).toThrow("persist failed");
+      expect((await instance.streams.status("turn-2"))?.state).toBe(
+        "streaming"
+      );
+      expect(stream.append("c")).toBe(2);
+      const all = await collect(
+        (async function* () {
+          for await (const batch of instance.streams.readBatches("turn-2", {
+            onUpToDate: () => stream.close()
+          })) {
+            for (const c of batch) yield c;
+          }
+        })()
+      );
+      expect(all.map((c) => c.chunk)).toEqual(["a", "b", "c"]);
+    });
+  });
+
+  it("blocks roll over and replay across the boundary", async () => {
+    const stub = env.CutoverHarnessObject.getByName(crypto.randomUUID());
+    await runInDurableObject(stub, async (instance: CutoverHarnessObject) => {
+      await instance.lifecycle.start();
+      const stream = await instance.streams.open("big");
+      const chunk = "x".repeat(60 * 1024);
+      for (let i = 0; i < 12; i++) stream.append(`${i}:${chunk}`);
+      stream.close();
+      const blocks = [
+        ...instance.ctx.storage.sql.exec(
+          "SELECT block, seq_from, seq_to FROM cf_agents_stream_blocks WHERE stream_id = 'big' ORDER BY block"
+        )
+      ] as { block: number; seq_from: number; seq_to: number }[];
+      // 256 KB ceiling, ~60 KB chunks: four per block, three blocks.
+      expect(blocks.map((b) => [b.seq_from, b.seq_to])).toEqual([
+        [0, 4],
+        [4, 8],
+        [8, 12]
+      ]);
+      const fromFive = await collect(instance.streams.read("big", { from: 5 }));
+      expect(fromFive.map((c) => c.seq)).toEqual([5, 6, 7, 8, 9, 10, 11]);
+      expect((fromFive[0].chunk as string).slice(0, 2)).toBe("5:");
+      expect(await instance.streams.delete("big")).toBe(true);
+      expect(
+        [
+          ...instance.ctx.storage.sql.exec(
+            "SELECT COUNT(*) AS n FROM cf_agents_stream_blocks WHERE stream_id = 'big'"
+          )
+        ][0].n
+      ).toBe(0);
+    });
+  });
+});

--- a/packages/agents/src/tests/streams/cutover.test.ts
+++ b/packages/agents/src/tests/streams/cutover.test.ts
@@ -3,6 +3,7 @@ import { runInDurableObject } from "cloudflare:test";
 import { describe, expect, it } from "vitest";
 import type { CutoverHarnessObject } from "../capabilities/streams";
 import type { StreamChunk } from "../../streams";
+import { captureDiagnosticsEvents } from "../shared/diagnostics-capture";
 
 /**
  * The cutover: temporary stream blocks → session message → delete the
@@ -136,5 +137,58 @@ describe("stream → session cutover", () => {
         ][0].n
       ).toBe(0);
     });
+  });
+
+  it("a repeated cutover is a no-op: commit does not run again", async () => {
+    const stub = env.CutoverHarnessObject.getByName(crypto.randomUUID());
+    await runInDurableObject(stub, async (instance: CutoverHarnessObject) => {
+      await instance.lifecycle.start();
+      const stream = await instance.streams.open("turn-3");
+      stream.append("a");
+      let commits = 0;
+      const commit = () => {
+        commits++;
+      };
+      stream.close({ commit });
+      stream.close({ commit, discard: true });
+      stream.error("late", { commit, discard: true });
+      expect(commits).toBe(1);
+      // The repeat's discard did not run either: the settled rows remain.
+      expect((await instance.streams.status("turn-3"))?.state).toBe(
+        "completed"
+      );
+      await instance.streams.delete("turn-3");
+      stream.close({ commit, discard: true });
+      expect(commits).toBe(1);
+    });
+  });
+
+  it("a rolled-back cutover emits no terminal event", async () => {
+    const name = crypto.randomUUID();
+    const stub = env.CutoverHarnessObject.getByName(name);
+    const capture = captureDiagnosticsEvents("agents:stream", name);
+    try {
+      await runInDurableObject(stub, async (instance: CutoverHarnessObject) => {
+        await instance.lifecycle.start();
+        const stream = await instance.streams.open("turn-4");
+        stream.append("a");
+        expect(() =>
+          stream.close({
+            commit: () => {
+              throw new Error("persist failed");
+            },
+            discard: true
+          })
+        ).toThrow("persist failed");
+        stream.close({ commit: () => {}, discard: true });
+      });
+      expect(capture.events.map((event) => event.type)).toEqual([
+        "stream:opened",
+        "stream:closed",
+        "stream:deleted"
+      ]);
+    } finally {
+      capture.stop();
+    }
   });
 });

--- a/packages/agents/src/tests/streams/legacy-fold.test.ts
+++ b/packages/agents/src/tests/streams/legacy-fold.test.ts
@@ -1,0 +1,157 @@
+import { env } from "cloudflare:workers";
+import { runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import type { CutoverHarnessObject } from "../capabilities/streams";
+import type { StreamChunk } from "../../streams";
+
+/**
+ * Schema v1 → v2 is lazy: a stream's per-chunk rows fold into blocks the
+ * first time the stream is touched, one stream at a time, and the legacy
+ * table is dropped once it is empty. Startup never reads the whole log.
+ */
+
+function sqlOf(instance: CutoverHarnessObject): SqlStorage {
+  return (instance as unknown as { ctx: DurableObjectState }).ctx.storage.sql;
+}
+
+function count(instance: CutoverHarnessObject, query: string): number {
+  return [...sqlOf(instance).exec(query)][0].n as number;
+}
+
+async function collect(
+  iterator: AsyncGenerator<StreamChunk, void, undefined>
+): Promise<StreamChunk[]> {
+  const chunks: StreamChunk[] = [];
+  for await (const chunk of iterator) chunks.push(chunk);
+  return chunks;
+}
+
+/** A v1 log: one stream row per stream, one chunk row per chunk. */
+function seedV1(
+  instance: CutoverHarnessObject,
+  streams: Record<
+    string,
+    { state: "streaming" | "completed"; chunks: unknown[] }
+  >
+) {
+  const sql = sqlOf(instance);
+  sql.exec(`CREATE TABLE IF NOT EXISTS cf_agents_streams (
+    stream_id TEXT PRIMARY KEY, state TEXT NOT NULL, tag TEXT, metadata TEXT,
+    error_message TEXT, chunk_count INTEGER NOT NULL DEFAULT 0,
+    created_at INTEGER NOT NULL, updated_at INTEGER NOT NULL, closed_at INTEGER)`);
+  sql.exec(`CREATE TABLE IF NOT EXISTS cf_agents_stream_chunks (
+    stream_id TEXT NOT NULL, seq INTEGER NOT NULL, chunk TEXT NOT NULL,
+    created_at INTEGER NOT NULL, PRIMARY KEY (stream_id, seq)) WITHOUT ROWID`);
+  for (const [id, { state, chunks }] of Object.entries(streams)) {
+    sql.exec(
+      `INSERT INTO cf_agents_streams
+         (stream_id, state, chunk_count, created_at, updated_at, closed_at)
+       VALUES (?, ?, ?, 1, 1, ?)`,
+      id,
+      state,
+      chunks.length,
+      state === "completed" ? 2 : null
+    );
+    chunks.forEach((chunk, seq) => {
+      sql.exec(
+        "INSERT INTO cf_agents_stream_chunks (stream_id, seq, chunk, created_at) VALUES (?, ?, ?, ?)",
+        id,
+        seq,
+        JSON.stringify(chunk),
+        1000 + seq
+      );
+    });
+  }
+}
+
+describe("v1 chunk rows fold into blocks lazily", () => {
+  it("folds one stream on first touch and drops the table once empty", async () => {
+    const stub = env.CutoverHarnessObject.getByName(crypto.randomUUID());
+    await runInDurableObject(stub, async (instance: CutoverHarnessObject) => {
+      const ctx = (instance as unknown as { ctx: DurableObjectState }).ctx;
+      await ctx.storage.put("cf_agents:streams_schema_version", 1);
+      const big = "x".repeat(100 * 1024);
+      seedV1(instance, {
+        live: { state: "streaming", chunks: ["a", "b", "c"] },
+        // ~100 KB chunks: three per 256 KB block ceiling → two blocks.
+        done: {
+          state: "completed",
+          chunks: [0, 1, 2, 3].map((i) => `${i}:${big}`)
+        },
+        gone: { state: "completed", chunks: ["z"] }
+      });
+      await instance.lifecycle.start();
+
+      // Startup folds nothing.
+      expect(
+        count(instance, "SELECT COUNT(*) AS n FROM cf_agents_stream_chunks")
+      ).toBe(8);
+      expect(
+        count(instance, "SELECT COUNT(*) AS n FROM cf_agents_stream_blocks")
+      ).toBe(0);
+
+      // A read folds only its own stream, replays every chunk in order.
+      const done = await collect(instance.streams.read("done"));
+      expect(done.map((c) => (c.chunk as string).slice(0, 2))).toEqual([
+        "0:",
+        "1:",
+        "2:",
+        "3:"
+      ]);
+      expect(
+        [
+          ...sqlOf(instance).exec(
+            "SELECT seq_from, seq_to FROM cf_agents_stream_blocks WHERE stream_id = 'done' ORDER BY block"
+          )
+        ].map((r) => [r.seq_from, r.seq_to])
+      ).toEqual([
+        [0, 2],
+        [2, 4]
+      ]);
+      expect(
+        count(
+          instance,
+          "SELECT COUNT(*) AS n FROM cf_agents_stream_chunks WHERE stream_id = 'done'"
+        )
+      ).toBe(0);
+      expect(
+        count(instance, "SELECT COUNT(*) AS n FROM cf_agents_stream_chunks")
+      ).toBe(4);
+
+      // An append continues the folded log: cursor follows the v1 rows.
+      const writer = await instance.streams.open("live");
+      expect(writer.cursor).toBe(3);
+      expect(writer.append("d")).toBe(3);
+      // The stream is live, so read one batch and stop at the tail.
+      const live: unknown[] = [];
+      for await (const batch of instance.streams.readBatches("live", {
+        from: 1
+      })) {
+        live.push(...batch.map((c) => c.chunk));
+        break;
+      }
+      expect(live).toEqual(["b", "c", "d"]);
+
+      // A cutover on a live v1 stream is a fold inside the cutover transaction.
+      let committed = 0;
+      writer.close({
+        commit: () => {
+          committed++;
+        },
+        discard: true
+      });
+      expect(committed).toBe(1);
+      expect(await instance.streams.status("live")).toBeNull();
+
+      // Deleting an untouched stream drops its rows without folding; the
+      // last legacy row gone drops the table.
+      expect(await instance.streams.delete("gone")).toBe(true);
+      expect([
+        ...sqlOf(instance).exec(
+          "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'cf_agents_stream_chunks'"
+        )
+      ]).toEqual([]);
+      expect((await instance.streams.status("done"))?.cursor).toBe(4);
+    });
+  });
+});

--- a/packages/agents/src/tests/streams/sqlite-strategies-bench.test.ts
+++ b/packages/agents/src/tests/streams/sqlite-strategies-bench.test.ts
@@ -1,0 +1,96 @@
+import { env } from "cloudflare:workers";
+import { runInDurableObject } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import type {
+  Measurement,
+  SqliteStrategiesBench,
+  Strategy,
+  Workload
+} from "../capabilities/sqlite-strategies-bench";
+
+/**
+ * Experimental: temporary stream blocks in DO SQLite → atomic cutover to
+ * a session message → delete the blocks. Compares three block shapes on
+ * billed rows, write time, page growth, replay, and the cursor a restart
+ * recovers. Numbers are logged; only the invariants are asserted.
+ */
+
+const STRATEGIES: Strategy[] = ["packed", "slots", "rollover"];
+
+// flushEvery is what a 1 s time-based flush produces at the workload's
+// token rate (chat ~20 chunks/s); the 10-chunk row is today's packing.
+const WORKLOADS: Workload[] = [
+  {
+    name: "W1 chat 400x70B pack10",
+    chunks: 400,
+    bytesPerChunk: 70,
+    flushEvery: 10
+  },
+  {
+    name: "W1 chat 400x70B pack20",
+    chunks: 400,
+    bytesPerChunk: 70,
+    flushEvery: 20
+  },
+  {
+    name: "W2 long 2000x70B pack20",
+    chunks: 2000,
+    bytesPerChunk: 70,
+    flushEvery: 20
+  },
+  {
+    name: "W3 huge 20000x70B pack20",
+    chunks: 20000,
+    bytesPerChunk: 70,
+    flushEvery: 20
+  }
+];
+
+function table(rows: Measurement[]): string {
+  const cols: [string, (m: Measurement) => string | number][] = [
+    ["strategy", (m) => m.strategy],
+    ["workload", (m) => m.workload],
+    ["rows W", (m) => m.rowsWritten],
+    ["rows R", (m) => m.rowsRead],
+    ["write ms", (m) => m.writeMs],
+    ["cutover W", (m) => m.cutoverRowsWritten],
+    ["cutover ms", (m) => m.cutoverMs],
+    ["db +KB", (m) => Math.round(m.dbGrowthBytes / 1024)],
+    ["peak +KB", (m) => Math.round(m.dbPeakGrowthBytes / 1024)],
+    ["replay ms", (m) => m.replayMs],
+    ["replay R", (m) => m.replayRowsRead],
+    ["kill@", (m) => m.killAt],
+    ["recovered", (m) => m.recoveredCursor]
+  ];
+  const lines = [cols.map((c) => c[0]).join(" | ")];
+  for (const m of rows)
+    lines.push(cols.map((c) => String(c[1](m))).join(" | "));
+  return lines.join("\n");
+}
+
+describe("SQLite block strategies (experimental bench)", () => {
+  it("packed rows vs generational slots vs mutable rollover blocks", async () => {
+    const results: Measurement[] = [];
+    for (const strategy of STRATEGIES) {
+      const stub = env.SqliteStrategiesBench.getByName(`bench-${strategy}`);
+      await runInDurableObject(
+        stub,
+        async (instance: SqliteStrategiesBench) => {
+          await instance.wipe();
+          for (const workload of WORKLOADS) {
+            const killAt = Math.floor(workload.chunks * 0.6) + 3; // mid-flush
+            const m = await instance.run(strategy, workload, killAt);
+            results.push(m);
+            // Invariants every strategy must hold.
+            expect(m.replayChunks).toBe(workload.chunks);
+            // A restart recovers exactly the flushed prefix, never more.
+            const flushedBefore =
+              Math.floor(killAt / workload.flushEvery) * workload.flushEvery;
+            expect(m.recoveredCursor).toBe(flushedBefore);
+          }
+        }
+      );
+    }
+    console.log(`\n${table(results)}\n`);
+  }, 120_000);
+});

--- a/packages/agents/src/tests/streams/storage-ops-bench.test.ts
+++ b/packages/agents/src/tests/streams/storage-ops-bench.test.ts
@@ -32,11 +32,14 @@ describe("Streams storage-ops benchmark", () => {
       );
 
       // The fence is a read, so the packed adapter writes exactly the
-      // legacy pattern's rows per turn: one stream-row insert, one chunk
-      // insert per 10-chunk segment, one settle update — 12 for this
-      // workload. Any regression that adds a write to the streaming hot
-      // path breaks this equality.
-      expect(adapter.rowsWritten).toBe(legacy.rowsWritten);
+      // legacy pattern's rows per turn on the hot path: one stream-row
+      // insert, one block write per 10-chunk segment, one settle update —
+      // 12 for this workload. On top of that, each start() reclaims the
+      // previous turn's completed stream (its one block row and its stream
+      // row): the cleanup the legacy pattern deferred to a sweep of ~13
+      // rows per turn, paid inline as 2. Any regression that adds a write
+      // to the streaming hot path breaks this equality.
+      expect(adapter.rowsWritten).toBe(legacy.rowsWritten + 2 * (TURNS - 1));
       // Packing is the point: an order of magnitude under naive per-chunk
       // (12 vs 102 rows per turn here, ~8.5×).
       expect(adapter.rowsWritten * 5).toBeLessThan(perChunk.rowsWritten);

--- a/packages/agents/src/tests/streams/write-accounting-probe.test.ts
+++ b/packages/agents/src/tests/streams/write-accounting-probe.test.ts
@@ -27,13 +27,17 @@ it("billed writes: WITHOUT ROWID tables pay one row per insert, indexes bill per
     expect(probe.updateNotTouchingIndexed).toBe(1);
     expect(probe.updateTouchingIndexed).toBe(2);
 
-    // The real hot statements: a chunk append bills exactly one row. A
+    // The real hot statements: a block append bills exactly one row. A
     // stream open pays its row plus the hidden PK index plus the tag
     // index — the metadata table deliberately stays a rowid table so
     // rowid keeps "newest first" deterministic within one created_at
     // millisecond, a cost paid once per stream, never per chunk. Settle
     // touches no index and bills one.
-    expect(probe.realChunkAppend).toBe(1);
+    // A chunk append is one row whether it opens a block or grows one, and
+    // a stream's whole log is one row to delete per block at cutover.
+    expect(probe.realBlockOpen).toBe(1);
+    expect(probe.realBlockAppend).toBe(1);
+    expect(probe.realBlockDelete).toBe(1);
     expect(probe.realStreamOpen).toBe(3);
     expect(probe.realStreamSettle).toBe(1);
   });

--- a/packages/agents/src/tests/worker.ts
+++ b/packages/agents/src/tests/worker.ts
@@ -32,6 +32,7 @@ export {
   TaskSchedulerCoexistObject
 } from "./capabilities/tasks.ts";
 export {
+  CutoverHarnessObject,
   StreamHarnessObject,
   TaskStreamComposeObject
 } from "./capabilities/streams.ts";
@@ -43,6 +44,7 @@ export {
   SessionSearchHarnessObject
 } from "./capabilities/sessions.ts";
 import type {
+  CutoverHarnessObject,
   StreamHarnessObject,
   TaskStreamComposeObject
 } from "./capabilities/streams.ts";
@@ -215,6 +217,7 @@ export type Env = {
   TaskHarnessObject: DurableObjectNamespace<TaskHarnessObject>;
   TaskSchedulerCoexistObject: DurableObjectNamespace<TaskSchedulerCoexistObject>;
   StreamHarnessObject: DurableObjectNamespace<StreamHarnessObject>;
+  CutoverHarnessObject: DurableObjectNamespace<CutoverHarnessObject>;
   SqliteStrategiesBench: DurableObjectNamespace<SqliteStrategiesBench>;
   STREAMS_R2: R2Bucket;
   TaskStreamComposeObject: DurableObjectNamespace<TaskStreamComposeObject>;

--- a/packages/agents/src/tests/worker.ts
+++ b/packages/agents/src/tests/worker.ts
@@ -36,6 +36,7 @@ export {
   TaskStreamComposeObject
 } from "./capabilities/streams.ts";
 export { StreamBenchObject } from "./capabilities/streams-bench.ts";
+export { SqliteStrategiesBench } from "./capabilities/sqlite-strategies-bench.ts";
 export {
   SessionBenchObject,
   SessionHarnessObject,
@@ -46,6 +47,7 @@ import type {
   TaskStreamComposeObject
 } from "./capabilities/streams.ts";
 import type { StreamBenchObject } from "./capabilities/streams-bench.ts";
+import type { SqliteStrategiesBench } from "./capabilities/sqlite-strategies-bench.ts";
 import type {
   SessionBenchObject,
   SessionHarnessObject,
@@ -213,6 +215,8 @@ export type Env = {
   TaskHarnessObject: DurableObjectNamespace<TaskHarnessObject>;
   TaskSchedulerCoexistObject: DurableObjectNamespace<TaskSchedulerCoexistObject>;
   StreamHarnessObject: DurableObjectNamespace<StreamHarnessObject>;
+  SqliteStrategiesBench: DurableObjectNamespace<SqliteStrategiesBench>;
+  STREAMS_R2: R2Bucket;
   TaskStreamComposeObject: DurableObjectNamespace<TaskStreamComposeObject>;
   StreamBenchObject: DurableObjectNamespace<StreamBenchObject>;
   SessionHarnessObject: DurableObjectNamespace<SessionHarnessObject>;

--- a/packages/agents/src/tests/wrangler.jsonc
+++ b/packages/agents/src/tests/wrangler.jsonc
@@ -49,6 +49,10 @@
         "name": "StreamHarnessObject"
       },
       {
+        "class_name": "SqliteStrategiesBench",
+        "name": "SqliteStrategiesBench"
+      },
+      {
         "class_name": "TaskStreamComposeObject",
         "name": "TaskStreamComposeObject"
       },
@@ -404,6 +408,7 @@
         "TaskHarnessObject",
         "TaskSchedulerCoexistObject",
         "StreamHarnessObject",
+        "SqliteStrategiesBench",
         "TaskStreamComposeObject",
         "StreamBenchObject",
         "SessionHarnessObject",

--- a/packages/agents/src/tests/wrangler.jsonc
+++ b/packages/agents/src/tests/wrangler.jsonc
@@ -49,6 +49,10 @@
         "name": "StreamHarnessObject"
       },
       {
+        "class_name": "CutoverHarnessObject",
+        "name": "CutoverHarnessObject"
+      },
+      {
         "class_name": "SqliteStrategiesBench",
         "name": "SqliteStrategiesBench"
       },
@@ -408,6 +412,7 @@
         "TaskHarnessObject",
         "TaskSchedulerCoexistObject",
         "StreamHarnessObject",
+        "CutoverHarnessObject",
         "SqliteStrategiesBench",
         "TaskStreamComposeObject",
         "StreamBenchObject",

--- a/packages/ai-chat/src/e2e-tests/stream-buffer-cleanup.test.ts
+++ b/packages/ai-chat/src/e2e-tests/stream-buffer-cleanup.test.ts
@@ -6,7 +6,7 @@
  * that is redundant with the persisted assistant message. The lazy sweep in
  * `ResumableStream` only fires when a *subsequent* stream completes, which never
  * happens for an idle/one-off chat DO — so the framework arms a
- * `_cleanupStreamBuffers` cleanup alarm whenever a stream finishes, and that
+ * no cleanup alarm any more: the cutover deletes the buffer, and that
  * alarm re-arms only while reclaimable rows remain.
  *
  * The real retention windows (10 min completed / 1 h abandoned) and cleanup
@@ -68,70 +68,35 @@ describe("resumable-stream buffer cleanup alarm e2e (#1706)", () => {
     }
   });
 
-  it("arms one cleanup alarm per DO and reclaims buffers on a forced future sweep", async () => {
+  it("a completed turn leaves no stream buffer and arms no cleanup alarm", async () => {
     wrangler = harness.start();
     await harness.waitForReady();
 
-    // Turn #1: complete a chat turn so a buffer row + a cleanup alarm exist.
+    // Turn #1: the cutover persists the message, settles the stream and
+    // deletes its rows in one transaction. Poll for the message, then assert
+    // the buffer is gone.
     await sendChatMessage(agentUrl, "first turn");
-
-    // The buffer row is written when the stream completes; poll for it rather
-    // than racing the (fast) stream.
     await pollUntil(
-      "buffer row after turn 1",
+      "buffer rows after turn 1",
       () => rpcCall(agentUrl, "bufferRowCount") as Promise<number>,
-      (count) => count >= 1
+      (count) => count === 0
     );
+    expect((await rpcCall(agentUrl, "chunkRowCount")) as number).toBe(0);
+    expect((await rpcCall(agentUrl, "cleanupScheduleCount")) as number).toBe(0);
 
-    const bufferRows1 = (await rpcCall(agentUrl, "bufferRowCount")) as number;
-    const chunkRows1 = (await rpcCall(agentUrl, "chunkRowCount")) as number;
-    expect(bufferRows1).toBe(1);
-    expect(chunkRows1).toBeGreaterThanOrEqual(1);
-
-    // A single cleanup alarm is armed for this DO (so idle DOs still reclaim).
-    const schedules1 = (await rpcCall(
-      agentUrl,
-      "cleanupScheduleCount"
-    )) as number;
-    expect(schedules1).toBe(1);
-
-    // Reclaimable while a completed buffer remains.
-    expect((await rpcCall(agentUrl, "hasReclaimableStreams")) as boolean).toBe(
-      true
-    );
-
-    // Turn #2: a second completed turn must NOT stack a duplicate cleanup alarm
-    // — `_ensureStreamCleanupScheduled` arms idempotently (dedupe on
-    // callback+payload+owner).
+    // Turn #2: same, and still no alarm.
     await sendChatMessage(agentUrl, "second turn");
     await pollUntil(
       "buffer rows after turn 2",
       () => rpcCall(agentUrl, "bufferRowCount") as Promise<number>,
-      (count) => count >= 2
+      (count) => count === 0
     );
-    expect((await rpcCall(agentUrl, "bufferRowCount")) as number).toBe(2);
-
-    const schedules2 = (await rpcCall(
-      agentUrl,
-      "cleanupScheduleCount"
-    )) as number;
-    expect(schedules2).toBe(1);
-
-    // Force a sweep with an injected "now" two hours in the future — past both
-    // the 10-minute completed-retention and the 1-hour abandoned windows — so
-    // every completed buffer is reclaimed without waiting out the real timers.
-    const farFutureNow = Date.now() + 2 * 60 * 60 * 1000;
-    await rpcCall(agentUrl, "forceSweep", [farFutureNow]);
-
-    // Buffers are reclaimed: no metadata rows, no chunk rows.
-    expect((await rpcCall(agentUrl, "bufferRowCount")) as number).toBe(0);
     expect((await rpcCall(agentUrl, "chunkRowCount")) as number).toBe(0);
+    expect((await rpcCall(agentUrl, "cleanupScheduleCount")) as number).toBe(0);
 
-    // A fully-swept DO reports no reclaimable streams — so the next
-    // `_cleanupStreamBuffers` run would NOT re-arm and the DO stops waking
-    // itself.
-    expect((await rpcCall(agentUrl, "hasReclaimableStreams")) as boolean).toBe(
-      false
-    );
+    // A reclaim finds nothing to do.
+    expect(
+      (await rpcCall(agentUrl, "forceSweep", [Date.now()])) as number
+    ).toBe(0);
   });
 });

--- a/packages/ai-chat/src/e2e-tests/worker.ts
+++ b/packages/ai-chat/src/e2e-tests/worker.ts
@@ -374,7 +374,7 @@ export class ChatRecoveryTestAgent extends AIChatAgent<Env> {
 /**
  * #1706 stream-buffer cleanup agent. Streams a SHORT turn that completes
  * quickly so a resumable-stream buffer (a chat-owned `cf_agents_streams` row
- * plus its packed `cf_agents_stream_chunks` rows) and a `_cleanupStreamBuffers`
+ * plus its `cf_agents_stream_blocks` rows) and a `_cleanupStreamBuffers`
  * cleanup alarm both exist after a single turn. Exposes @callable inspectors so
  * the test can drive a DETERMINISTIC sweep with an injected far-future "now"
  * instead of waiting out the real 10-minute/1-hour retention windows.
@@ -415,7 +415,7 @@ export class ChatBufferCleanupAgent extends AIChatAgent<Env> {
   @callable()
   chunkRowCount(): number {
     const rows = this.sql<{ count: number }>`
-      SELECT COUNT(*) as count FROM cf_agents_stream_chunks
+      SELECT COUNT(*) as count FROM cf_agents_stream_blocks
       WHERE stream_id IN (
         SELECT stream_id FROM cf_agents_streams
         WHERE json_extract(metadata, '$.cfChat') = 1

--- a/packages/ai-chat/src/e2e-tests/worker.ts
+++ b/packages/ai-chat/src/e2e-tests/worker.ts
@@ -372,12 +372,10 @@ export class ChatRecoveryTestAgent extends AIChatAgent<Env> {
 }
 
 /**
- * #1706 stream-buffer cleanup agent. Streams a SHORT turn that completes
- * quickly so a resumable-stream buffer (a chat-owned `cf_agents_streams` row
- * plus its `cf_agents_stream_blocks` rows) and a `_cleanupStreamBuffers`
- * cleanup alarm both exist after a single turn. Exposes @callable inspectors so
- * the test can drive a DETERMINISTIC sweep with an injected far-future "now"
- * instead of waiting out the real 10-minute/1-hour retention windows.
+ * Stream-buffer lifecycle agent. Streams a SHORT turn that completes quickly
+ * so the test can assert that the cutover left no resumable-stream buffer (no
+ * chat-owned `cf_agents_streams` row, no `cf_agents_stream_blocks` rows) and
+ * armed no cleanup alarm. Exposes @callable inspectors.
  */
 export class ChatBufferCleanupAgent extends AIChatAgent<Env> {
   static options = { keepAliveIntervalMs: 2_000 };
@@ -444,14 +442,8 @@ export class ChatBufferCleanupAgent extends AIChatAgent<Env> {
    * abandoned). Delegates to the same `cleanup(now)` the cleanup alarm uses.
    */
   @callable()
-  forceSweep(nowMs: number): void {
-    this._resumableStream.cleanup(nowMs);
-  }
-
-  /** Whether any stream rows remain — what the alarm uses to decide re-arming. */
-  @callable()
-  hasReclaimableStreams(): boolean {
-    return this._resumableStream.hasReclaimableStreams();
+  forceSweep(nowMs: number): number {
+    return this._resumableStream.reclaim(nowMs);
   }
 }
 

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -57,12 +57,7 @@ import {
   type SubmitConcurrencyDecision,
   type ChatFiberSnapshot
 } from "agents/chat";
-import {
-  ResumableStream,
-  cleanupStreamBuffers,
-  createChatStreams,
-  STREAM_CLEANUP_DELAY_SECONDS
-} from "agents/chat";
+import { ResumableStream, createChatStreams } from "agents/chat";
 import type { Streams } from "agents/streams";
 import { Sessions, type Session, type SessionMessage } from "agents/sessions";
 import {
@@ -242,8 +237,7 @@ type AIChatRecoveryClassification = { shouldRetryPreStream: boolean };
 // sweep via the shared `sweepStaleChatRecoveryIncidents` helper.)
 // (N9 throttle now lives in the shared engine as `AgentToolStreamProgressThrottle`
 // / `AGENT_TOOL_STREAM_PROGRESS_BUMP_THROTTLE_MS`; the stream-cleanup delay and
-// re-arm loop now live in agents/chat as `STREAM_CLEANUP_DELAY_SECONDS` /
-// `cleanupStreamBuffers`. The `sendIfOpen` / `isWebSocketClosedSendError` WS send
+// The `sendIfOpen` / `isWebSocketClosedSendError` WS send
 // guard is shared via agents/chat.)
 
 type StreamResultStatus = {
@@ -1818,7 +1812,6 @@ export class AIChatAgent<
     // wake if fiber recovery cannot finalize a stream. The last-activity sweep
     // threshold keeps an actively streaming run from being reclaimed before it
     // goes quiet (#1706).
-    void this._ensureStreamCleanupScheduled();
     return streamId;
   }
 
@@ -1826,46 +1819,36 @@ export class AIChatAgent<
   protected _completeStream(streamId: string) {
     const completedRequestId = this._resumableStream.activeRequestId;
     this._resumableStream.complete(streamId);
+    this._afterStreamFinished(completedRequestId);
+  }
+
+  /**
+   * @internal The producer finished; leave the row for the cutover that
+   * persists the message (`persistMessages` with `_cutover`). `_reply`'s
+   * finally settles it if no persist follows.
+   */
+  protected _finishStream(streamId: string) {
+    const finishedRequestId = this._resumableStream.activeRequestId;
+    this._resumableStream.finish(streamId);
+    this._afterStreamFinished(finishedRequestId);
+  }
+
+  private _afterStreamFinished(requestId: string | null) {
     this._pendingResumeConnections.clear();
-    if (completedRequestId === this._continuation.activeRequestId) {
+    if (requestId === this._continuation.activeRequestId) {
       this._continuation.activeRequestId = null;
       this._continuation.activeConnectionId = null;
     }
-    void this._ensureStreamCleanupScheduled();
   }
 
   /**
-   * Ensure a single cleanup alarm is pending for this DO's resumable-stream
-   * buffers. Armed whenever a stream finishes (completes or errors) so that
-   * idle/one-off chat DOs still reclaim their buffers — the lazy sweep in
-   * {@link ResumableStream} only fires when a *subsequent* stream completes,
-   * which never happens for a chat that receives a single turn (#1706).
-   *
-   * `idempotent` dedupes on (callback, payload, owner) so repeated finishes
-   * collapse onto one pending alarm rather than stacking.
-   * @internal
-   */
-  protected async _ensureStreamCleanupScheduled({
-    idempotent = true
-  }: { idempotent?: boolean } = {}): Promise<void> {
-    await this.schedule(
-      STREAM_CLEANUP_DELAY_SECONDS,
-      "_cleanupStreamBuffers",
-      undefined,
-      { idempotent }
-    );
-  }
-
-  /**
-   * Alarm callback: sweep aged stream buffers, re-arming while rows remain (see
-   * the shared {@link cleanupStreamBuffers}). Public so it is reachable as a
-   * schedule callback.
+   * @deprecated Streams are reclaimed at cutover and on the next stream
+   * start; no alarm is armed any more. Kept so a cleanup alarm persisted
+   * by an earlier version still resolves to a callback when it fires.
    * @internal
    */
   async _cleanupStreamBuffers(): Promise<void> {
-    await cleanupStreamBuffers(this._resumableStream, () =>
-      this._ensureStreamCleanupScheduled({ idempotent: false })
-    );
+    this._resumableStream.reclaim();
   }
 
   /** @internal Delegate to _resumableStream. Also advances the recovery
@@ -1930,7 +1913,6 @@ export class AIChatAgent<
       this._continuation.activeRequestId = null;
       this._continuation.activeConnectionId = null;
     }
-    void this._ensureStreamCleanupScheduled();
   }
 
   /**
@@ -5021,7 +5003,6 @@ export class AIChatAgent<
         this._persistOrphanedStream(streamId),
       completeRecoveredStream: (streamId) => {
         this._resumableStream.complete(streamId);
-        void this._ensureStreamCleanupScheduled();
       },
       dispatchRecoveredTurn: (input) => this._dispatchRecoveredChatTurn(input)
     } satisfies ChatFiberWakeHooks<AIChatRecoveryClassification>);
@@ -5755,7 +5736,15 @@ export class AIChatAgent<
     messages: UIMessage[],
     excludeBroadcastIds: string[] = [],
     /** @internal */
-    options?: { _deleteStaleRows?: boolean }
+    options?: {
+      _deleteStaleRows?: boolean;
+      /**
+       * Persist inside the stream's cutover: the message writes, the
+       * stream's settlement and the deletion of its temporary rows commit
+       * in one transaction.
+       */
+      _cutover?: { streamId: string; discard: boolean };
+    }
   ) {
     // Snapshot the pre-write transcript: `this.messages` is mirrored from the
     // change feed and therefore mutates as the loop below writes.
@@ -5765,6 +5754,7 @@ export class AIChatAgent<
       this._sanitizeMessageForPersistence(msg)
     );
 
+    const toWrite: UIMessage[] = [];
     for (const message of mergedMessages) {
       const resolved = resolveToolMergeId(
         this._sanitizeMessageForPersistence(message),
@@ -5776,7 +5766,25 @@ export class AIChatAgent<
       // decode and hash of every payload on every turn.
       const prior = priorById.get(resolved.id);
       if (prior && JSON.stringify(prior) === JSON.stringify(resolved)) continue;
-      await this.#session.upsertMessage(resolved);
+      toWrite.push(resolved);
+    }
+    if (options?._cutover) {
+      // The cutover: every changed message lands in the same transaction
+      // that settles the stream and drops its rows. The change feed (and
+      // auto-compaction) run once the transaction has committed.
+      const sync = this.#session.__DO_NOT_USE_WILL_BREAK__sync();
+      const afters: Array<() => Promise<void>> = [];
+      this._resumableStream.cutover(
+        options._cutover.streamId,
+        () => {
+          for (const message of toWrite)
+            afters.push(sync.upsert(message).after);
+        },
+        { discard: options._cutover.discard }
+      );
+      for (const after of afters) await after();
+    } else {
+      for (const message of toWrite) await this.#session.upsertMessage(message);
     }
 
     // Regeneration can submit a strict subset of the server transcript. Keep
@@ -6409,7 +6417,7 @@ export class AIChatAgent<
       if (done) {
         // reader.cancel() resolves read() with { done: true } — check abort
         if (abortSignal?.aborted) break;
-        this._completeStream(streamId);
+        this._finishStream(streamId);
         streamCompleted.value = true;
         this._broadcastChatMessage({
           body: "",
@@ -6765,7 +6773,7 @@ export class AIChatAgent<
 
     // If we exited due to abort, send a done signal so clients know the stream ended
     if (!streamCompleted.value) {
-      this._completeStream(streamId);
+      this._finishStream(streamId);
       streamCompleted.value = true;
       this._broadcastChatMessage({
         body: "",
@@ -6858,7 +6866,7 @@ export class AIChatAgent<
         );
 
         // Mark the stream as completed
-        this._completeStream(streamId);
+        this._finishStream(streamId);
         streamCompleted.value = true;
         // Send final completion signal
         this._broadcastChatMessage({
@@ -6892,7 +6900,7 @@ export class AIChatAgent<
         { type: "text-end", id },
         continuation
       );
-      this._completeStream(streamId);
+      this._finishStream(streamId);
       streamCompleted.value = true;
       this._broadcastChatMessage({
         body: "",
@@ -7133,6 +7141,17 @@ export class AIChatAgent<
             }
           }
 
+          // The cutover: when this turn's stream is awaiting settlement, the
+          // message write settles it and drops its rows in one transaction.
+          // Agent-tool child turns keep their rows (the parent tails the
+          // stored chunks after completion); the next start() reclaims them.
+          const cutover =
+            this._resumableStream.pendingCutoverId === streamId
+              ? {
+                  streamId,
+                  discard: !this._agentToolRunsByRequestId.get(id)
+                }
+              : undefined;
           if (message.parts.length > 0) {
             if (earlyPersistedId) {
               // Message already exists in this.messages from the early persist.
@@ -7152,7 +7171,9 @@ export class AIChatAgent<
                 updatedMessages.push(persistedMessage);
               }
 
-              await this.persistMessages(updatedMessages, excludeBroadcastIds);
+              await this.persistMessages(updatedMessages, excludeBroadcastIds, {
+                _cutover: cutover
+              });
             } else if (continuation) {
               const existingIdx = this.messages.findIndex(
                 (msg) => msg.id === message.id
@@ -7162,29 +7183,28 @@ export class AIChatAgent<
                 updatedMessages[existingIdx] = message;
                 await this.persistMessages(
                   updatedMessages,
-                  excludeBroadcastIds
+                  excludeBroadcastIds,
+                  { _cutover: cutover }
                 );
               } else {
                 // No assistant message to append to, create new one
                 await this.persistMessages(
                   [...this.messages, message],
-                  excludeBroadcastIds
+                  excludeBroadcastIds,
+                  { _cutover: cutover }
                 );
               }
             } else {
               await this.persistMessages(
                 [...this.messages, message],
-                excludeBroadcastIds
+                excludeBroadcastIds,
+                { _cutover: cutover }
               );
             }
-            // The message is durable: the stream's block rows are now
-            // redundant, so drop them instead of leaving them for a sweep.
-            // Agent-tool child turns are the exception: the parent tails the
-            // stored chunks after completion, so those stay for the sweep.
-            if (!this._agentToolRunsByRequestId.get(id)) {
-              this._resumableStream.discardCompleted(streamId);
-            }
           }
+          // Nothing to persist (or the persist threw): settle the stream so
+          // it is not mistaken for an interrupted turn.
+          this._resumableStream.finalizePending();
 
           this._pendingChatResponseResults.push({
             message,
@@ -7197,6 +7217,7 @@ export class AIChatAgent<
           });
           return streamResult;
         } finally {
+          this._resumableStream.finalizePending();
           // The streamed assistant message (with all tool parts) is now
           // persisted: clear the stream-active gate and re-run the
           // auto-continuation barrier for a continuation it held (#1650). This

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -7177,6 +7177,13 @@ export class AIChatAgent<
                 excludeBroadcastIds
               );
             }
+            // The message is durable: the stream's block rows are now
+            // redundant, so drop them instead of leaving them for a sweep.
+            // Agent-tool child turns are the exception: the parent tails the
+            // stored chunks after completion, so those stay for the sweep.
+            if (!this._agentToolRunsByRequestId.get(id)) {
+              this._resumableStream.discardCompleted(streamId);
+            }
           }
 
           this._pendingChatResponseResults.push({

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -1824,7 +1824,7 @@ export class AIChatAgent<
 
   /**
    * @internal The producer finished; leave the row for the cutover that
-   * persists the message (`persistMessages` with `_cutover`). `_reply`'s
+   * persists the message (`persistMessages` via `#pendingCutover`). `_reply`'s
    * finally settles it if no persist follows.
    */
   protected _finishStream(streamId: string) {
@@ -5732,19 +5732,25 @@ export class AIChatAgent<
     );
   }
 
+  /**
+   * The turn whose finished stream is waiting for its message write: the
+   * cutover rides on the instance, not on an argument, so a subclass that
+   * overrides {@link persistMessages} and calls `super` with only the
+   * messages still lands the message, the stream's settlement and the
+   * deletion of its rows in one transaction. Consumed by the first persist
+   * that carries the turn's message; cleared when the turn ends.
+   */
+  #pendingCutover: {
+    streamId: string;
+    messageId: string;
+    discard: boolean;
+  } | null = null;
+
   async persistMessages(
     messages: UIMessage[],
     excludeBroadcastIds: string[] = [],
     /** @internal */
-    options?: {
-      _deleteStaleRows?: boolean;
-      /**
-       * Persist inside the stream's cutover: the message writes, the
-       * stream's settlement and the deletion of its temporary rows commit
-       * in one transaction.
-       */
-      _cutover?: { streamId: string; discard: boolean };
-    }
+    options?: { _deleteStaleRows?: boolean }
   ) {
     // Snapshot the pre-write transcript: `this.messages` is mirrored from the
     // change feed and therefore mutates as the loop below writes.
@@ -5768,19 +5774,27 @@ export class AIChatAgent<
       if (prior && JSON.stringify(prior) === JSON.stringify(resolved)) continue;
       toWrite.push(resolved);
     }
-    if (options?._cutover) {
-      // The cutover: every changed message lands in the same transaction
-      // that settles the stream and drops its rows. The change feed (and
-      // auto-compaction) run once the transaction has committed.
+    // The cutover: a persist that carries the finished turn's message
+    // lands every changed message in the same transaction that settles the
+    // stream and drops its rows. A persist of other messages (an override
+    // writing its own first) takes the plain path and leaves the cutover
+    // pending. The change feed (and auto-compaction) run once the
+    // transaction has committed.
+    const cutover = this.#pendingCutover;
+    if (
+      cutover &&
+      mergedMessages.some((message) => message.id === cutover.messageId)
+    ) {
+      this.#pendingCutover = null;
       const sync = this.#session.__DO_NOT_USE_WILL_BREAK__sync();
       const afters: Array<() => Promise<void>> = [];
       this._resumableStream.cutover(
-        options._cutover.streamId,
+        cutover.streamId,
         () => {
           for (const message of toWrite)
             afters.push(sync.upsert(message).after);
         },
-        { discard: options._cutover.discard }
+        { discard: cutover.discard }
       );
       for (const after of afters) await after();
     } else {
@@ -7142,16 +7156,18 @@ export class AIChatAgent<
           }
 
           // The cutover: when this turn's stream is awaiting settlement, the
-          // message write settles it and drops its rows in one transaction.
-          // Agent-tool child turns keep their rows (the parent tails the
-          // stored chunks after completion); the next start() reclaims them.
-          const cutover =
+          // persist that carries this turn's message settles it and drops
+          // its rows in one transaction (see `#pendingCutover`). Agent-tool
+          // child turns keep their rows (the parent tails the stored chunks
+          // after completion); the next start() reclaims them.
+          this.#pendingCutover =
             this._resumableStream.pendingCutoverId === streamId
               ? {
                   streamId,
+                  messageId: earlyPersistedId ?? message.id,
                   discard: !this._agentToolRunsByRequestId.get(id)
                 }
-              : undefined;
+              : null;
           if (message.parts.length > 0) {
             if (earlyPersistedId) {
               // Message already exists in this.messages from the early persist.
@@ -7171,9 +7187,7 @@ export class AIChatAgent<
                 updatedMessages.push(persistedMessage);
               }
 
-              await this.persistMessages(updatedMessages, excludeBroadcastIds, {
-                _cutover: cutover
-              });
+              await this.persistMessages(updatedMessages, excludeBroadcastIds);
             } else if (continuation) {
               const existingIdx = this.messages.findIndex(
                 (msg) => msg.id === message.id
@@ -7183,27 +7197,26 @@ export class AIChatAgent<
                 updatedMessages[existingIdx] = message;
                 await this.persistMessages(
                   updatedMessages,
-                  excludeBroadcastIds,
-                  { _cutover: cutover }
+                  excludeBroadcastIds
                 );
               } else {
                 // No assistant message to append to, create new one
                 await this.persistMessages(
                   [...this.messages, message],
-                  excludeBroadcastIds,
-                  { _cutover: cutover }
+                  excludeBroadcastIds
                 );
               }
             } else {
               await this.persistMessages(
                 [...this.messages, message],
-                excludeBroadcastIds,
-                { _cutover: cutover }
+                excludeBroadcastIds
               );
             }
           }
-          // Nothing to persist (or the persist threw): settle the stream so
-          // it is not mistaken for an interrupted turn.
+          // Nothing to persist (or the persist threw, or an override never
+          // reached the session write): settle the stream so it is not
+          // mistaken for an interrupted turn.
+          this.#pendingCutover = null;
           this._resumableStream.finalizePending();
 
           this._pendingChatResponseResults.push({
@@ -7217,6 +7230,7 @@ export class AIChatAgent<
           });
           return streamResult;
         } finally {
+          this.#pendingCutover = null;
           this._resumableStream.finalizePending();
           // The streamed assistant message (with all tool parts) is now
           // persisted: clear the stream-active gate and re-run the

--- a/packages/ai-chat/src/tests/resumable-streaming.test.ts
+++ b/packages/ai-chat/src/tests/resumable-streaming.test.ts
@@ -1790,9 +1790,8 @@ describe("Resumable Streaming", () => {
       const metadata = await agentStub.getStreamMetadata("old-errored");
       expect(metadata?.status).toBe("error");
 
-      // Trigger cleanup by completing a dummy stream
-      // (cleanup runs periodically inside completeStream)
-      await agentStub.testTriggerStreamCleanup();
+      // Reclaim, as the next stream start does.
+      await agentStub.testReclaimStreams();
 
       // The old errored stream should be cleaned up
       const afterMetadata = await agentStub.getStreamMetadata("old-errored");
@@ -1820,8 +1819,8 @@ describe("Resumable Streaming", () => {
       const metadata = await agentStub.getStreamMetadata("abandoned-streaming");
       expect(metadata?.status).toBe("streaming");
 
-      // Trigger cleanup
-      await agentStub.testTriggerStreamCleanup();
+      // Reclaim, as the next stream start does.
+      await agentStub.testReclaimStreams();
 
       // The abandoned streaming row should be cleaned up
       const afterMetadata = await agentStub.getStreamMetadata(
@@ -1834,166 +1833,97 @@ describe("Resumable Streaming", () => {
     });
   });
 
-  describe("alarm-driven stream cleanup (#1706)", () => {
-    it("arms a single cleanup alarm when a stream finishes, deduping repeats", async () => {
+  describe("stream reclaim (no cleanup alarm)", () => {
+    it("never arms a cleanup alarm, before or after a turn", async () => {
       const room = crypto.randomUUID();
       const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
       await new Promise((r) => setTimeout(r, 50));
-
       const agentStub = await getAgentByName(env.TestChatAgent, room);
-
-      // No cleanup alarm before any stream finishes.
       expect(await agentStub.testCountStreamCleanupSchedules()).toBe(0);
 
-      // Finishing a stream arms exactly one cleanup alarm.
-      await agentStub.testTriggerStreamCleanup();
-      expect(await agentStub.testCountStreamCleanupSchedules()).toBe(1);
-
-      // Subsequent finishes collapse onto the same pending alarm (idempotent),
-      // so DOs with many turns never accumulate cleanup schedules.
-      await agentStub.testTriggerStreamCleanup();
-      await agentStub.testTriggerStreamCleanup();
-      expect(await agentStub.testCountStreamCleanupSchedules()).toBe(1);
-
-      await new Promise((r) => setTimeout(r, 50));
+      const done = new Promise<void>((resolve) => {
+        ws.addEventListener("message", (e: MessageEvent) => {
+          const data = JSON.parse(e.data as string);
+          if (
+            data.type === MessageType.CF_AGENT_USE_CHAT_RESPONSE &&
+            data.done
+          ) {
+            resolve();
+          }
+        });
+      });
+      ws.send(
+        JSON.stringify({
+          type: MessageType.CF_AGENT_USE_CHAT_REQUEST,
+          id: "req-no-alarm",
+          init: {
+            method: "POST",
+            body: JSON.stringify({
+              messages: [
+                {
+                  id: "u-1",
+                  role: "user",
+                  parts: [{ type: "text", text: "hi" }]
+                }
+              ]
+            })
+          }
+        })
+      );
+      await done;
+      await waitFor(async () =>
+        (
+          (await agentStub.getPersistedMessages()) as Array<{ role: string }>
+        ).some((m) => m.role === "assistant")
+      );
+      // The cutover deleted the stream with the message write; no alarm.
+      expect(await agentStub.getAllStreamMetadata()).toEqual([]);
+      expect(await agentStub.testCountStreamCleanupSchedules()).toBe(0);
       ws.close(1000);
     });
 
-    it("reclaims aged buffers when the alarm fires without a new stream completing", async () => {
+    it("reclaims finished streams of any age and abandoned in-flight rows past the stale window", async () => {
       const room = crypto.randomUUID();
       const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
       await new Promise((r) => setTimeout(r, 50));
-
       const agentStub = await getAgentByName(env.TestChatAgent, room);
 
-      // The exact #1706 scenario: a one-off chat whose buffers age out, with no
-      // further stream ever completing to drive the lazy in-line sweep.
-      await agentStub.testInsertOldErroredStream(
-        "old-errored",
-        "req-errored",
-        25 * 60 * 60 * 1000
+      await agentStub.testInsertOldErroredStream("done-recent", "req-1", 5_000);
+      await agentStub.testInsertStaleStream(
+        "inflight-recent",
+        "req-2",
+        30 * 60 * 1000
       );
       await agentStub.testInsertStaleStream(
-        "abandoned-streaming",
-        "req-abandoned",
-        25 * 60 * 60 * 1000
+        "inflight-stale",
+        "req-3",
+        70 * 60 * 1000
       );
 
-      // The alarm callback alone (no completeStream) reclaims both.
-      await agentStub.testRunStreamCleanup();
-
-      expect(await agentStub.getStreamMetadata("old-errored")).toBeNull();
+      expect(await agentStub.testReclaimStreams()).toBe(2);
+      expect(await agentStub.getStreamMetadata("done-recent")).toBeNull();
+      expect(await agentStub.getStreamMetadata("inflight-stale")).toBeNull();
       expect(
-        await agentStub.getStreamMetadata("abandoned-streaming")
-      ).toBeNull();
-
-      await new Promise((r) => setTimeout(r, 50));
+        (await agentStub.getStreamMetadata("inflight-recent"))?.status
+      ).toBe("streaming");
       ws.close(1000);
     });
 
-    it("re-arms only while reclaimable buffers remain", async () => {
+    it("does not reclaim a long-running stream that is still emitting chunks", async () => {
       const room = crypto.randomUUID();
       const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
       await new Promise((r) => setTimeout(r, 50));
-
       const agentStub = await getAgentByName(env.TestChatAgent, room);
 
-      // Fully-swept DO: running cleanup with nothing left does NOT re-arm, so an
-      // idle/dead chat stops waking itself.
-      await agentStub.testRunStreamCleanup();
-      expect(await agentStub.testCountStreamCleanupSchedules()).toBe(0);
-
-      // A still-recent stream survives the sweep (not yet aged), so the DO must
-      // keep an alarm pending to revisit it later.
-      await agentStub.testInsertStaleStream(
-        "recent-streaming",
-        "req-recent",
-        60 * 1000
-      );
-      await agentStub.testRunStreamCleanup();
-      expect(
-        await agentStub.getStreamMetadata("recent-streaming")
-      ).not.toBeNull();
-      expect(await agentStub.testCountStreamCleanupSchedules()).toBe(1);
-
-      await new Promise((r) => setTimeout(r, 50));
-      ws.close(1000);
-    });
-
-    it("survives the real alarm fire and re-arms when a younger buffer remains", async () => {
-      // Guards the idempotent-reschedule footgun: when the cleanup alarm fires,
-      // `alarm()` deletes the fired one-shot row after the callback returns. An
-      // idempotent re-arm would dedup onto that doomed row and vanish with it,
-      // leaking any buffer that survived the sweep. The re-arm must be fresh.
-      const room = crypto.randomUUID();
-      const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
-      await new Promise((r) => setTimeout(r, 50));
-
-      const agentStub = await getAgentByName(env.TestChatAgent, room);
-
-      await agentStub.testInsertStaleStream("young", "req-young", 60 * 1000);
-      await agentStub.testArmStreamCleanup();
-      expect(await agentStub.testCountStreamCleanupSchedules()).toBe(1);
-
-      // Fire the alarm for real — the fired row is deleted after the callback.
-      await agentStub.testFireDueCleanupAlarm();
-
-      // The young buffer survived the sweep, so a FRESH cleanup alarm must
-      // remain pending (this is exactly 0 if the re-arm were idempotent).
-      expect(await agentStub.getStreamMetadata("young")).not.toBeNull();
-      expect(await agentStub.testCountStreamCleanupSchedules()).toBe(1);
-
-      await new Promise((r) => setTimeout(r, 50));
-      ws.close(1000);
-    });
-
-    it("stops re-arming after the real alarm sweeps the last buffer", async () => {
-      const room = crypto.randomUUID();
-      const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
-      await new Promise((r) => setTimeout(r, 50));
-
-      const agentStub = await getAgentByName(env.TestChatAgent, room);
-
-      await agentStub.testInsertOldErroredStream(
-        "old",
-        "req-old",
-        25 * 60 * 60 * 1000
-      );
-      await agentStub.testArmStreamCleanup();
-      expect(await agentStub.testCountStreamCleanupSchedules()).toBe(1);
-
-      await agentStub.testFireDueCleanupAlarm();
-
-      // Nothing reclaimable remains, so no re-arm: the DO stops waking itself.
-      expect(await agentStub.getStreamMetadata("old")).toBeNull();
-      expect(await agentStub.testCountStreamCleanupSchedules()).toBe(0);
-
-      await new Promise((r) => setTimeout(r, 50));
-      ws.close(1000);
-    });
-
-    it("does not sweep a long-running stream that is still emitting chunks", async () => {
-      // The abandoned-streaming sweep keys off LAST chunk activity, not start
-      // time: a stream that began > 24h ago but is still writing chunks must
-      // survive, while one that has been silent past the window is reclaimed.
-      const room = crypto.randomUUID();
-      const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
-      await new Promise((r) => setTimeout(r, 50));
-
-      const agentStub = await getAgentByName(env.TestChatAgent, room);
-
-      // Started 25h ago but emitted a chunk a minute ago — still active.
       await agentStub.testInsertStaleStream(
         "long-active",
-        "req-active",
+        "req-a",
         25 * 60 * 60 * 1000
       );
       await agentStub.testInsertStreamChunkAt("long-active", 60 * 1000);
-
-      // Started 25h ago and went silent (last chunk 25h ago) — abandoned.
       await agentStub.testInsertStaleStream(
         "long-silent",
-        "req-silent",
+        "req-s",
         25 * 60 * 60 * 1000
       );
       await agentStub.testInsertStreamChunkAt(
@@ -2001,401 +1931,12 @@ describe("Resumable Streaming", () => {
         25 * 60 * 60 * 1000
       );
 
-      await agentStub.testRunStreamCleanup();
-
-      expect(await agentStub.getStreamMetadata("long-active")).not.toBeNull();
-      expect(await agentStub.getStreamMetadata("long-silent")).toBeNull();
-
-      await new Promise((r) => setTimeout(r, 50));
-      ws.close(1000);
-    });
-
-    it("arms cleanup when a stream starts (covers never-finished orphans)", async () => {
-      const room = crypto.randomUUID();
-      const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
-      await new Promise((r) => setTimeout(r, 50));
-
-      const agentStub = await getAgentByName(env.TestChatAgent, room);
-
-      // No alarm yet on a fresh DO.
-      expect(await agentStub.testCountStreamCleanupSchedules()).toBe(0);
-
-      // Starting a stream (without ever finishing it) must arm cleanup so an
-      // evicted, never-resumed mid-stream orphan still gets a future sweep.
-      await agentStub.testStartStream("req-orphan");
-      expect(await agentStub.testCountStreamCleanupSchedules()).toBe(1);
-
-      await new Promise((r) => setTimeout(r, 50));
-      ws.close(1000);
-    });
-
-    it("arms the cleanup alarm at the completion-grace delay (10 minutes)", async () => {
-      // Locks the arming interval: a regression that lengthens it back toward
-      // the old 24h window (re-introducing the #1706 leak) fails here.
-      const room = crypto.randomUUID();
-      const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
-      await new Promise((r) => setTimeout(r, 50));
-
-      const agentStub = await getAgentByName(env.TestChatAgent, room);
-
-      await agentStub.testArmStreamCleanup();
-      expect(await agentStub.testStreamCleanupScheduleDelaySeconds()).toBe(
-        10 * 60
-      );
-
-      await new Promise((r) => setTimeout(r, 50));
-      ws.close(1000);
-    });
-
-    it("sweeps a finished buffer past the 10-minute grace, keeps a recent one", async () => {
-      // Completion retention is short: the assistant message is persisted
-      // separately, so a finished buffer is only a brief replay grace.
-      const room = crypto.randomUUID();
-      const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
-      await new Promise((r) => setTimeout(r, 50));
-
-      const agentStub = await getAgentByName(env.TestChatAgent, room);
-
-      await agentStub.testInsertOldErroredStream(
-        "done-stale",
-        "req-done-stale",
-        11 * 60 * 1000
-      );
-      await agentStub.testInsertOldErroredStream(
-        "done-recent",
-        "req-done-recent",
-        5 * 60 * 1000
-      );
-
-      await agentStub.testRunStreamCleanup();
-
-      expect(await agentStub.getStreamMetadata("done-stale")).toBeNull();
-      expect(await agentStub.getStreamMetadata("done-recent")).not.toBeNull();
-
-      await new Promise((r) => setTimeout(r, 50));
-      ws.close(1000);
-    });
-
-    it("keeps an abandoned in-flight buffer until the 1-hour stale window", async () => {
-      // In-flight retention is generous so an interrupted turn has ample time
-      // to be resumed or recovered before its buffer is presumed dead.
-      const room = crypto.randomUUID();
-      const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
-      await new Promise((r) => setTimeout(r, 50));
-
-      const agentStub = await getAgentByName(env.TestChatAgent, room);
-
-      await agentStub.testInsertStaleStream(
-        "inflight-recent",
-        "req-inflight-recent",
-        30 * 60 * 1000
-      );
-      await agentStub.testInsertStaleStream(
-        "inflight-stale",
-        "req-inflight-stale",
-        70 * 60 * 1000
-      );
-
-      await agentStub.testRunStreamCleanup();
-
-      expect(
-        await agentStub.getStreamMetadata("inflight-recent")
-      ).not.toBeNull();
-      expect(await agentStub.getStreamMetadata("inflight-stale")).toBeNull();
-
-      await new Promise((r) => setTimeout(r, 50));
-      ws.close(1000);
-    });
-
-    it("keeps an in-flight buffer's chunks reconstructable past the completion grace", async () => {
-      // Recovery reconstructs a partial assistant message from the stream
-      // buffer (getStreamChunks / _persistOrphanedStream), and only ever does
-      // so for an ACTIVE `streaming` row — which uses the generous 1h
-      // last-activity window, NOT the 10min completion grace. A buffer whose
-      // last chunk is older than the completion grace but within the in-flight
-      // window must survive a sweep with its chunks intact, otherwise a turn
-      // interrupted >10min could not be recovered.
-      const room = crypto.randomUUID();
-      const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);
-      await new Promise((r) => setTimeout(r, 50));
-
-      const agentStub = await getAgentByName(env.TestChatAgent, room);
-
-      await agentStub.testInsertStaleStream(
-        "recovering",
-        "req-recovering",
-        30 * 60 * 1000
-      );
-      // Last chunk 20 minutes ago: past the 10min grace, within the 1h window.
-      await agentStub.testInsertStreamChunkAt("recovering", 20 * 60 * 1000);
-
-      await agentStub.testRunStreamCleanup();
-
-      expect((await agentStub.getStreamMetadata("recovering"))?.status).toBe(
+      await agentStub.testReclaimStreams();
+      expect((await agentStub.getStreamMetadata("long-active"))?.status).toBe(
         "streaming"
       );
-      expect(
-        (await agentStub.getStreamChunks("recovering")).length
-      ).toBeGreaterThan(0);
-
-      await new Promise((r) => setTimeout(r, 50));
+      expect(await agentStub.getStreamMetadata("long-silent")).toBeNull();
       ws.close(1000);
-    });
-  });
-
-  describe("Duplicate resume notify / replay contract (#1733)", () => {
-    it("notifies STREAM_RESUMING from both onConnect and RESUME_REQUEST for the same request", async () => {
-      // This duplication is INTENTIONAL and must not be deduped server-side:
-      // an explicit resume request always deserves a response (otherwise
-      // the client's reconnectToStream hangs until its safety timeout), and
-      // the proactive onConnect notify covers clients that never send one.
-      // Clients are responsible for not ACKing the same offer twice.
-      const room = crypto.randomUUID();
-
-      const { ws: ws1 } = await connectChatWS(
-        `/agents/test-chat-agent/${room}`
-      );
-      await new Promise((r) => setTimeout(r, 50));
-
-      const agentStub = await getAgentByName(env.TestChatAgent, room);
-      const streamId = await agentStub.testStartStream("req-double-notify");
-      await agentStub.testStoreStreamChunk(
-        streamId,
-        '{"type":"text-start","id":"t1"}'
-      );
-      await agentStub.testFlushChunkBuffer();
-
-      ws1.close();
-      await new Promise((r) => setTimeout(r, 50));
-
-      const { ws: ws2 } = await connectChatWS(
-        `/agents/test-chat-agent/${room}`
-      );
-      const messages2 = collectMessages(ws2);
-
-      // Wait for the proactive onConnect notify first…
-      await waitFor(
-        () => messages2.filter(isStreamResumingMessage).length >= 1
-      );
-
-      // …then the explicit request must produce a second notify.
-      ws2.send(
-        JSON.stringify({ type: MessageType.CF_AGENT_STREAM_RESUME_REQUEST })
-      );
-      await waitFor(
-        () => messages2.filter(isStreamResumingMessage).length >= 2
-      );
-
-      const resumeMsgs = messages2.filter(isStreamResumingMessage);
-      expect(resumeMsgs.length).toBe(2);
-      expect(resumeMsgs[0].id).toBe("req-double-notify");
-      expect(resumeMsgs[1].id).toBe("req-double-notify");
-
-      ws2.close(1000);
-    });
-
-    it("replays the full buffer once per ACK — clients must dedupe duplicate offers", async () => {
-      // Pin the contract the client-side fix relies on: the server has no
-      // per-connection replay memory (an ACK from the fallback path and one
-      // from the transport handshake both legitimately need the full
-      // prefix), so a client that ACKs the same offer twice receives the
-      // buffer twice. The dedupe therefore lives client-side.
-      const room = crypto.randomUUID();
-
-      const { ws: ws1 } = await connectChatWS(
-        `/agents/test-chat-agent/${room}`
-      );
-      await new Promise((r) => setTimeout(r, 50));
-
-      const agentStub = await getAgentByName(env.TestChatAgent, room);
-      const streamId = await agentStub.testStartStream("req-double-ack");
-      await agentStub.testStoreStreamChunk(
-        streamId,
-        '{"type":"start","messageId":"m-double-ack"}'
-      );
-      await agentStub.testStoreStreamChunk(
-        streamId,
-        '{"type":"text-start","id":"t1"}'
-      );
-      await agentStub.testStoreStreamChunk(
-        streamId,
-        '{"type":"text-delta","id":"t1","delta":"hello"}'
-      );
-      await agentStub.testFlushChunkBuffer();
-
-      ws1.close();
-      await new Promise((r) => setTimeout(r, 50));
-
-      const { ws: ws2 } = await connectChatWS(
-        `/agents/test-chat-agent/${room}`
-      );
-      const messages2 = collectMessages(ws2);
-
-      await waitFor(
-        () => messages2.filter(isStreamResumingMessage).length >= 1
-      );
-
-      const ack = JSON.stringify({
-        type: MessageType.CF_AGENT_STREAM_RESUME_ACK,
-        id: "req-double-ack"
-      });
-      ws2.send(ack);
-      ws2.send(ack);
-
-      const isReplayedStart = (m: unknown) =>
-        isUseChatResponseMessage(m) &&
-        (m as { replay?: boolean }).replay === true &&
-        typeof (m as { body?: string }).body === "string" &&
-        (m as { body: string }).body.includes('"type":"start"');
-      const replayCompleteCount = () =>
-        messages2.filter(
-          (m) =>
-            isUseChatResponseMessage(m) &&
-            (m as { replayComplete?: boolean }).replayComplete === true
-        ).length;
-
-      await waitFor(() => replayCompleteCount() >= 2);
-
-      expect(messages2.filter(isReplayedStart).length).toBe(2);
-      expect(replayCompleteCount()).toBe(2);
-
-      ws2.close(1000);
-    });
-
-    it("replay frames of a continuation stream carry continuation: true", async () => {
-      // Live continuation frames carry `continuation: true`; replay frames
-      // must mirror them (#1733) — a replayed continuation `start` without
-      // the flag is treated by clients as a fresh message, dropping the
-      // parts streamed before the continuation.
-      const room = crypto.randomUUID();
-
-      const { ws: ws1 } = await connectChatWS(
-        `/agents/test-chat-agent/${room}`
-      );
-      await new Promise((r) => setTimeout(r, 50));
-
-      const agentStub = await getAgentByName(env.TestChatAgent, room);
-      const streamId = await agentStub.testStartStream("req-cont-replay", {
-        continuation: true
-      });
-      await agentStub.testStoreStreamChunk(
-        streamId,
-        '{"type":"start","messageId":"m-cont"}'
-      );
-      await agentStub.testStoreStreamChunk(
-        streamId,
-        '{"type":"text-delta","id":"t1","delta":"continued"}'
-      );
-      await agentStub.testFlushChunkBuffer();
-
-      ws1.close();
-      await new Promise((r) => setTimeout(r, 50));
-
-      const { ws: ws2 } = await connectChatWS(
-        `/agents/test-chat-agent/${room}`
-      );
-      const messages2 = collectMessages(ws2);
-
-      await waitFor(
-        () => messages2.filter(isStreamResumingMessage).length >= 1
-      );
-
-      ws2.send(
-        JSON.stringify({
-          type: MessageType.CF_AGENT_STREAM_RESUME_ACK,
-          id: "req-cont-replay"
-        })
-      );
-
-      const replayFrames = () =>
-        messages2.filter(
-          (m) =>
-            isUseChatResponseMessage(m) &&
-            (m as { replay?: boolean }).replay === true
-        ) as Array<{
-          continuation?: boolean;
-          replayComplete?: boolean;
-          body?: string;
-        }>;
-
-      await waitFor(() =>
-        replayFrames().some((m) => m.replayComplete === true)
-      );
-
-      const frames = replayFrames();
-      expect(frames.length).toBeGreaterThanOrEqual(3);
-      for (const frame of frames) {
-        expect(frame.continuation).toBe(true);
-      }
-
-      ws2.close(1000);
-    });
-
-    it("retains the continuation flag on replay after hibernation wake", async () => {
-      // The flag is persisted in stream metadata (is_continuation) so a
-      // restored/orphaned continuation stream still replays with
-      // `continuation: true` after the in-memory state was lost.
-      const room = crypto.randomUUID();
-
-      const { ws: ws1 } = await connectChatWS(
-        `/agents/test-chat-agent/${room}`
-      );
-      await new Promise((r) => setTimeout(r, 50));
-
-      const agentStub = await getAgentByName(env.TestChatAgent, room);
-      const streamId = await agentStub.testStartStream("req-cont-orphan2", {
-        continuation: true
-      });
-      await agentStub.testStoreStreamChunk(
-        streamId,
-        '{"type":"text-delta","id":"t1","delta":"continued after wake"}'
-      );
-      await agentStub.testFlushChunkBuffer();
-
-      ws1.close();
-      await new Promise((r) => setTimeout(r, 50));
-
-      // Simulate hibernation: ResumableStream is reconstructed and restores
-      // the active stream (including is_continuation) from SQLite.
-      await agentStub.testSimulateHibernationWake();
-      expect(await agentStub.getActiveStreamId()).toBe(streamId);
-
-      const { ws: ws2 } = await connectChatWS(
-        `/agents/test-chat-agent/${room}`
-      );
-      const messages2 = collectMessages(ws2);
-
-      await waitFor(
-        () => messages2.filter(isStreamResumingMessage).length >= 1
-      );
-
-      ws2.send(
-        JSON.stringify({
-          type: MessageType.CF_AGENT_STREAM_RESUME_ACK,
-          id: "req-cont-orphan2"
-        })
-      );
-
-      // Orphaned stream: replay ends with done=true.
-      await waitFor(() =>
-        messages2.some(
-          (m) =>
-            isUseChatResponseMessage(m) &&
-            (m as { done?: boolean }).done === true
-        )
-      );
-
-      const replayFrames = messages2.filter(
-        (m) =>
-          isUseChatResponseMessage(m) &&
-          (m as { replay?: boolean }).replay === true
-      ) as Array<{ continuation?: boolean }>;
-      expect(replayFrames.length).toBeGreaterThanOrEqual(2);
-      for (const frame of replayFrames) {
-        expect(frame.continuation).toBe(true);
-      }
-
-      ws2.close(1000);
     });
   });
 });

--- a/packages/ai-chat/src/tests/resumable-streaming.test.ts
+++ b/packages/ai-chat/src/tests/resumable-streaming.test.ts
@@ -79,6 +79,7 @@ describe("Resumable Streaming", () => {
       // reconstructed chunks with the right message. Without this wiring the
       // column would be null and recovery would fall back to the (buggy)
       // last-assistant heuristic.
+      const agentStub = await getAgentByName(env.TestChatAgent, room);
       const done = new Promise<void>((resolve) => {
         ws.addEventListener("message", (e: MessageEvent) => {
           const data = JSON.parse(e.data as string);
@@ -112,8 +113,6 @@ describe("Resumable Streaming", () => {
 
       await done;
 
-      const agentStub = await getAgentByName(env.TestChatAgent, room);
-
       // Persistence runs after the `done` broadcast, so wait for the assistant
       // message to land before asserting.
       await waitFor(async () =>
@@ -129,9 +128,14 @@ describe("Resumable Streaming", () => {
       const assistant = persisted.find((m) => m.role === "assistant");
       expect(assistant).toBeDefined();
 
-      const metadata = await agentStub.getAllStreamMetadata();
-      const row = metadata.find((m) => m.request_id === "req-wiring");
+      // The stream's rows are discarded as soon as its message persists, so
+      // the metadata the live path recorded is read from the test agent's
+      // capture at stream start.
+      const row = await agentStub.getStartedStreamMetadata("req-wiring");
       expect(row).toBeDefined();
+      // And once persisted, the stream is gone: nothing left to sweep.
+      const after = await agentStub.getAllStreamMetadata();
+      expect(after.find((m) => m.request_id === "req-wiring")).toBeUndefined();
       // The wiring: the metadata records the SAME id the assistant message was
       // persisted under (the allocated id, since no provider id was emitted).
       expect(row?.message_id).toBeTruthy();

--- a/packages/ai-chat/src/tests/resumable-streaming.test.ts
+++ b/packages/ai-chat/src/tests/resumable-streaming.test.ts
@@ -1882,6 +1882,57 @@ describe("Resumable Streaming", () => {
       ws.close(1000);
     });
 
+    it("cuts over through a persistMessages override that forwards only the messages", async () => {
+      const room = crypto.randomUUID();
+      const { ws } = await connectChatWS(
+        `/agents/overriding-persist-agent/${room}`
+      );
+      await new Promise((r) => setTimeout(r, 50));
+      const agentStub = await getAgentByName(env.OverridingPersistAgent, room);
+
+      const done = new Promise<void>((resolve) => {
+        ws.addEventListener("message", (e: MessageEvent) => {
+          const data = JSON.parse(e.data as string);
+          if (
+            data.type === MessageType.CF_AGENT_USE_CHAT_RESPONSE &&
+            data.done
+          ) {
+            resolve();
+          }
+        });
+      });
+      ws.send(
+        JSON.stringify({
+          type: MessageType.CF_AGENT_USE_CHAT_REQUEST,
+          id: "req-override",
+          init: {
+            method: "POST",
+            body: JSON.stringify({
+              messages: [
+                {
+                  id: "u-1",
+                  role: "user",
+                  parts: [{ type: "text", text: "hi" }]
+                }
+              ]
+            })
+          }
+        })
+      );
+      await done;
+      await waitFor(async () =>
+        (
+          (await agentStub.getPersistedMessages()) as Array<{ role: string }>
+        ).some((m) => m.role === "assistant")
+      );
+      expect(await agentStub.getPersistOverrideCalls()).toBeGreaterThan(0);
+      // The override dropped the internal options, yet the message write
+      // still ran inside the cutover: a plain persist would have left the
+      // finished stream's row (settled, not discarded) until the next turn.
+      expect(await agentStub.getAllStreamMetadata()).toEqual([]);
+      ws.close(1000);
+    });
+
     it("reclaims finished streams of any age and abandoned in-flight rows past the stale window", async () => {
       const room = crypto.randomUUID();
       const { ws } = await connectChatWS(`/agents/test-chat-agent/${room}`);

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -950,56 +950,16 @@ export class TestChatAgent extends AIChatAgent<Env> {
     this._restoreActiveStream();
   }
 
-  testTriggerStreamCleanup(): void {
-    // Force the cleanup interval to 0 so the next completeStream triggers it
-    // We do this by starting and immediately completing a dummy stream
-    const dummyId = this._startStream("cleanup-trigger");
-    this._completeStream(dummyId);
+  /** Reclaim leftover chat streams now, as the next stream start would. */
+  testReclaimStreams(nowMs?: number): number {
+    return this._resumableStream.reclaim(nowMs);
   }
 
-  /** Invoke the alarm-driven cleanup callback directly (no new stream needed). */
-  async testRunStreamCleanup(): Promise<void> {
-    await this._cleanupStreamBuffers();
-  }
-
-  /** Number of pending alarm-driven stream-cleanup schedules for this DO. */
+  /** Number of pending stream-cleanup schedules (always 0: none are armed). */
   testCountStreamCleanupSchedules(): number {
     return this.getSchedules().filter(
       (s) => s.callback === "_cleanupStreamBuffers"
     ).length;
-  }
-
-  /**
-   * The delay (seconds) of the pending cleanup schedule, or null if none.
-   * Locks the arming interval (STREAM_CLEANUP_DELAY_SECONDS) so a regression
-   * that lengthens it back toward the old 24h leak window is caught.
-   */
-  testStreamCleanupScheduleDelaySeconds(): number | null {
-    const schedule = this.getSchedules().find(
-      (s) => s.callback === "_cleanupStreamBuffers"
-    );
-    if (!schedule || schedule.type !== "delayed") return null;
-    return schedule.delayInSeconds;
-  }
-
-  /** Arm the cleanup alarm without finishing a stream (leaves no new buffer). */
-  async testArmStreamCleanup(): Promise<void> {
-    await this._ensureStreamCleanupScheduled();
-  }
-
-  /**
-   * Backdate any pending cleanup schedule so it is due, then run the REAL
-   * `alarm()` handler. This exercises the production path where `alarm()`
-   * deletes the fired one-shot row after the callback returns — so a re-arm
-   * must create a fresh row to survive (the idempotent-reschedule footgun).
-   */
-  async testFireDueCleanupAlarm(): Promise<void> {
-    this.sql`
-      update cf_agents_jobs
-      set time = ${Date.now() - 1_000}
-      where capability = 'scheduler' and fn = '_cleanupStreamBuffers'
-    `;
-    await this.alarm();
   }
 
   /**

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -834,10 +834,15 @@ export class TestChatAgent extends AIChatAgent<Env> {
     return this._resumableStream.getStreamChunks(streamId);
   }
 
-  /** Raw count of stored rows for a stream (packed segments count as 1 each). */
+  /**
+   * Number of stored segments for a stream (packed segments count as 1
+   * each): the appended-segment cursor, read from the block log's tail.
+   * Blocks pack many segments into one row, so a row count no longer
+   * reflects how the adapter batched its writes.
+   */
   getStreamChunkRowCount(streamId: string): number {
-    const result = this.sql<{ cnt: number }>`
-      select count(*) as cnt from cf_agents_stream_chunks
+    const result = this.sql<{ cnt: number | null }>`
+      select max(seq_to) as cnt from cf_agents_stream_blocks
       where stream_id = ${streamId}
     `;
     return result?.[0]?.cnt ?? 0;
@@ -859,18 +864,48 @@ export class TestChatAgent extends AIChatAgent<Env> {
       values (${streamId}, 'completed', ${requestId}, ${JSON.stringify({ cfChat: 1 })},
               ${bodies.length}, ${now}, ${now}, ${now})
     `;
-    bodies.forEach((body, index) => {
+    if (bodies.length > 0) {
       this.sql`
-        insert into cf_agents_stream_chunks (stream_id, seq, chunk, created_at)
-        values (${streamId}, ${index}, ${JSON.stringify(body)}, ${now})
+        insert into cf_agents_stream_blocks
+          (stream_id, block, seq_from, seq_to, body, created_at, updated_at)
+        values (${streamId}, 0, 0, ${bodies.length},
+                ${bodies.map((b) => JSON.stringify(b)).join(",")}, ${now}, ${now})
       `;
-    });
+    }
   }
 
   getStreamMetadata(
     streamId: string
   ): { status: string; request_id: string } | null {
     return this._resumableStream.getStreamMetadata(streamId);
+  }
+
+  /**
+   * Stream metadata captured at stream start, keyed by request id. The rows
+   * themselves are discarded as soon as the turn's message persists, so a
+   * test that wants to see what the live path recorded reads it here.
+   */
+  private _startedStreams = new Map<
+    string,
+    { id: string; message_id: string | null }
+  >();
+
+  protected override _startStream(
+    requestId: string,
+    options: { messageId?: string; continuation?: boolean } = {}
+  ): string {
+    const streamId = super._startStream(requestId, options);
+    this._startedStreams.set(requestId, {
+      id: streamId,
+      message_id: this._resumableStream.getStreamMessageId(streamId)
+    });
+    return streamId;
+  }
+
+  getStartedStreamMetadata(
+    requestId: string
+  ): { id: string; message_id: string | null } | null {
+    return this._startedStreams.get(requestId) ?? null;
   }
 
   getAllStreamMetadata(): Array<{
@@ -3075,10 +3110,13 @@ export class ChatRecoveryTestAgent extends AIChatAgent<Env> {
       values (${streamId}, 'streaming', ${requestId}, ${JSON.stringify(streamMetadata)},
               ${chunks.length}, ${createdAt}, ${createdAt})
     `;
-    for (const chunk of chunks) {
+    if (chunks.length > 0) {
+      const body = chunks.map((c) => JSON.stringify(c.body)).join(",");
       this.sql`
-        insert into cf_agents_stream_chunks (stream_id, seq, chunk, created_at)
-        values (${streamId}, ${chunk.index}, ${JSON.stringify(chunk.body)}, ${createdAt})
+        insert into cf_agents_stream_blocks
+          (stream_id, block, seq_from, seq_to, body, created_at, updated_at)
+        values (${streamId}, 0, ${chunks[0].index}, ${chunks[chunks.length - 1].index + 1},
+                ${body}, ${createdAt}, ${createdAt})
       `;
     }
     this._resumableStream.restore();

--- a/packages/ai-chat/src/tests/worker.ts
+++ b/packages/ai-chat/src/tests/worker.ts
@@ -121,6 +121,7 @@ function makeHangingSSEResponse() {
 export type Env = {
   TestChatAgent: DurableObjectNamespace<TestChatAgent>;
   CustomSanitizeAgent: DurableObjectNamespace<CustomSanitizeAgent>;
+  OverridingPersistAgent: DurableObjectNamespace<OverridingPersistAgent>;
   AgentWithSuperCall: DurableObjectNamespace<AgentWithSuperCall>;
   AgentWithoutSuperCall: DurableObjectNamespace<AgentWithoutSuperCall>;
   SlowStreamAgent: DurableObjectNamespace<SlowStreamAgent>;
@@ -1021,6 +1022,28 @@ export class TestChatAgent extends AIChatAgent<Env> {
  * Test agent that overrides sanitizeMessageForPersistence to strip custom data.
  * Used to verify the user-overridable hook runs after built-in sanitization.
  */
+/**
+ * A subclass that overrides `persistMessages` the way application code
+ * does: extra side effects, then `super` with only the messages. The
+ * cutover must still reach the session write — the finished turn leaves no
+ * stream row behind — even though the override forwards no third argument.
+ */
+export class OverridingPersistAgent extends TestChatAgent {
+  private _persistOverrideCalls = 0;
+
+  override async persistMessages(
+    messages: ChatMessage[],
+    excludeBroadcastIds: string[] = []
+  ) {
+    this._persistOverrideCalls++;
+    await super.persistMessages(messages, excludeBroadcastIds);
+  }
+
+  getPersistOverrideCalls(): number {
+    return this._persistOverrideCalls;
+  }
+}
+
 export class CustomSanitizeAgent extends AIChatAgent<Env> {
   async onChatMessage() {
     return new Response("ok");

--- a/packages/ai-chat/src/tests/wrangler.jsonc
+++ b/packages/ai-chat/src/tests/wrangler.jsonc
@@ -113,6 +113,10 @@
       {
         "class_name": "StuckAgentToolChild",
         "name": "StuckAgentToolChild"
+      },
+      {
+        "class_name": "OverridingPersistAgent",
+        "name": "OverridingPersistAgent"
       }
       // Agent-tool children are addressed as facets of
       // `AIChatAgentToolParent`, so they do not need migration entries.
@@ -192,6 +196,10 @@
     },
     {
       "tag": "v14"
+    },
+    {
+      "new_sqlite_classes": ["OverridingPersistAgent"],
+      "tag": "v15"
     }
   ]
 }

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -4975,10 +4975,13 @@ export class ThinkToolsTestAgent extends Think {
       VALUES (${streamId}, ${state}, ${requestId}, ${JSON.stringify({ cfChat: 1 })},
               ${chunks.length}, ${now}, ${now}, ${closedAt})
     `;
-    for (const chunk of chunks) {
+    if (chunks.length > 0) {
+      const body = chunks.map((c) => JSON.stringify(c.body)).join(",");
       this.sql`
-        INSERT INTO cf_agents_stream_chunks (stream_id, seq, chunk, created_at)
-        VALUES (${streamId}, ${chunk.index}, ${JSON.stringify(chunk.body)}, ${now})
+        INSERT INTO cf_agents_stream_blocks
+          (stream_id, block, seq_from, seq_to, body, created_at, updated_at)
+        VALUES (${streamId}, 0, ${chunks[0].index}, ${chunks[chunks.length - 1].index + 1},
+                ${body}, ${now}, ${now})
       `;
     }
   }
@@ -6910,7 +6913,7 @@ export class ThinkRecoveryTestAgent extends Think {
       self._storeChunkDurably(streamId, chunk, JSON.stringify(chunk), state);
     const rawCount = (): number => {
       const rows = this.sql<{ count: number }>`
-        SELECT COUNT(*) as count FROM cf_agents_stream_chunks
+        SELECT COALESCE(MAX(seq_to), 0) as count FROM cf_agents_stream_blocks
         WHERE stream_id = ${streamId}
       `;
       return rows[0]?.count ?? 0;
@@ -7775,10 +7778,13 @@ export class ThinkRecoveryTestAgent extends Think {
       VALUES (${streamId}, ${state}, ${requestId}, ${JSON.stringify({ cfChat: 1 })},
               ${chunks.length}, ${now}, ${now}, ${closedAt})
     `;
-    for (const chunk of chunks) {
+    if (chunks.length > 0) {
+      const body = chunks.map((c) => JSON.stringify(c.body)).join(",");
       this.sql`
-        INSERT INTO cf_agents_stream_chunks (stream_id, seq, chunk, created_at)
-        VALUES (${streamId}, ${chunk.index}, ${JSON.stringify(chunk.body)}, ${now})
+        INSERT INTO cf_agents_stream_blocks
+          (stream_id, block, seq_from, seq_to, body, created_at, updated_at)
+        VALUES (${streamId}, 0, ${chunks[0].index}, ${chunks[chunks.length - 1].index + 1},
+                ${body}, ${now}, ${now})
       `;
     }
   }

--- a/packages/think/src/tests/agents/think-session.ts
+++ b/packages/think/src/tests/agents/think-session.ts
@@ -7841,11 +7841,9 @@ export class ThinkRecoveryTestAgent extends Think {
     )._startResumableStream(requestId);
   }
 
-  /** Invoke the alarm-driven cleanup callback directly. */
-  async runStreamCleanupForTest(): Promise<void> {
-    await (
-      this as unknown as { _cleanupStreamBuffers(): Promise<void> }
-    )._cleanupStreamBuffers();
+  /** Reclaim leftover streams now, as the next stream start does. */
+  async runStreamCleanupForTest(nowMs?: number): Promise<number> {
+    return this._resumableStream.reclaim(nowMs);
   }
 
   /** Finish a stream via the cleanup-arming wrapper (mirrors a real turn end). */
@@ -7853,43 +7851,6 @@ export class ThinkRecoveryTestAgent extends Think {
     (
       this as unknown as { _completeResumableStream(id: string): void }
     )._completeResumableStream(streamId);
-  }
-
-  /** Arm the cleanup alarm without finishing a stream (leaves no new buffer). */
-  async armStreamCleanupForTest(): Promise<void> {
-    await (
-      this as unknown as { _ensureStreamCleanupScheduled(): Promise<void> }
-    )._ensureStreamCleanupScheduled();
-  }
-
-  /**
-   * The delay (seconds) of the pending cleanup schedule, or null if none.
-   * Locks the arming interval (STREAM_CLEANUP_DELAY_SECONDS) so a regression
-   * that lengthens it back toward the old 24h leak window is caught.
-   */
-  async streamCleanupScheduleDelaySecondsForTest(): Promise<number | null> {
-    const rows = this.sql<{ delayInSeconds: number | null }>`
-      SELECT json_extract(payload, '$.delayInSeconds') AS delayInSeconds
-      FROM cf_agents_jobs
-      WHERE capability = 'scheduler' AND fn = '_cleanupStreamBuffers'
-      LIMIT 1
-    `;
-    return rows[0]?.delayInSeconds ?? null;
-  }
-
-  /**
-   * Backdate any pending cleanup schedule so it is due, then run the REAL
-   * `alarm()` handler. This exercises the production path where `alarm()`
-   * deletes the fired one-shot row after the callback returns — so a re-arm
-   * must create a fresh row to survive (the idempotent-reschedule footgun).
-   */
-  async fireDueCleanupAlarmForTest(): Promise<void> {
-    this.sql`
-      UPDATE cf_agents_jobs
-      SET time = ${Date.now() - 1_000}
-      WHERE capability = 'scheduler' AND fn = '_cleanupStreamBuffers'
-    `;
-    await this.alarm();
   }
 
   async insertInterruptedFiber(

--- a/packages/think/src/tests/stream-cleanup.test.ts
+++ b/packages/think/src/tests/stream-cleanup.test.ts
@@ -3,11 +3,11 @@ import { describe, expect, it } from "vitest";
 import { getAgentByName } from "agents";
 import type { ThinkRecoveryTestAgent } from "./agents/think-session";
 
-// Covers alarm-driven resumable-stream buffer cleanup (#1706): Think arms a
-// scheduled cleanup alarm whenever a stream finishes so idle/one-off chat DOs
-// still reclaim their buffers, instead of only sweeping lazily when a
-// *subsequent* stream completes. Uses ThinkRecoveryTestAgent, which carries the
-// stream/schedule test helpers.
+// Resumable-stream buffers are reclaimed without an alarm: the cutover
+// deletes a finished stream's rows in the transaction that persists its
+// message, and the next stream start reclaims anything a crash left behind —
+// finished streams of any age and in-flight rows abandoned past the stale
+// window. Uses ThinkRecoveryTestAgent, which carries the stream test helpers.
 
 const CLEANUP_CALLBACK = "_cleanupStreamBuffers";
 
@@ -18,259 +18,102 @@ async function freshAgent(name?: string) {
   );
 }
 
-describe("Think — alarm-driven stream cleanup (#1706)", () => {
-  it("arms a single cleanup alarm when a stream finishes, deduping repeats", async () => {
+describe("Think — stream reclaim (no cleanup alarm)", () => {
+  it("never arms a cleanup alarm when a stream starts or finishes", async () => {
     const agent = await freshAgent();
-
+    await agent.startStreamForTest("req-1");
     expect(
       await agent.getScheduledChatRecoveryCountForTest(CLEANUP_CALLBACK)
     ).toBe(0);
-
-    await agent.insertAgedStreamForTest("s1", "req-1", "streaming", 1000);
+    await agent.insertAgedStreamForTest("s1", "req-2", "streaming", 1000);
     await agent.completeStreamForTest("s1");
     expect(
       await agent.getScheduledChatRecoveryCountForTest(CLEANUP_CALLBACK)
-    ).toBe(1);
-
-    // Subsequent finishes collapse onto the same pending alarm (idempotent).
-    await agent.insertAgedStreamForTest("s2", "req-2", "streaming", 1000);
-    await agent.completeStreamForTest("s2");
-    expect(
-      await agent.getScheduledChatRecoveryCountForTest(CLEANUP_CALLBACK)
-    ).toBe(1);
+    ).toBe(0);
   });
 
-  it("reclaims aged buffers when the alarm fires without a new stream completing", async () => {
+  it("reclaims finished streams of any age and abandoned in-flight rows past the stale window", async () => {
     const agent = await freshAgent();
-
-    // The #1706 scenario: a one-off chat whose buffers age out with no further
-    // stream ever completing to drive the lazy in-line sweep.
+    await agent.insertAgedStreamForTest(
+      "done-recent",
+      "req-d",
+      "completed",
+      5_000
+    );
     await agent.insertAgedStreamForTest(
       "old-errored",
-      "req-errored",
+      "req-e",
       "error",
       25 * 60 * 60 * 1000
     );
     await agent.insertAgedStreamForTest(
-      "abandoned",
-      "req-abandoned",
+      "inflight-recent",
+      "req-r",
       "streaming",
-      25 * 60 * 60 * 1000
+      30 * 60 * 1000
+    );
+    await agent.insertAgedStreamForTest(
+      "inflight-stale",
+      "req-s",
+      "streaming",
+      70 * 60 * 1000
     );
 
-    await agent.runStreamCleanupForTest();
-
+    expect(await agent.runStreamCleanupForTest()).toBe(3);
+    expect(await agent.getStreamStatusForTest("done-recent")).toBeNull();
     expect(await agent.getStreamStatusForTest("old-errored")).toBeNull();
-    expect(await agent.getStreamStatusForTest("abandoned")).toBeNull();
-  });
-
-  it("re-arms only while reclaimable buffers remain", async () => {
-    const agent = await freshAgent();
-
-    // Fully-swept DO: running cleanup with nothing left does NOT re-arm.
-    await agent.runStreamCleanupForTest();
-    expect(
-      await agent.getScheduledChatRecoveryCountForTest(CLEANUP_CALLBACK)
-    ).toBe(0);
-
-    // A still-recent stream survives the sweep, so an alarm stays pending.
-    await agent.insertAgedStreamForTest(
-      "recent",
-      "req-recent",
-      "streaming",
-      60 * 1000
+    expect(await agent.getStreamStatusForTest("inflight-stale")).toBeNull();
+    expect(await agent.getStreamStatusForTest("inflight-recent")).toBe(
+      "streaming"
     );
-    await agent.runStreamCleanupForTest();
-    expect(await agent.getStreamStatusForTest("recent")).toBe("streaming");
-    expect(
-      await agent.getScheduledChatRecoveryCountForTest(CLEANUP_CALLBACK)
-    ).toBe(1);
   });
 
-  it("survives the real alarm fire and re-arms when a younger buffer remains", async () => {
-    // Guards the idempotent-reschedule footgun: when the cleanup alarm fires,
-    // `alarm()` deletes the fired one-shot row after the callback returns. An
-    // idempotent re-arm would dedup onto that doomed row and vanish with it,
-    // leaking any buffer that survived this sweep. The re-arm must be a fresh
-    // row.
+  it("does not reclaim a long-running stream that is still emitting chunks", async () => {
     const agent = await freshAgent();
-
-    // A recent buffer that survives the 24h sweep, plus a finish to arm the
-    // alarm.
-    await agent.insertAgedStreamForTest(
-      "young",
-      "req-young",
-      "streaming",
-      60 * 1000
-    );
-    await agent.completeStreamForTest("young");
-    expect(
-      await agent.getScheduledChatRecoveryCountForTest(CLEANUP_CALLBACK)
-    ).toBe(1);
-
-    // Fire the alarm for real — the fired row is deleted after the callback.
-    await agent.fireDueCleanupAlarmForTest();
-
-    // The young buffer survived the sweep, so a FRESH cleanup alarm must remain
-    // pending (this is exactly 0 if the re-arm were idempotent).
-    expect(await agent.getStreamStatusForTest("young")).toBe("completed");
-    expect(
-      await agent.getScheduledChatRecoveryCountForTest(CLEANUP_CALLBACK)
-    ).toBe(1);
-  });
-
-  it("stops re-arming after the real alarm sweeps the last buffer", async () => {
-    const agent = await freshAgent();
-
-    // An aged buffer that the sweep will reclaim. Arm directly so we don't
-    // leave a fresh surviving buffer (completing a stream would reset its age).
-    await agent.insertAgedStreamForTest(
-      "old",
-      "req-old",
-      "completed",
-      25 * 60 * 60 * 1000
-    );
-    await agent.armStreamCleanupForTest();
-    expect(
-      await agent.getScheduledChatRecoveryCountForTest(CLEANUP_CALLBACK)
-    ).toBe(1);
-
-    await agent.fireDueCleanupAlarmForTest();
-
-    // Nothing reclaimable remains, so no re-arm: the DO stops waking itself.
-    expect(await agent.getStreamStatusForTest("old")).toBeNull();
-    expect(
-      await agent.getScheduledChatRecoveryCountForTest(CLEANUP_CALLBACK)
-    ).toBe(0);
-  });
-
-  it("does not sweep a long-running stream that is still emitting chunks", async () => {
-    // The abandoned-streaming sweep keys off LAST chunk activity, not start
-    // time: a stream that began > 24h ago but is still writing chunks must
-    // survive, while one silent past the window is reclaimed.
-    const agent = await freshAgent();
-
     await agent.insertAgedStreamForTest(
       "long-active",
-      "req-active",
+      "req-a",
       "streaming",
       25 * 60 * 60 * 1000
     );
     await agent.insertStreamChunkForTest("long-active", 60 * 1000);
-
     await agent.insertAgedStreamForTest(
       "long-silent",
-      "req-silent",
+      "req-s",
       "streaming",
       25 * 60 * 60 * 1000
     );
     await agent.insertStreamChunkForTest("long-silent", 25 * 60 * 60 * 1000);
 
     await agent.runStreamCleanupForTest();
-
     expect(await agent.getStreamStatusForTest("long-active")).toBe("streaming");
     expect(await agent.getStreamStatusForTest("long-silent")).toBeNull();
   });
 
-  it("arms cleanup when a stream starts (covers never-finished orphans)", async () => {
+  it("keeps an in-flight buffer's chunks reconstructable within the stale window", async () => {
     const agent = await freshAgent();
-
-    expect(
-      await agent.getScheduledChatRecoveryCountForTest(CLEANUP_CALLBACK)
-    ).toBe(0);
-
-    // Starting a stream (without ever finishing it) must arm cleanup so an
-    // evicted, never-resumed mid-stream orphan still gets a future sweep.
-    await agent.startStreamForTest("req-orphan");
-    expect(
-      await agent.getScheduledChatRecoveryCountForTest(CLEANUP_CALLBACK)
-    ).toBe(1);
-  });
-
-  it("arms the cleanup alarm at the completion-grace delay (10 minutes)", async () => {
-    // Locks the arming interval: a regression that lengthens it back toward
-    // the old 24h window (re-introducing the #1706 leak) fails here.
-    const agent = await freshAgent();
-
-    await agent.armStreamCleanupForTest();
-    expect(await agent.streamCleanupScheduleDelaySecondsForTest()).toBe(
-      10 * 60
-    );
-  });
-
-  it("sweeps a finished buffer past the 10-minute grace, keeps a recent one", async () => {
-    // Completion retention is short: the assistant message is persisted
-    // separately, so a finished buffer is only a brief replay grace.
-    const agent = await freshAgent();
-
-    await agent.insertAgedStreamForTest(
-      "done-stale",
-      "req-done-stale",
-      "completed",
-      11 * 60 * 1000
-    );
-    await agent.insertAgedStreamForTest(
-      "done-recent",
-      "req-done-recent",
-      "completed",
-      5 * 60 * 1000
-    );
-
-    await agent.runStreamCleanupForTest();
-
-    expect(await agent.getStreamStatusForTest("done-stale")).toBeNull();
-    expect(await agent.getStreamStatusForTest("done-recent")).toBe("completed");
-  });
-
-  it("keeps an abandoned in-flight buffer until the 1-hour stale window", async () => {
-    // In-flight retention is generous so an interrupted turn has ample time to
-    // be resumed or recovered before its buffer is presumed dead.
-    const agent = await freshAgent();
-
-    await agent.insertAgedStreamForTest(
-      "inflight-recent",
-      "req-inflight-recent",
-      "streaming",
-      30 * 60 * 1000
-    );
-    await agent.insertAgedStreamForTest(
-      "inflight-stale",
-      "req-inflight-stale",
-      "streaming",
-      70 * 60 * 1000
-    );
-
-    await agent.runStreamCleanupForTest();
-
-    expect(await agent.getStreamStatusForTest("inflight-recent")).toBe(
-      "streaming"
-    );
-    expect(await agent.getStreamStatusForTest("inflight-stale")).toBeNull();
-  });
-
-  it("keeps an in-flight buffer's chunks reconstructable past the completion grace", async () => {
-    // Recovery reconstructs a partial assistant message from the stream buffer
-    // (getStreamChunks), and only ever does so for an ACTIVE `streaming` row —
-    // which uses the generous 1h last-activity window, NOT the 10min completion
-    // grace. A buffer whose last chunk is older than the completion grace but
-    // within the in-flight window must survive a sweep with its chunks intact,
-    // otherwise a turn interrupted >10min could not be recovered.
-    const agent = await freshAgent();
-
     await agent.insertAgedStreamForTest(
       "recovering",
       "req-recovering",
       "streaming",
       30 * 60 * 1000
     );
-    // Last chunk 20 minutes ago: past the 10min grace, within the 1h window.
     await agent.insertStreamChunkForTest("recovering", 20 * 60 * 1000);
 
     await agent.runStreamCleanupForTest();
-
     expect(await agent.getStreamStatusForTest("recovering")).toBe("streaming");
     const snapshot = await agent.getLatestStreamSnapshot();
     expect(snapshot?.requestId).toBe("req-recovering");
     expect(snapshot?.chunkCount).toBeGreaterThan(0);
+  });
+
+  it("a real turn leaves no stream rows behind", async () => {
+    const agent = await freshAgent();
+    const result = await agent.testChat("Cut over");
+    expect(result.done).toBe(true);
+    expect(await agent.getLatestStreamSnapshot()).toBeNull();
+    expect(
+      await agent.getScheduledChatRecoveryCountForTest(CLEANUP_CALLBACK)
+    ).toBe(0);
   });
 });

--- a/packages/think/src/tests/think-session.test.ts
+++ b/packages/think/src/tests/think-session.test.ts
@@ -2438,17 +2438,20 @@ describe("Think — chatRecovery", () => {
     expect(fibers).toHaveLength(0);
   });
 
-  it("chat() records stream chunks for recovery lookup", async () => {
+  it("chat() discards the stream once its message is persisted", async () => {
     const agent = await freshRecoveryAgent("chat-stream-metadata");
 
     const result = await agent.testChat("Record the stream");
     expect(result.done).toBe(true);
 
+    // The stream's rows were the recovery evidence while the turn was in
+    // flight; once the assistant message is durable they are redundant and
+    // are dropped in place, leaving nothing for the retention sweep.
+    // Interrupted turns keep their rows (covered by the recovery tests).
     const snapshot = await agent.getLatestStreamSnapshot();
-    expect(snapshot).not.toBeNull();
-    expect(snapshot!.status).toBe("completed");
-    expect(snapshot!.chunkCount).toBeGreaterThan(0);
-    expect(snapshot!.text).toBe("Continued response.");
+    expect(snapshot).toBeNull();
+    const messages = (await agent.getStoredMessages()) as UIMessage[];
+    expect(messages.at(-1)?.role).toBe("assistant");
   });
 
   it("saveMessages with recovery wraps in fiber and cleans up", async () => {

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -187,9 +187,7 @@ import {
   CHAT_MESSAGE_TYPES,
   TurnQueue,
   ResumableStream,
-  cleanupStreamBuffers,
   createChatStreams,
-  STREAM_CLEANUP_DELAY_SECONDS,
   ContinuationState,
   PreStreamTurns,
   AutoContinuationController,
@@ -1127,7 +1125,7 @@ type ThinkRecoveryClassification = { retryTargetUserId: string | null };
 // (The recovering-flag key/TTL and the stream-cleanup delay/re-arm loop now live
 // in agents/chat — the durable recovery UX is driven via the shared
 // `setChatRecovering` / `buildChatRecoveringFrame` helpers, and buffer cleanup via
-// `STREAM_CLEANUP_DELAY_SECONDS` / `cleanupStreamBuffers`. The N9 throttle lives
+// The N9 throttle lives
 // there too as `AgentToolStreamProgressThrottle`.)
 
 // Ephemeral user message appended when a model request would otherwise end in
@@ -12727,7 +12725,7 @@ export class Think<
       if (streamError) {
         this._errorResumableStream(streamId);
       } else {
-        this._completeResumableStream(streamId);
+        this._finishResumableStream(streamId);
       }
       streamFinalized = true;
       this._broadcastChat({
@@ -12740,12 +12738,11 @@ export class Think<
 
       assistantMsg = accumulator.toMessage();
       if (accumulator.parts.length > 0) {
-        await this._persistAssistantMessage(assistantMsg);
+        await this._persistAssistantMessageWithCutover(streamId, assistantMsg);
         this._broadcastMessages();
-        // The message is durable: drop the stream's block rows now rather
-        // than leaving them for the retention sweep.
-        this._resumableStream.discardCompleted(streamId);
       }
+      // Nothing to persist (or the persist threw): settle the finished stream.
+      this._resumableStream.finalizePending();
 
       if (streamError) {
         await this._fireResponseHook({
@@ -13215,7 +13212,7 @@ export class Think<
       if (streamError) {
         this._errorResumableStream(streamId);
       } else {
-        this._completeResumableStream(streamId);
+        this._finishResumableStream(streamId);
       }
       this._pendingResumeConnections.clear();
       this._broadcastChat({
@@ -13340,12 +13337,16 @@ export class Think<
         const assistantMsg = accumulator.toMessage();
 
         if (accumulator.parts.length > 0) {
-          await this._persistAssistantMessage(assistantMsg, parentId);
+          await this._persistAssistantMessageWithCutover(
+            streamId,
+            assistantMsg,
+            parentId
+          );
           this._broadcastMessages();
-          // The message is durable: drop the stream's block rows now rather
-          // than leaving them for the retention sweep.
-          this._resumableStream.discardCompleted(streamId);
         }
+        // Nothing to persist (or the persist threw): settle the finished
+        // stream so it is not mistaken for an interrupted turn.
+        this._resumableStream.finalizePending();
 
         await this._fireResponseHook({
           message: assistantMsg,
@@ -13362,6 +13363,7 @@ export class Think<
         console.error("Failed to persist assistant message:", e);
       }
     }
+    this._resumableStream.finalizePending();
 
     // The message is now persisted (or the turn was cleared), so subsequent
     // tool results resolve against storage; stop exposing the accumulator and
@@ -13404,6 +13406,36 @@ export class Think<
     const toPersist = this._strippedForPersist(msg);
     if (toPersist === null) return;
     await this._upsertMessageInHistory(toPersist, parentId);
+  }
+
+  /**
+   * The cutover: persist the finished turn's assistant message, settle its
+   * resumable stream and delete the stream's rows in ONE SQLite transaction,
+   * so a crash leaves either the live stream (recovery rebuilds the message
+   * from it) or the message — never neither, never both. The session
+   * change feed and auto-compaction run once the transaction has committed.
+   */
+  private async _persistAssistantMessageWithCutover(
+    streamId: string,
+    msg: UIMessage,
+    parentId?: string
+  ): Promise<void> {
+    const toPersist = this._strippedForPersist(msg);
+    if (toPersist === null) return;
+    if (this._resumableStream.pendingCutoverId !== streamId) {
+      // The stream was settled by another path (a stall, an error): plain persist.
+      await this._upsertMessageInHistory(toPersist, parentId);
+      return;
+    }
+    const sync = this.sessions.session().__DO_NOT_USE_WILL_BREAK__sync();
+    let after: (() => Promise<void>) | undefined;
+    this._resumableStream.cutover(streamId, () => {
+      after = sync.upsert(toPersist as SessionMessage, {
+        parentId,
+        source: "server"
+      }).after;
+    });
+    await after?.();
   }
 
   /**
@@ -16223,58 +16255,35 @@ export class Think<
     // reconnected before the first chunk. (Continuation-turn parks live in
     // `_continuation` and are flushed by the caller.)
     this._preStream.flushOnStreamStart((c) => this._notifyStreamResuming(c));
-    void this._ensureStreamCleanupScheduled();
     return streamId;
   }
 
-  /**
-   * Mark a resumable stream completed and arm buffer cleanup. Wrapper around
-   * `ResumableStream.complete` so every stream-finish path also schedules the
-   * cleanup alarm (#1706).
-   */
+  /** Mark a resumable stream completed (settled now, rows kept until reclaim). */
   protected _completeResumableStream(streamId: string): void {
     this._resumableStream.complete(streamId);
-    void this._ensureStreamCleanupScheduled();
   }
 
   /**
-   * Mark a resumable stream errored and arm buffer cleanup. Wrapper around
-   * `ResumableStream.markError` — see {@link _completeResumableStream}.
+   * The producer finished; leave the row for the cutover that persists the
+   * assistant message (`_persistAssistantMessageWithCutover`). Every path
+   * that calls this must end in that cutover or `finalizePending()`.
    */
+  protected _finishResumableStream(streamId: string): void {
+    this._resumableStream.finish(streamId);
+  }
+
+  /** Mark a resumable stream errored. */
   protected _errorResumableStream(streamId: string): void {
     this._resumableStream.markError(streamId);
-    void this._ensureStreamCleanupScheduled();
   }
 
   /**
-   * Ensure a single cleanup alarm is pending for this DO's resumable-stream
-   * buffers. Armed whenever a stream finishes so that idle/one-off chat DOs
-   * still reclaim their buffers — the lazy sweep in {@link ResumableStream}
-   * only fires when a *subsequent* stream completes, which never happens for a
-   * chat that receives a single turn (#1706).
-   *
-   * `idempotent` dedupes on (callback, payload, owner) so repeated finishes
-   * collapse onto one pending alarm rather than stacking.
-   */
-  protected async _ensureStreamCleanupScheduled({
-    idempotent = true
-  }: { idempotent?: boolean } = {}): Promise<void> {
-    await this.schedule(
-      STREAM_CLEANUP_DELAY_SECONDS,
-      "_cleanupStreamBuffers",
-      undefined,
-      { idempotent }
-    );
-  }
-
-  /**
-   * Alarm callback: sweep aged stream buffers, re-arming while rows remain (see
-   * the shared {@link cleanupStreamBuffers}).
+   * @deprecated Streams are reclaimed at cutover and on the next stream
+   * start; no alarm is armed any more. Kept so a cleanup alarm persisted by
+   * an earlier version still resolves to a callback when it fires.
    */
   async _cleanupStreamBuffers(): Promise<void> {
-    await cleanupStreamBuffers(this._resumableStream, () =>
-      this._ensureStreamCleanupScheduled({ idempotent: false })
-    );
+    this._resumableStream.reclaim();
   }
 
   private async _persistOrphanedStream(streamId: string): Promise<void> {

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -12742,6 +12742,9 @@ export class Think<
       if (accumulator.parts.length > 0) {
         await this._persistAssistantMessage(assistantMsg);
         this._broadcastMessages();
+        // The message is durable: drop the stream's block rows now rather
+        // than leaving them for the retention sweep.
+        this._resumableStream.discardCompleted(streamId);
       }
 
       if (streamError) {
@@ -13339,6 +13342,9 @@ export class Think<
         if (accumulator.parts.length > 0) {
           await this._persistAssistantMessage(assistantMsg, parentId);
           this._broadcastMessages();
+          // The message is durable: drop the stream's block rows now rather
+          // than leaving them for the retention sweep.
+          this._resumableStream.discardCompleted(streamId);
         }
 
         await this._fireResponseHook({


### PR DESCRIPTION
## What

The stream data and the final session message live in the same Durable Object storage, and the handoff between them is one transaction:

```
temporary stream blocks
        ↓
session message
        ↓
delete temporary blocks
```

Three changes make that cheap and crash-safe:

1. **Rollover block log.** `cf_agents_stream_chunks` (one row per append) becomes `cf_agents_stream_blocks`: an append grows the open block row with an UPDATE until it reaches 256 KB, then opens the next. Still one billed row per append, but a stream of thousands of chunks is a handful of rows, so deleting it is a handful of writes instead of thousands. Schema v2 folds existing chunk rows into blocks on startup.
2. **Atomic cutover.** `writer.close({ commit, discard })` (and `error(reason, { … })`) settles the stream, runs the caller's synchronous writes and deletes the stream's rows in one `transactionSync`. `Session.__DO_NOT_USE_WILL_BREAK__sync().upsert()` is the matching synchronous message write; it returns a `notify()` to dispatch the change feed after the commit.
3. **Hosts persist inside the cutover, and the sweep is gone.** When the producer finishes, `ResumableStream.finish()` leaves the row live; the host's final persist then runs `cutover()`: message write, settlement and row deletion in one transaction (`persistMessages { _cutover }` in AIChatAgent, `_persistAssistantMessageWithCutover` in Think). A turn with nothing to persist is settled by `finalizePending()`. `start()` reclaims whatever a crash left behind: finished streams immediately, abandoned in-flight rows after an hour without a chunk. No cleanup alarm is armed any more; `cleanupStreamBuffers` and `STREAM_CLEANUP_DELAY_SECONDS` are removed from `agents/chat`, and the hosts' `_cleanupStreamBuffers` callback stays as a no-op so alarms persisted by earlier versions still resolve. Agent-tool child turns cut over without discarding (the parent tails their stored chunks after completion); those rows go at the next start.

## Why

Measured on a real DO (`src/tests/streams/sqlite-strategies-bench.test.ts`, kept in the PR): a 400-chunk chat turn packed 10 per write.

| Log shape | Write phase | Cutover / cleanup | Lifetime rows |
|---|---|---|---|
| Immutable packed rows (before) | 42 | 42 deleted by a sweep later | 84 |
| Reusable generational slots | 42 | 2 | 44 |
| **Mutable rollover blocks** | 42 | 3 | **45** |

Rollover was chosen over slots because it has no shared state: every row belongs to one stream, is addressed by its primary key, and dies with the stream. Slots need a pool that never shrinks (5.6 MB left behind at 20k chunks), an index that doubles the per-flush write, and a free list rebuilt on every restart.

## Crash matrix (`ctx.abort()` at each point; in-repo as `src/e2e-tests/stream-cutover-crash.test.ts` against `wrangler dev`, and reproduced on a deployed DO)

| Crash point | Restart finds |
|---|---|
| Before a block append commits | exact prefix (10 chunks), the uncommitted append absent |
| Immediately after it commits | exact prefix (11 chunks) |
| During rollover, before commit | block 0 only, cursor 1 |
| During rollover, after commit | blocks 0 and 1, cursor 2, contiguous |
| After session persist, before discard, with I/O between (the non-atomic path hosts use today) | message present once, stream `completed` with its exact prefix; the next `start()` reclaims it |
| After session persist, before discard, no I/O between | stream live with its prefix, no message (the runtime commits at I/O boundaries, so both rolled back together) |
| Inside the atomic cutover's `commit` | stream live with its prefix, no message |
| Right after the atomic cutover | message present once, stream gone |

Never neither, never both.

## Tests

- `src/tests/streams/cutover.test.ts`: cutover commits message + settle + discard together; a throwing `commit` rolls the settle back and the stream stays live; blocks roll over and replay across the boundary; `delete()` removes every block.
- Write-accounting probe pins block open, block append and block delete at 1 row each; the storage-ops bench pins the hot path unchanged and the inline reclaim at 2 rows per turn.
- agents streams/sessions/chat suites (107), agents chat unit project (545), ai-chat workers suite (637), Think stream/session/recovery suites (224), the ai-chat e2e stream-buffer test (a turn leaves no rows and arms no alarm) all green. Test workers that seeded the old chunk table now seed blocks; `getStreamChunkRowCount` reports appended segments from the block tail; the alarm-driven cleanup tests became reclaim tests.
- Real-R2 spike and the R2 backend (#2215) are superseded by this PR.
