### PR TITLE
fix(codemode): truncate structured results structurally and keep the call log out of model context

### DIFF
--- a/.changeset/browser-calls-projection.md
+++ b/.changeset/browser-calls-projection.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+`browser_execute` no longer sends the durable `calls` log to the model. The persisted tool part keeps it for UIs and audit, matching the Code Mode tool's own projection.

--- a/.changeset/compaction-structured-output.md
+++ b/.changeset/compaction-structured-output.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Compaction summaries now serialize structured tool outputs as JSON instead of `[object Object]`, matching how tool inputs were already rendered. Fixes #2138.

--- a/.changeset/structured-result-truncation.md
+++ b/.changeset/structured-result-truncation.md
@@ -6,6 +6,8 @@ Truncate structured results structurally instead of slicing their JSON.
 
 `truncateResult` (the default `transformResult` in Think's execute tool and the browser tools) and the `codeMcpServer` / `openApiMcpServer` response path used to pretty-print an oversized object and cut it at a character count, leaving the model with half a JSON document. Oversized values are now shrunk in place, largest values first: strings are clipped with a `--- TRUNCATED --- <n> chars` suffix, arrays keep their leading items and end with a `--- TRUNCATED --- <n> more items` element, and an object only loses entries (largest first, named in a `"--- TRUNCATED ---"` entry) when its values cannot share the budget. The output is always valid JSON of the original shape and small values pass through untouched.
 
-The Code Mode tool now carries a `toModelOutput` that projects `calls` out of what the model sees. The durable call log — every connector call's args and result — stays on the persisted tool part for UIs and audit, but no longer rides into the model's context uncapped alongside the transformed `result`.
+The Code Mode tool now carries a `toModelOutput` that projects `calls` out of what the model sees and bounds the sandbox `logs` the same way a result is bounded. The durable call log — every connector call's args and result — stays on the persisted tool part for UIs and audit, but no longer rides into the model's context uncapped alongside the transformed `result`. The projection never throws: a BigInt or cyclic value is rendered rather than failing a completed run at model assembly.
+
+The MCP servers apply the response budget to the text they emit, pretty-printing only while that still fits.
 
 Fixes #2009, #2143 and #2182.

--- a/.changeset/structured-result-truncation.md
+++ b/.changeset/structured-result-truncation.md
@@ -1,0 +1,11 @@
+---
+"@cloudflare/codemode": patch
+---
+
+Truncate structured results structurally instead of slicing their JSON.
+
+`truncateResult` (the default `transformResult` in Think's execute tool and the browser tools) and the `codeMcpServer` / `openApiMcpServer` response path used to pretty-print an oversized object and cut it at a character count, leaving the model with half a JSON document. Oversized values are now shrunk in place, largest values first: strings are clipped with a `--- TRUNCATED --- <n> chars` suffix, arrays keep their leading items and end with a `--- TRUNCATED --- <n> more items` element, and an object only loses entries (largest first, named in a `"--- TRUNCATED ---"` entry) when its values cannot share the budget. The output is always valid JSON of the original shape and small values pass through untouched.
+
+The Code Mode tool now carries a `toModelOutput` that projects `calls` out of what the model sees. The durable call log — every connector call's args and result — stays on the persisted tool part for UIs and audit, but no longer rides into the model's context uncapped alongside the transformed `result`.
+
+Fixes #2009, #2143 and #2182.

--- a/docs/codemode/runtime.md
+++ b/docs/codemode/runtime.md
@@ -234,7 +234,7 @@ const runtime = createCodemodeRuntime({
 
 `truncateResult(value, options?)` returns the value unchanged when its serialized size is within budget. When it isn't, the value is shrunk structurally — largest values first — so the model still receives valid JSON of the original shape: a clipped string ends with `--- TRUNCATED --- <n> chars`, a clipped array ends with a `--- TRUNCATED --- <n> more items` element, and an object that had to lose entries gains a `"--- TRUNCATED ---"` entry naming the omitted keys. `truncateResponse(text, options?)` is the string-only variant. Both take `{ maxChars?, maxTokens? }` (default ~6000 tokens).
 
-The tool's `toModelOutput` sends the model everything but `calls`: the durable call log (every connector call's args and result) stays on the persisted tool part for UIs and audit, and is never part of the model's context.
+The tool's `toModelOutput` sends the model everything but `calls`, with `logs` bounded the same way: the durable call log (every connector call's args and result) stays on the persisted tool part for UIs and audit, and is never part of the model's context.
 
 `transformResult` shapes only the final returned value — individual connector results inside the run are unaffected, so the model's own code still sees full data to reason over.
 

--- a/docs/codemode/runtime.md
+++ b/docs/codemode/runtime.md
@@ -232,7 +232,9 @@ const runtime = createCodemodeRuntime({
 });
 ```
 
-`truncateResult(value, options?)` returns the value unchanged when its serialized size is within budget, and a truncated string (with a marker noting the original size) when it isn't. `truncateResponse(text, options?)` is the string-only variant. Both take `{ maxChars?, maxTokens? }` (default ~6000 tokens).
+`truncateResult(value, options?)` returns the value unchanged when its serialized size is within budget. When it isn't, the value is shrunk structurally — largest values first — so the model still receives valid JSON of the original shape: a clipped string ends with `--- TRUNCATED --- <n> chars`, a clipped array ends with a `--- TRUNCATED --- <n> more items` element, and an object that had to lose entries gains a `"--- TRUNCATED ---"` entry naming the omitted keys. `truncateResponse(text, options?)` is the string-only variant. Both take `{ maxChars?, maxTokens? }` (default ~6000 tokens).
+
+The tool's `toModelOutput` sends the model everything but `calls`: the durable call log (every connector call's args and result) stays on the persisted tool part for UIs and audit, and is never part of the model's context.
 
 `transformResult` shapes only the final returned value — individual connector results inside the run are unaffected, so the model's own code still sees full data to reason over.
 

--- a/packages/agents/src/browser/ai.ts
+++ b/packages/agents/src/browser/ai.ts
@@ -281,10 +281,16 @@ function browserExecuteModelOutput(
   }
 
   // `calls` is the durable audit log; like the codemode tool's own projection,
-  // it stays on the persisted part and never enters the model's context.
+  // it stays on the persisted part and never enters the model's context, and
+  // the sandbox `logs` are bounded like a result.
   const modelFacing =
     typeof output === "object" && output !== null && !Array.isArray(output)
-      ? (({ calls: _calls, ...rest }: { calls?: unknown }) => rest)(output)
+      ? (({ calls: _calls, ...rest }: { calls?: unknown; logs?: unknown }) => ({
+          ...rest,
+          ...(Array.isArray(rest.logs)
+            ? { logs: truncateResult(rest.logs) }
+            : {})
+        }))(output)
       : output;
   const redacted = redactBase64Payloads(modelFacing);
   try {

--- a/packages/agents/src/browser/ai.ts
+++ b/packages/agents/src/browser/ai.ts
@@ -280,7 +280,13 @@ function browserExecuteModelOutput(
     };
   }
 
-  const redacted = redactBase64Payloads(output);
+  // `calls` is the durable audit log; like the codemode tool's own projection,
+  // it stays on the persisted part and never enters the model's context.
+  const modelFacing =
+    typeof output === "object" && output !== null && !Array.isArray(output)
+      ? (({ calls: _calls, ...rest }: { calls?: unknown }) => rest)(output)
+      : output;
+  const redacted = redactBase64Payloads(modelFacing);
   try {
     const serialized = JSON.stringify(redacted);
     return {

--- a/packages/agents/src/browser/tanstack-ai.ts
+++ b/packages/agents/src/browser/tanstack-ai.ts
@@ -68,8 +68,9 @@ export function createBrowserTools(
     } as never)) as ProxyToolOutput;
     // TanStack has a single return channel, so what the host sees is what the
     // model sees: apply the AI SDK path's `toModelOutput` projection so a
-    // screenshot's base64 cannot reach the model. The execution envelope
-    // (status, executionId, calls) is preserved either way.
+    // screenshot's base64 cannot reach the model and the durable `calls` log
+    // stays out of its context. The execution envelope (status, executionId)
+    // is preserved either way.
     const modelOutput = await executeTool.toModelOutput?.({
       toolCallId: crypto.randomUUID(),
       input: { code },

--- a/packages/agents/src/sessions/compaction-helpers.ts
+++ b/packages/agents/src/sessions/compaction-helpers.ts
@@ -204,7 +204,7 @@ export function buildSummaryPrompt(
           if (tp.input)
             parts.push(`Input: ${JSON.stringify(tp.input).slice(0, 500)}`);
           if (tp.output)
-            parts.push(`Output: ${String(tp.output).slice(0, 500)}`);
+            parts.push(`Output: ${JSON.stringify(tp.output).slice(0, 500)}`);
           return parts.join("\n");
         })
         .join("\n");

--- a/packages/agents/src/tests/browser-connector.test.ts
+++ b/packages/agents/src/tests/browser-connector.test.ts
@@ -270,6 +270,15 @@ describe("browser_execute model output", () => {
     expect(serialized).not.toContain(image);
     // The durable call log is audit data for the UI, not model context.
     expect(serialized).not.toContain("calls");
+
+    const noisy = (await tool.toModelOutput({
+      output: {
+        status: "completed",
+        result: "ok",
+        logs: Array.from({ length: 5_000 }, (_, i) => `line ${i}`)
+      }
+    })) as { value: { logs: unknown[] } };
+    expect(JSON.stringify(noisy.value.logs).length).toBeLessThanOrEqual(24_000);
     expect(output.result.captures[0]).toHaveProperty("data", "AAAA");
     expect(output.calls[0].result.data).toBe(image);
   });

--- a/packages/agents/src/tests/browser-connector.test.ts
+++ b/packages/agents/src/tests/browser-connector.test.ts
@@ -256,7 +256,8 @@ describe("browser_execute model output", () => {
             data: "AAAA"
           },
           `data:image/jpeg;base64,${image}`
-        ]
+        ],
+        raw: { data: image }
       },
       calls: [{ result: { data: image } }]
     };
@@ -267,6 +268,8 @@ describe("browser_execute model output", () => {
     expect(serialized).toContain("base64 image/jpeg data omitted");
     expect(serialized).toContain("base64 data omitted");
     expect(serialized).not.toContain(image);
+    // The durable call log is audit data for the UI, not model context.
+    expect(serialized).not.toContain("calls");
     expect(output.result.captures[0]).toHaveProperty("data", "AAAA");
     expect(output.calls[0].result.data).toBe(image);
   });

--- a/packages/agents/src/tests/sessions/compaction-utils.test.ts
+++ b/packages/agents/src/tests/sessions/compaction-utils.test.ts
@@ -6,6 +6,7 @@ import {
   ROW_MAX_BYTES
 } from "../../chat/sanitize";
 import { createCompactFunction, type SessionMessage } from "../../sessions";
+import { buildSummaryPrompt } from "../../sessions/compaction-helpers";
 import {
   COMPACTION_PREFIX,
   isCompactionMessage
@@ -156,5 +157,32 @@ describe("enforceRowSizeLimit", () => {
     );
     expect(output.__truncated).toBe(true);
     expect(output.__truncatedChars).toBeGreaterThan(ROW_MAX_BYTES);
+  });
+});
+
+describe("buildSummaryPrompt", () => {
+  it("renders structured tool outputs as JSON", () => {
+    const prompt = buildSummaryPrompt(
+      [
+        {
+          id: "m1",
+          role: "assistant",
+          parts: [
+            {
+              type: "tool-lookup",
+              toolCallId: "tc-1",
+              toolName: "lookup",
+              state: "output-available",
+              input: { id: 7 },
+              output: { customer: "ACME", amount: 1200 }
+            } as UIMessage["parts"][number]
+          ]
+        }
+      ],
+      null,
+      10_000
+    );
+    expect(prompt).toContain('Output: {"customer":"ACME","amount":1200}');
+    expect(prompt).not.toContain("[object Object]");
   });
 });

--- a/packages/codemode/src/mcp.ts
+++ b/packages/codemode/src/mcp.ts
@@ -15,43 +15,22 @@ import {
 import { normalizeCode } from "./normalize";
 import { sanitizeToolName } from "./utils";
 import type { Executor } from "./executor";
+import { truncateResult } from "./truncate";
 
 import type { JSONSchema7 } from "json-schema";
 
 // -- Shared utilities --
 
-const CHARS_PER_TOKEN = 4;
-const MAX_TOKENS = 6000;
-const MAX_CHARS = MAX_TOKENS * CHARS_PER_TOKEN;
-const TRUNCATION_MARKER = "--- TRUNCATED ---";
-const TRUNCATION_FOOTER_PREFIX = `\n\n${TRUNCATION_MARKER}\nResponse was ~`;
-const MAX_SANDBOX_TRUNCATED_CHARS = MAX_CHARS + 512;
-
-function truncateResponse(content: unknown): string {
-  const text =
-    typeof content === "string"
-      ? content
-      : (JSON.stringify(content, null, 2) ?? "undefined");
-
-  if (text.length <= MAX_CHARS) {
-    return text;
-  }
-
-  const truncated = text.slice(0, MAX_CHARS);
-  const estimatedTokens = Math.ceil(text.length / CHARS_PER_TOKEN);
-
-  return `${truncated}\n\n${TRUNCATION_MARKER}\nResponse was ~${estimatedTokens.toLocaleString()} tokens (limit: ${MAX_TOKENS.toLocaleString()}). Use more specific queries to reduce response size.`;
-}
-
-function sandboxResponseText(content: unknown): string {
-  if (
-    typeof content === "string" &&
-    content.length <= MAX_SANDBOX_TRUNCATED_CHARS &&
-    content.slice(MAX_CHARS).startsWith(TRUNCATION_FOOTER_PREFIX)
-  ) {
-    return content;
-  }
-  return truncateResponse(content);
+/**
+ * Model-facing text for a sandbox or executor result. Strings are clipped to
+ * the token budget; structured values are truncated structurally (largest
+ * values first) so the text stays valid JSON, then pretty-printed.
+ */
+function responseText(content: unknown): string {
+  const shaped = truncateResult(content);
+  return typeof shaped === "string"
+    ? shaped
+    : (JSON.stringify(shaped, null, 2) ?? "undefined");
 }
 
 function formatError(error: unknown): string {
@@ -231,7 +210,7 @@ export async function codeMcpServer(
         }
         return {
           content: [
-            { type: "text" as const, text: truncateResponse(result.result) }
+            { type: "text" as const, text: responseText(result.result) }
           ]
         };
       } catch (error) {
@@ -417,17 +396,10 @@ const __resolveRefs = (obj, root, seen = new Set()) => {
   return result;
 };
 let __resolvedSpec;
-const __truncateResponse = (content) => {
-  const text = typeof content === "string" ? content : (JSON.stringify(content, null, 2) ?? "undefined");
-  if (text.length <= ${MAX_CHARS}) return text;
-  const truncated = text.slice(0, ${MAX_CHARS});
-  const estimatedTokens = Math.ceil(text.length / ${CHARS_PER_TOKEN});
-  return truncated + "\\n\\n${TRUNCATION_MARKER}\\nResponse was ~" + estimatedTokens.toLocaleString() + " tokens (limit: ${MAX_TOKENS.toLocaleString()}). Use more specific queries to reduce response size.";
-};
 const codemode = {
   spec: async () => (__resolvedSpec ??= __resolveRefs(__rawSpec, __rawSpec))${requestFn ? `,\n  ${requestFn}` : ""}
 };
-return __truncateResponse(await (${normalized})());
+return await (${normalized})();
 }`;
 }
 
@@ -508,7 +480,7 @@ async () => {
         }
         return {
           content: [
-            { type: "text" as const, text: sandboxResponseText(result.result) }
+            { type: "text" as const, text: responseText(result.result) }
           ]
         };
       } catch (error) {
@@ -567,7 +539,7 @@ async () => {
         }
         return {
           content: [
-            { type: "text" as const, text: sandboxResponseText(result.result) }
+            { type: "text" as const, text: responseText(result.result) }
           ]
         };
       } catch (error) {

--- a/packages/codemode/src/mcp.ts
+++ b/packages/codemode/src/mcp.ts
@@ -21,16 +21,22 @@ import type { JSONSchema7 } from "json-schema";
 
 // -- Shared utilities --
 
+/** Character budget for a tool response (~6,000 tokens). */
+const MAX_RESPONSE_CHARS = 24_000;
+
 /**
  * Model-facing text for a sandbox or executor result. Strings are clipped to
- * the token budget; structured values are truncated structurally (largest
- * values first) so the text stays valid JSON, then pretty-printed.
+ * the budget; structured values are truncated structurally (largest values
+ * first) so the text stays valid JSON. The budget applies to the emitted text:
+ * pretty-printed when that still fits, compact otherwise.
  */
 function responseText(content: unknown): string {
-  const shaped = truncateResult(content);
-  return typeof shaped === "string"
-    ? shaped
-    : (JSON.stringify(shaped, null, 2) ?? "undefined");
+  const shaped = truncateResult(content, { maxChars: MAX_RESPONSE_CHARS });
+  if (typeof shaped === "string") return shaped;
+  const pretty = JSON.stringify(shaped, null, 2) ?? "undefined";
+  return pretty.length <= MAX_RESPONSE_CHARS
+    ? pretty
+    : (JSON.stringify(shaped) ?? "undefined");
 }
 
 function formatError(error: unknown): string {

--- a/packages/codemode/src/proxy-tool.ts
+++ b/packages/codemode/src/proxy-tool.ts
@@ -21,6 +21,7 @@
 import { RpcTarget } from "cloudflare:workers";
 import type { Executor, ResolvedProvider, ConnectorBinding } from "./executor";
 import { runCode } from "./run-code";
+import { truncateResult } from "./truncate";
 import { normalizeCode } from "./normalize";
 import type { CodemodeConnector, ConnectorDescription } from "./connectors";
 import type {
@@ -774,7 +775,12 @@ type JSONValue =
   | JSONValue[]
   | { [key: string]: JSONValue };
 
-/** Drop the audit-only `calls` log from a tool output bound for the model. */
+/**
+ * Project a tool output for the model: drop the audit-only `calls` log and
+ * bound the sandbox `logs` the same way `truncateResult` bounds a result.
+ * Never throws — a completed run must not fail at model assembly because its
+ * value carried a BigInt or a cycle.
+ */
 function toModelOutput(output: unknown): {
   type: "json";
   value: JSONValue;
@@ -782,15 +788,29 @@ function toModelOutput(output: unknown): {
   if (typeof output !== "object" || output === null || Array.isArray(output)) {
     return { type: "json", value: toJSONValue(output) };
   }
-  const { calls: _calls, ...rest } = output as { calls?: unknown };
+  const { calls: _calls, ...rest } = output as {
+    calls?: unknown;
+    logs?: unknown;
+  };
+  if (Array.isArray(rest.logs)) rest.logs = truncateResult(rest.logs);
   return { type: "json", value: toJSONValue(rest) };
 }
 
 function toJSONValue(value: unknown): JSONValue {
-  const serialized = JSON.stringify(value);
-  return serialized === undefined
-    ? null
-    : (JSON.parse(serialized) as JSONValue);
+  try {
+    const serialized = JSON.stringify(value, (_key, v: unknown) =>
+      typeof v === "bigint" ? v.toString() : v
+    );
+    return serialized === undefined
+      ? null
+      : (JSON.parse(serialized) as JSONValue);
+  } catch (err) {
+    return {
+      error: `Result could not be serialized for the model: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    };
+  }
 }
 
 export function createProxyTool(options: CreateProxyToolOptions): CodemodeTool {

--- a/packages/codemode/src/proxy-tool.ts
+++ b/packages/codemode/src/proxy-tool.ts
@@ -752,7 +752,46 @@ export type CodemodeTool = {
     input: ProxyToolInput,
     options: unknown
   ) => Promise<ProxyToolOutput>;
+  /**
+   * The AI SDK model-facing projection of the output: everything but `calls`.
+   * The full output (with the durable call log) stays on the persisted tool
+   * part for UIs; the model sees the transformed `result`, `logs`, `pending`
+   * or `error`. Without this the raw call log — every connector call's args
+   * and result — would ride along uncapped and defeat `transformResult`.
+   */
+  toModelOutput: (options: { output: unknown }) => {
+    type: "json";
+    value: JSONValue;
+  };
 };
+
+/** Structural twin of the AI SDK's `JSONValue`; the root entry must not import `ai`. */
+type JSONValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JSONValue[]
+  | { [key: string]: JSONValue };
+
+/** Drop the audit-only `calls` log from a tool output bound for the model. */
+function toModelOutput(output: unknown): {
+  type: "json";
+  value: JSONValue;
+} {
+  if (typeof output !== "object" || output === null || Array.isArray(output)) {
+    return { type: "json", value: toJSONValue(output) };
+  }
+  const { calls: _calls, ...rest } = output as { calls?: unknown };
+  return { type: "json", value: toJSONValue(rest) };
+}
+
+function toJSONValue(value: unknown): JSONValue {
+  const serialized = JSON.stringify(value);
+  return serialized === undefined
+    ? null
+    : (JSON.parse(serialized) as JSONValue);
+}
 
 export function createProxyTool(options: CreateProxyToolOptions): CodemodeTool {
   const connectors = options.connectors;
@@ -801,7 +840,8 @@ export function createProxyTool(options: CreateProxyToolOptions): CodemodeTool {
         options.executor,
         options.transformResult
       );
-    }
+    },
+    toModelOutput: ({ output }) => toModelOutput(output)
   };
 }
 

--- a/packages/codemode/src/tests/mcp.test.ts
+++ b/packages/codemode/src/tests/mcp.test.ts
@@ -874,6 +874,32 @@ describe("openApiMcpServer", () => {
     await client.close();
   });
 
+  it("search keeps the emitted text within budget when pretty-printing would not", async () => {
+    // Compact JSON fits the budget; the same value pretty-printed does not.
+    const executor = {
+      execute: async () => ({
+        result: Array.from({ length: 4_000 }, (_, i) => [i, i])
+      })
+    };
+    const server = openApiMcpServer({
+      spec: sampleSpec,
+      executor,
+      request: async () => ({})
+    });
+    const client = await connectClient(server);
+
+    const result = await client.callTool({
+      name: "search",
+      arguments: { code: "async () => 'ignored'" }
+    });
+
+    const text = callText(result);
+    expect(text.length).toBeLessThanOrEqual(24_000);
+    expect(Array.isArray(JSON.parse(text))).toBe(true);
+
+    await client.close();
+  });
+
   it("search should truncate oversized string results from custom executors on the host", async () => {
     const executor = {
       execute: async () => ({ result: "x".repeat(25000) })
@@ -899,7 +925,7 @@ describe("openApiMcpServer", () => {
     await client.close();
   });
 
-  it("search should not trust arbitrary truncation markers from custom executors", async () => {
+  it("search truncates on the host even when the payload leads with a marker", async () => {
     const executor = {
       execute: async () => ({
         result: "--- TRUNCATED ---\n" + "x".repeat(25000)

--- a/packages/codemode/src/tests/mcp.test.ts
+++ b/packages/codemode/src/tests/mcp.test.ts
@@ -841,6 +841,39 @@ describe("openApiMcpServer", () => {
     await client.close();
   });
 
+  it("search keeps oversized structured results as valid JSON", async () => {
+    const executor = {
+      execute: async () => ({
+        result: {
+          schema: "fixture_v1",
+          rows: [{ detail: "x".repeat(70_000) }]
+        }
+      })
+    };
+    const server = openApiMcpServer({
+      spec: sampleSpec,
+      executor,
+      request: async () => ({})
+    });
+    const client = await connectClient(server);
+
+    const result = await client.callTool({
+      name: "search",
+      arguments: { code: "async () => 'ignored'" }
+    });
+
+    const text = callText(result);
+    const parsed = JSON.parse(text) as {
+      schema: string;
+      rows: { detail: string }[];
+    };
+    expect(parsed.schema).toBe("fixture_v1");
+    expect(parsed.rows[0].detail).toContain("--- TRUNCATED --- 70,000 chars");
+    expect(text.length).toBeLessThan(70_000);
+
+    await client.close();
+  });
+
   it("search should truncate oversized string results from custom executors on the host", async () => {
     const executor = {
       execute: async () => ({ result: "x".repeat(25000) })

--- a/packages/codemode/src/tests/runtime-handle.test.ts
+++ b/packages/codemode/src/tests/runtime-handle.test.ts
@@ -103,6 +103,34 @@ describe("createCodemodeRuntime", () => {
     });
   });
 
+  it("projects the model-facing output without the durable call log", async () => {
+    const runtime = createCodemodeRuntime({
+      ctx: createMockCtx({}),
+      executor: createMockExecutor(),
+      connectors: []
+    });
+    const codemode = runtime.tool();
+
+    const output = {
+      status: "completed",
+      executionId: "exec_1",
+      result: { ok: true },
+      logs: ["hi"],
+      calls: [{ seq: 0, args: { big: "x".repeat(10_000) }, result: {} }]
+    };
+    expect(codemode.toModelOutput({ output })).toEqual({
+      type: "json",
+      value: {
+        status: "completed",
+        executionId: "exec_1",
+        result: { ok: true },
+        logs: ["hi"]
+      }
+    });
+    // The persisted output is untouched — UIs keep the audit trail.
+    expect(output.calls).toHaveLength(1);
+  });
+
   it("executes directly without an AI SDK adapter", async () => {
     const runtimeStub = {
       begin: vi.fn(async () => "exec_direct"),

--- a/packages/codemode/src/tests/runtime-handle.test.ts
+++ b/packages/codemode/src/tests/runtime-handle.test.ts
@@ -129,6 +129,25 @@ describe("createCodemodeRuntime", () => {
     });
     // The persisted output is untouched — UIs keep the audit trail.
     expect(output.calls).toHaveLength(1);
+
+    // Sandbox logs are bounded like a result; BigInt and cycles never throw.
+    const noisy = codemode.toModelOutput({
+      output: {
+        status: "completed",
+        executionId: "exec_2",
+        result: 10n,
+        logs: Array.from({ length: 5_000 }, (_, i) => `line ${i}`)
+      }
+    }).value as { result: unknown; logs: unknown[] };
+    expect(noisy.result).toBe("10");
+    expect(JSON.stringify(noisy.logs).length).toBeLessThanOrEqual(24_000);
+
+    const cyclic: Record<string, unknown> = {};
+    cyclic.self = cyclic;
+    const projected = codemode.toModelOutput({
+      output: { status: "completed", executionId: "exec_3", result: cyclic }
+    }).value as { error?: string };
+    expect(projected.error).toMatch(/could not be serialized/);
   });
 
   it("executes directly without an AI SDK adapter", async () => {

--- a/packages/codemode/src/tests/truncate.test.ts
+++ b/packages/codemode/src/tests/truncate.test.ts
@@ -34,11 +34,98 @@ describe("truncateResult", () => {
     expect(truncateResult(value, { maxChars: 1000 })).toBe(value);
   });
 
-  it("serializes and truncates oversized structured values to a string", () => {
+  it("keeps oversized structured values as valid JSON of the same shape", () => {
     const value = { items: Array.from({ length: 500 }, (_, i) => ({ i })) };
-    const out = truncateResult(value, { maxChars: 50 });
+    const out = truncateResult(value, { maxChars: 120 }) as {
+      items: unknown[];
+    };
+    expect(JSON.stringify(out).length).toBeLessThanOrEqual(120);
+    expect(Array.isArray(out.items)).toBe(true);
+    expect(out.items.at(-1)).toMatch(/^--- TRUNCATED --- \d+ more items$/);
+    expect(out.items.slice(0, -1)).toEqual(
+      value.items.slice(0, out.items.length - 1)
+    );
+  });
+
+  it("cuts the largest values first and leaves small siblings intact", () => {
+    const value = {
+      schema: "fixture_v1",
+      count: 3,
+      rows: [{ detail: "x".repeat(70_000) }, { detail: "small" }]
+    };
+    const out = truncateResult(value, { maxChars: 2_000 }) as typeof value;
+    expect(JSON.stringify(out).length).toBeLessThanOrEqual(2_000);
+    expect(out.schema).toBe("fixture_v1");
+    expect(out.count).toBe(3);
+    expect(out.rows).toHaveLength(2);
+    expect(out.rows[0].detail).toMatch(/^x+ --- TRUNCATED --- 70,000 chars$/);
+    expect(out.rows[1].detail).toBe("small");
+  });
+
+  it("drops object entries largest-first only when values cannot share the budget", () => {
+    const value = {
+      id: "abc",
+      blob: "b".repeat(5_000),
+      text: "t".repeat(5_000),
+      n: 1
+    };
+    // Room for the skeleton, both strings at a reasonable preview, and the id.
+    const roomy = truncateResult(value, { maxChars: 400 }) as Record<
+      string,
+      unknown
+    >;
+    expect(Object.keys(roomy).sort()).toEqual(["blob", "id", "n", "text"]);
+    expect(JSON.stringify(roomy).length).toBeLessThanOrEqual(400);
+
+    // Not enough room for both strings: the largest goes, the rest survive.
+    const tight = truncateResult(value, { maxChars: 110 }) as Record<
+      string,
+      unknown
+    >;
+    expect(JSON.stringify(tight).length).toBeLessThanOrEqual(110);
+    expect(tight.id).toBe("abc");
+    expect(tight.n).toBe(1);
+    expect(tight["--- TRUNCATED ---"]).toMatch(/keys omitted: /);
+  });
+
+  it("recurses so a nested log of calls keeps every call but bounds each result", () => {
+    const calls = Array.from({ length: 20 }, (_, i) => ({
+      seq: i,
+      method: "sql.query",
+      result: { rows: Array.from({ length: 50 }, (_, r) => ({ r, i })) }
+    }));
+    const out = truncateResult(calls, { maxChars: 3_000 }) as typeof calls;
+    expect(JSON.stringify(out).length).toBeLessThanOrEqual(3_000);
+    const kept = out.filter((c) => typeof c === "object");
+    expect(kept.length).toBeGreaterThan(5);
+    for (const call of kept) {
+      expect(call.method).toBe("sql.query");
+      expect(Array.isArray(call.result.rows)).toBe(true);
+    }
+  });
+
+  it("falls back to a clipped serialization when even the skeleton cannot fit", () => {
+    const out = truncateResult(
+      { a: [1, 2, 3], b: { c: "x" } },
+      { maxChars: 8 }
+    );
     expect(typeof out).toBe("string");
     expect(out as string).toContain("--- TRUNCATED ---");
+  });
+
+  it("sees values the way they serialize", () => {
+    const value = {
+      when: new Date(0),
+      gone: undefined,
+      big: "z".repeat(1_000)
+    };
+    const out = truncateResult(value, { maxChars: 200 }) as Record<
+      string,
+      unknown
+    >;
+    expect(out.when).toBe("1970-01-01T00:00:00.000Z");
+    expect("gone" in out).toBe(false);
+    expect(typeof out.big).toBe("string");
   });
 
   it("leaves non-serializable values unchanged", () => {

--- a/packages/codemode/src/tests/truncate.test.ts
+++ b/packages/codemode/src/tests/truncate.test.ts
@@ -173,6 +173,21 @@ describe("truncateResult", () => {
     expect(JSON.stringify(out).length).toBeLessThanOrEqual(100);
   });
 
+  it("bounds the omitted-key note and stays linear on wide objects", () => {
+    const wide: Record<string, string> = {};
+    for (let i = 0; i < 20_000; i++)
+      wide[`property_number_${i}`] = "v".repeat(40);
+    const started = performance.now();
+    const out = truncateResult(wide, { maxChars: 300 }) as Record<
+      string,
+      unknown
+    >;
+    expect(performance.now() - started).toBeLessThan(2_000);
+    expect(typeof out).toBe("object");
+    expect(JSON.stringify(out).length).toBeLessThanOrEqual(300);
+    expect(out["--- TRUNCATED ---"]).toContain("keys omitted");
+  });
+
   it("honours the budget for any structured input", () => {
     let seed = 42;
     const rnd = () =>

--- a/packages/codemode/src/tests/truncate.test.ts
+++ b/packages/codemode/src/tests/truncate.test.ts
@@ -104,13 +104,103 @@ describe("truncateResult", () => {
     }
   });
 
-  it("falls back to a clipped serialization when even the skeleton cannot fit", () => {
+  it("returns a bounded empty container when nothing can fit", () => {
     const out = truncateResult(
       { a: [1, 2, 3], b: { c: "x" } },
       { maxChars: 8 }
     );
-    expect(typeof out).toBe("string");
-    expect(out as string).toContain("--- TRUNCATED ---");
+    expect(out).toEqual({});
+  });
+
+  it("keeps a prefix that fits instead of dropping everything", () => {
+    // A large first element beside tiny siblings: all three survive, the big
+    // one carries the cut.
+    const rows = truncateResult(
+      [{ id: 1, note: "n".repeat(4000) }, { id: 2 }, { id: 3 }],
+      { maxChars: 80 }
+    ) as Record<string, unknown>[];
+    expect(JSON.stringify(rows).length).toBeLessThanOrEqual(80);
+    expect(rows.map((r) => r.id)).toEqual([1, 2, 3]);
+
+    const mixed = truncateResult(["x".repeat(1000), 5], {
+      maxChars: 60
+    }) as unknown[];
+    expect(JSON.stringify(mixed).length).toBeLessThanOrEqual(60);
+    expect(mixed[1]).toBe(5);
+    expect(mixed[0]).toContain("--- TRUNCATED ---");
+  });
+
+  it("keeps a long list of small records structural at the default budget", () => {
+    const rows = Array.from({ length: 450 }, (_, i) => ({
+      id: i,
+      name: `customer_${i}`,
+      email: `a${i}@example.com`,
+      status: "active"
+    }));
+    const out = truncateResult({ schema: "f", rows }) as {
+      schema: string;
+      rows: unknown[];
+    };
+    expect(typeof out).toBe("object");
+    expect(out.schema).toBe("f");
+    expect(JSON.stringify(out).length).toBeLessThanOrEqual(24_000);
+    expect(out.rows.length).toBeGreaterThan(100);
+    expect(out.rows.slice(0, -1)).toEqual(rows.slice(0, out.rows.length - 1));
+  });
+
+  it("never lets a nested marker overshoot its slot", () => {
+    const nested: Record<string, string> = {};
+    for (let i = 0; i < 6; i++) nested["k".repeat(60) + i] = "v".repeat(200);
+    const out = truncateResult(
+      { small: "ok", nested, pad: "p".repeat(5000) },
+      { maxChars: 400 }
+    ) as Record<string, unknown>;
+    expect(typeof out).toBe("object");
+    expect(out.small).toBe("ok");
+    expect(JSON.stringify(out).length).toBeLessThanOrEqual(400);
+  });
+
+  it("does not shadow a real key named like the marker", () => {
+    const out = truncateResult(
+      {
+        "--- TRUNCATED ---": "real",
+        big: "b".repeat(5000),
+        other: "o".repeat(5000)
+      },
+      { maxChars: 100 }
+    ) as Record<string, unknown>;
+    expect(out["--- TRUNCATED ---"]).toBe("real");
+    expect(JSON.stringify(out).length).toBeLessThanOrEqual(100);
+  });
+
+  it("honours the budget for any structured input", () => {
+    let seed = 42;
+    const rnd = () =>
+      (seed = (seed * 1664525 + 1013904223) % 4294967296) / 4294967296;
+    const gen = (depth: number): unknown => {
+      const t = rnd();
+      if (depth > 3 || t < 0.25) {
+        return t < 0.1
+          ? Math.floor(rnd() * 1e9)
+          : "s\u00e9".repeat(Math.floor(rnd() * 150));
+      }
+      if (t < 0.6) {
+        return Array.from({ length: Math.floor(rnd() * 12) }, () =>
+          gen(depth + 1)
+        );
+      }
+      const o: Record<string, unknown> = {};
+      for (let i = 0; i < rnd() * 8; i++) o[`k${i}`] = gen(depth + 1);
+      return o;
+    };
+    for (let i = 0; i < 2000; i++) {
+      const value = gen(0);
+      if (typeof value !== "object" || value === null) continue;
+      const maxChars = 16 + Math.floor(rnd() * 600);
+      const out = truncateResult(value, { maxChars });
+      expect(typeof out).toBe("object");
+      expect(JSON.stringify(out).length).toBeLessThanOrEqual(maxChars);
+    }
   });
 
   it("sees values the way they serialize", () => {

--- a/packages/codemode/src/truncate.ts
+++ b/packages/codemode/src/truncate.ts
@@ -20,10 +20,11 @@ const CHARS_PER_TOKEN = 4;
 const DEFAULT_MAX_TOKENS = 6000;
 const TRUNCATION_MARKER = "--- TRUNCATED ---";
 /**
- * Below this many serialized characters a value cannot carry a useful prefix
- * plus a marker, so it is dropped in favour of its siblings instead.
+ * The least a string or container is worth keeping at (see `floorSize`). A
+ * value that would get fewer serialized characters than this is dropped in
+ * favour of its siblings rather than reduced to a bare marker.
  */
-const MIN_SLOT = 48;
+const MIN_SLOT = 128;
 
 export type TruncateOptions = {
   /**
@@ -94,8 +95,8 @@ export function truncateResult(
   // Re-parse so `toJSON`, class instances and `undefined` members are seen in
   // their serialized form — the shape the model would receive anyway.
   const shrunk = shrink(JSON.parse(serialized) as Json, maxChars);
-  // A value whose skeleton alone exceeds the budget (e.g. a tiny budget) falls
-  // back to a clipped serialization so the cap still holds.
+  // `shrink` honours its budget for anything a container can hold; only a
+  // scalar (a number too long for the budget) can still miss it.
   return size(shrunk) <= maxChars
     ? shrunk
     : truncateResponse(serialized, options);
@@ -104,6 +105,14 @@ export function truncateResult(
 // ---------------------------------------------------------------------------
 // Structural shrinking
 // ---------------------------------------------------------------------------
+//
+// Every `shrink*` below returns a value whose compact serialization fits the
+// budget it was given, provided the budget can hold an empty container (2
+// chars). Containers share their budget by water-filling: each child is owed
+// at least its floor (`floorSize`), small children keep their full size, and
+// the largest children absorb the cut. A container only drops children when
+// even their floors cannot fit — arrays drop from the tail (order carries
+// meaning), objects drop their largest values first (keys are all meaningful).
 
 type Json = string | number | boolean | null | Json[] | { [key: string]: Json };
 
@@ -115,6 +124,18 @@ function size(value: Json): number {
 /** Only strings and containers can give up characters; scalars are atomic. */
 function shrinkable(value: Json): boolean {
   return typeof value === "string" || (typeof value === "object" && !!value);
+}
+
+/**
+ * The least budget a value is kept at; a scalar must fit whole. The floor
+ * never exceeds half the container's own budget, so tiny budgets still keep
+ * something rather than nothing.
+ */
+function floorSize(value: Json, maxChars: number): number {
+  const full = size(value);
+  return shrinkable(value)
+    ? Math.min(full, MIN_SLOT, Math.max(2, Math.floor(maxChars / 2)))
+    : full;
 }
 
 function shrink(value: Json, maxChars: number): Json {
@@ -133,30 +154,29 @@ function shrinkString(value: string, maxChars: number): string {
   let out = value.slice(0, keep) + suffix;
   // Escapes inflate the serialized form; back off until it fits.
   while (keep > 0 && size(out) > maxChars) {
-    keep = Math.floor(keep - (size(out) - maxChars) - 1);
-    out = value.slice(0, Math.max(0, keep)) + suffix;
+    keep = Math.max(0, keep - (size(out) - maxChars));
+    out = value.slice(0, keep) + suffix;
   }
-  return out;
+  // No room for a prefix and the size note: keep as much of the marker as fits.
+  return size(out) <= maxChars
+    ? out
+    : TRUNCATION_MARKER.slice(0, Math.max(0, maxChars - 2));
 }
 
 /**
- * Share `available` characters across values so small ones keep their full
- * size and the largest absorb the cut (water-filling). Returns `null` when
- * some value would be left with less than it can meaningfully use — a scalar
- * that does not fit, or a shrinkable value below {@link MIN_SLOT}.
+ * Share `available` characters across values by water-filling: values are
+ * admitted smallest first, each taking the lesser of its full size and an
+ * equal share of what is left. Requires `available >= Σ floorSize(values)`;
+ * then every value receives at least its floor.
  */
-function allocate(values: Json[], available: number): number[] | null {
+function allocate(values: Json[], available: number): number[] {
   const sizes = values.map(size);
   const order = sizes.map((_, i) => i).sort((a, b) => sizes[a] - sizes[b]);
   const allocation = new Array<number>(values.length);
   let remaining = available;
   let count = values.length;
   for (const i of order) {
-    const share = Math.floor(remaining / count);
-    const alloc = Math.min(sizes[i], share);
-    if (alloc < sizes[i] && (!shrinkable(values[i]) || alloc < MIN_SLOT)) {
-      return null;
-    }
+    const alloc = Math.min(sizes[i], Math.floor(remaining / count));
     allocation[i] = alloc;
     remaining -= alloc;
     count--;
@@ -164,41 +184,34 @@ function allocate(values: Json[], available: number): number[] | null {
   return allocation;
 }
 
-/** Largest `k` in `[0, max]` for which `feasible(k)` holds; feasibility is monotone. */
-function largestFeasible(
-  max: number,
-  feasible: (k: number) => boolean
-): number {
-  let lo = 0;
-  let hi = max;
-  while (lo < hi) {
-    const mid = Math.ceil((lo + hi) / 2);
-    if (feasible(mid)) lo = mid;
-    else hi = mid - 1;
-  }
-  return lo;
-}
-
 function shrinkArray(items: Json[], maxChars: number): Json[] {
   const marker = (dropped: number) =>
     `${TRUNCATION_MARKER} ${dropped.toLocaleString()} more items`;
+  const floors = items.map((item) => floorSize(item, maxChars));
+  const skeleton = (count: number) => 2 + Math.max(0, count - 1);
 
-  // Keep the longest prefix whose members can share the budget; the tail is
-  // dropped because item order usually carries meaning (rows, pages, steps).
-  const plan = (keep: number): number[] | null => {
-    const dropped = items.length - keep;
-    const tail = dropped > 0 ? size(marker(dropped)) + (keep > 0 ? 1 : 0) : 0;
-    const overhead = 2 + Math.max(0, keep - 1) + tail;
-    if (overhead > maxChars) return null;
-    return allocate(items.slice(0, keep), maxChars - overhead);
-  };
+  // Keep everything when every floor fits.
+  let keep = items.length;
+  if (floors.reduce((n, f) => n + f, 0) + skeleton(keep) > maxChars) {
+    // Otherwise keep the longest prefix whose floors fit beside a tail marker
+    // (sized for the largest possible count, so the real one always fits).
+    const tail = size(marker(items.length)) + 1;
+    let used = skeleton(0) + tail;
+    keep = 0;
+    while (keep < items.length && used + floors[keep] + 1 <= maxChars) {
+      used += floors[keep] + 1;
+      keep++;
+    }
+  }
 
-  const keep = largestFeasible(items.length, (k) => plan(k) !== null);
-  const allocation = plan(keep) ?? [];
-  const out = items
-    .slice(0, keep)
-    .map((item, i) => shrink(item, allocation[i]));
-  if (keep < items.length) out.push(marker(items.length - keep));
+  const kept = items.slice(0, keep);
+  const dropped = items.length - keep;
+  const tail = dropped > 0 ? size(marker(dropped)) + (keep > 0 ? 1 : 0) : 0;
+  const allocation = allocate(kept, maxChars - skeleton(keep) - tail);
+  const out = kept.map((item, i) => shrink(item, allocation[i]));
+  if (dropped > 0 && size([...out, marker(dropped)]) <= maxChars) {
+    out.push(marker(dropped));
+  }
   return out;
 }
 
@@ -207,52 +220,61 @@ function shrinkObject(
   maxChars: number
 ): { [key: string]: Json } {
   const entries = Object.entries(value);
-  const marker = (omitted: string[]) =>
-    `${omitted.length.toLocaleString()} keys omitted: ${omitted.join(", ")}`;
+  // The marker entry must not shadow a real key.
+  let markerKey = TRUNCATION_MARKER;
+  while (markerKey in value) markerKey += " ";
+  const marker = (omitted: string[]): [string, string] => [
+    markerKey,
+    `${omitted.length.toLocaleString()} keys omitted: ${omitted.join(", ")}`
+  ];
+  const entryCost = ([key, v]: [string, Json]) =>
+    size(key) + 1 + floorSize(v, maxChars);
+  const skeleton = (count: number) => 2 + Math.max(0, count - 1);
 
-  // Keys are all equally meaningful, so entries are dropped largest-first and
-  // only when sharing the budget across the remaining values is impossible.
+  // Drop the largest values first, only until the remaining floors fit.
   const byValueSize = entries
-    .map((entry, i) => ({ i, size: size(entry[1]) }))
-    .sort((a, b) => b.size - a.size)
-    .map((e) => e.i);
-
-  const plan = (
-    keep: number
-  ): { kept: [string, Json][]; omitted: string[]; alloc: number[] } | null => {
-    const omitted = byValueSize
-      .slice(0, entries.length - keep)
-      .sort((a, b) => a - b);
-    const drop = new Set(omitted);
-    const kept = entries.filter((_, i) => !drop.has(i));
-    const omittedKeys = omitted.map((i) => entries[i][0]);
-    const markerEntry: [string, Json][] =
-      omittedKeys.length > 0 ? [[TRUNCATION_MARKER, marker(omittedKeys)]] : [];
-    const all = [...kept, ...markerEntry];
-    const overhead =
-      2 +
-      Math.max(0, all.length - 1) +
-      all.reduce((n, [k]) => n + size(k) + 1, 0) +
-      markerEntry.reduce((n, [, v]) => n + size(v), 0);
-    if (overhead > maxChars) return null;
-    const alloc = allocate(
-      kept.map(([, v]) => v),
-      maxChars - overhead
-    );
-    return alloc ? { kept, omitted: omittedKeys, alloc } : null;
+    .map((_, i) => i)
+    .sort((a, b) => size(entries[b][1]) - size(entries[a][1]));
+  const dropped = new Set<number>();
+  const fits = () => {
+    const kept = entries.filter((_, i) => !dropped.has(i));
+    const omitted = [...dropped]
+      .sort((a, b) => a - b)
+      .map((i) => entries[i][0]);
+    const extra = omitted.length > 0 ? [marker(omitted)] : [];
+    const cost =
+      kept.reduce((n, e) => n + entryCost(e), 0) +
+      extra.reduce((n, e) => n + entryCost(e), 0) +
+      skeleton(kept.length + extra.length);
+    return cost <= maxChars;
   };
+  for (const i of byValueSize) {
+    if (fits()) break;
+    dropped.add(i);
+  }
 
-  const keep = largestFeasible(entries.length, (k) => plan(k) !== null);
-  const chosen = plan(keep);
-  if (!chosen) {
-    return { [TRUNCATION_MARKER]: marker(entries.map(([k]) => k)) };
-  }
+  const kept = entries.filter((_, i) => !dropped.has(i));
+  const omitted = [...dropped].sort((a, b) => a - b).map((i) => entries[i][0]);
   const out: { [key: string]: Json } = {};
-  chosen.kept.forEach(([k, v], i) => {
-    out[k] = shrink(v, chosen.alloc[i]);
-  });
-  if (chosen.omitted.length > 0) {
-    out[TRUNCATION_MARKER] = marker(chosen.omitted);
+  if (kept.length === 0) {
+    // Nothing survives: the marker alone, clipped to whatever room there is.
+    const [key, note] = marker(omitted);
+    const room = maxChars - skeleton(1) - size(key) - 1;
+    if (room >= 2) out[key] = shrink(note, room);
+    return out;
   }
+  const extra = omitted.length > 0 ? [marker(omitted)] : [];
+  const fixed =
+    [...kept, ...extra].reduce((n, [k]) => n + size(k) + 1, 0) +
+    extra.reduce((n, [, note]) => n + size(note), 0) +
+    skeleton(kept.length + extra.length);
+  const allocation = allocate(
+    kept.map(([, v]) => v),
+    maxChars - fixed
+  );
+  kept.forEach(([k, v], i) => {
+    out[k] = shrink(v, allocation[i]);
+  });
+  for (const [k, note] of extra) out[k] = note;
   return out;
 }

--- a/packages/codemode/src/truncate.ts
+++ b/packages/codemode/src/truncate.ts
@@ -223,58 +223,60 @@ function shrinkObject(
   // The marker entry must not shadow a real key.
   let markerKey = TRUNCATION_MARKER;
   while (markerKey in value) markerKey += " ";
-  const marker = (omitted: string[]): [string, string] => [
-    markerKey,
-    `${omitted.length.toLocaleString()} keys omitted: ${omitted.join(", ")}`
-  ];
-  const entryCost = ([key, v]: [string, Json]) =>
-    size(key) + 1 + floorSize(v, maxChars);
-  const skeleton = (count: number) => 2 + Math.max(0, count - 1);
+  const keyCost = (key: string) => size(key) + 1;
+  const floors = entries.map(([k, v]) => keyCost(k) + floorSize(v, maxChars));
+  const floorOf = (chars: number) =>
+    Math.min(chars, MIN_SLOT, Math.max(2, Math.floor(maxChars / 2)));
 
-  // Drop the largest values first, only until the remaining floors fit.
+  // Drop the largest values first, only until the remaining floors fit. Costs
+  // are tracked incrementally so a wide object stays linear in its key count;
+  // the marker note's cost is derived arithmetically from the omitted names.
   const byValueSize = entries
     .map((_, i) => i)
     .sort((a, b) => size(entries[b][1]) - size(entries[a][1]));
   const dropped = new Set<number>();
-  const fits = () => {
-    const kept = entries.filter((_, i) => !dropped.has(i));
-    const omitted = [...dropped]
-      .sort((a, b) => a - b)
-      .map((i) => entries[i][0]);
-    const extra = omitted.length > 0 ? [marker(omitted)] : [];
-    const cost =
-      kept.reduce((n, e) => n + entryCost(e), 0) +
-      extra.reduce((n, e) => n + entryCost(e), 0) +
-      skeleton(kept.length + extra.length);
-    return cost <= maxChars;
+  let present = entries.length;
+  let floorsSum = floors.reduce((n, f) => n + f, 0);
+  let namesLength = 0;
+  const noteLength = () =>
+    `${dropped.size.toLocaleString()} keys omitted: `.length +
+    namesLength +
+    2 * (dropped.size - 1);
+  const cost = () => {
+    const marker =
+      dropped.size > 0 ? keyCost(markerKey) + floorOf(noteLength() + 2) : 0;
+    const count = present + (dropped.size > 0 ? 1 : 0);
+    return 2 + Math.max(0, count - 1) + floorsSum + marker;
   };
   for (const i of byValueSize) {
-    if (fits()) break;
+    if (cost() <= maxChars) break;
     dropped.add(i);
+    present--;
+    floorsSum -= floors[i];
+    namesLength += size(entries[i][0]) - 2;
   }
 
   const kept = entries.filter((_, i) => !dropped.has(i));
   const omitted = [...dropped].sort((a, b) => a - b).map((i) => entries[i][0]);
-  const out: { [key: string]: Json } = {};
-  if (kept.length === 0) {
-    // Nothing survives: the marker alone, clipped to whatever room there is.
-    const [key, note] = marker(omitted);
-    const room = maxChars - skeleton(1) - size(key) - 1;
-    if (room >= 2) out[key] = shrink(note, room);
-    return out;
+  const note = `${omitted.length.toLocaleString()} keys omitted: ${omitted.join(", ")}`;
+  if (cost() > maxChars) {
+    // Not even the marker fits at its floor: keep as much of it as there is
+    // room for, or nothing.
+    const room = maxChars - 2 - keyCost(markerKey);
+    return room >= 2 ? { [markerKey]: shrink(note, room) } : {};
   }
-  const extra = omitted.length > 0 ? [marker(omitted)] : [];
+  const all: [string, Json][] = [...kept];
+  if (omitted.length > 0) all.push([markerKey, note]);
   const fixed =
-    [...kept, ...extra].reduce((n, [k]) => n + size(k) + 1, 0) +
-    extra.reduce((n, [, note]) => n + size(note), 0) +
-    skeleton(kept.length + extra.length);
+    2 + Math.max(0, all.length - 1) + all.reduce((n, [k]) => n + keyCost(k), 0);
+  // The note is shrunk like any other value, so it can never overshoot.
   const allocation = allocate(
-    kept.map(([, v]) => v),
+    all.map(([, v]) => v),
     maxChars - fixed
   );
-  kept.forEach(([k, v], i) => {
+  const out: { [key: string]: Json } = {};
+  all.forEach(([k, v], i) => {
     out[k] = shrink(v, allocation[i]);
   });
-  for (const [k, note] of extra) out[k] = note;
   return out;
 }

--- a/packages/codemode/src/truncate.ts
+++ b/packages/codemode/src/truncate.ts
@@ -6,12 +6,24 @@
  * structured results intact so the model can still reason over them. They are
  * the default building blocks for a `transformResult` hook (see
  * `createCodemodeRuntime`).
+ *
+ * Structured values are truncated structurally: the output is always valid
+ * JSON of the same shape, with the largest values cut first. A truncated
+ * string ends with a marker, a truncated array ends with a marker element
+ * counting the dropped items, and an object that had to lose entries carries a
+ * marker entry naming the omitted keys. Every marker contains
+ * `--- TRUNCATED ---` so callers and models can find them.
  */
 
 /** ~4 characters per token is a reasonable cross-model estimate. */
 const CHARS_PER_TOKEN = 4;
 const DEFAULT_MAX_TOKENS = 6000;
 const TRUNCATION_MARKER = "--- TRUNCATED ---";
+/**
+ * Below this many serialized characters a value cannot carry a useful prefix
+ * plus a marker, so it is dropped in favour of its siblings instead.
+ */
+const MIN_SLOT = 48;
 
 export type TruncateOptions = {
   /**
@@ -54,9 +66,10 @@ export function truncateResponse(
 
 /**
  * Truncate a structured result. Strings are truncated directly. Other values
- * pass through unchanged when their JSON serialization is within budget; when
- * oversized, the serialized form is truncated and returned as a string, so the
- * model still gets a usable, bounded preview rather than a dropped result.
+ * pass through unchanged (same reference) when their JSON serialization is
+ * within budget. When oversized, the value is shrunk structurally — largest
+ * values first, deepest last — so the model gets a bounded value that is still
+ * valid JSON of the original shape, with markers where content was cut.
  *
  * Values that can't be serialized (cycles, bigint, `undefined`) are returned
  * unchanged.
@@ -69,7 +82,7 @@ export function truncateResult(
 
   let serialized: string | undefined;
   try {
-    serialized = JSON.stringify(value, null, 2);
+    serialized = JSON.stringify(value);
   } catch {
     return value;
   }
@@ -77,5 +90,169 @@ export function truncateResult(
 
   const { maxChars } = budget(options);
   if (serialized.length <= maxChars) return value;
-  return truncateResponse(serialized, options);
+
+  // Re-parse so `toJSON`, class instances and `undefined` members are seen in
+  // their serialized form — the shape the model would receive anyway.
+  const shrunk = shrink(JSON.parse(serialized) as Json, maxChars);
+  // A value whose skeleton alone exceeds the budget (e.g. a tiny budget) falls
+  // back to a clipped serialization so the cap still holds.
+  return size(shrunk) <= maxChars
+    ? shrunk
+    : truncateResponse(serialized, options);
+}
+
+// ---------------------------------------------------------------------------
+// Structural shrinking
+// ---------------------------------------------------------------------------
+
+type Json = string | number | boolean | null | Json[] | { [key: string]: Json };
+
+/** Serialized size in characters (compact JSON). */
+function size(value: Json): number {
+  return JSON.stringify(value).length;
+}
+
+/** Only strings and containers can give up characters; scalars are atomic. */
+function shrinkable(value: Json): boolean {
+  return typeof value === "string" || (typeof value === "object" && !!value);
+}
+
+function shrink(value: Json, maxChars: number): Json {
+  if (size(value) <= maxChars) return value;
+  if (typeof value === "string") return shrinkString(value, maxChars);
+  if (Array.isArray(value)) return shrinkArray(value, maxChars);
+  if (typeof value === "object" && value !== null) {
+    return shrinkObject(value, maxChars);
+  }
+  return value;
+}
+
+function shrinkString(value: string, maxChars: number): string {
+  const suffix = ` ${TRUNCATION_MARKER} ${value.length.toLocaleString()} chars`;
+  let keep = Math.max(0, maxChars - suffix.length - 2);
+  let out = value.slice(0, keep) + suffix;
+  // Escapes inflate the serialized form; back off until it fits.
+  while (keep > 0 && size(out) > maxChars) {
+    keep = Math.floor(keep - (size(out) - maxChars) - 1);
+    out = value.slice(0, Math.max(0, keep)) + suffix;
+  }
+  return out;
+}
+
+/**
+ * Share `available` characters across values so small ones keep their full
+ * size and the largest absorb the cut (water-filling). Returns `null` when
+ * some value would be left with less than it can meaningfully use — a scalar
+ * that does not fit, or a shrinkable value below {@link MIN_SLOT}.
+ */
+function allocate(values: Json[], available: number): number[] | null {
+  const sizes = values.map(size);
+  const order = sizes.map((_, i) => i).sort((a, b) => sizes[a] - sizes[b]);
+  const allocation = new Array<number>(values.length);
+  let remaining = available;
+  let count = values.length;
+  for (const i of order) {
+    const share = Math.floor(remaining / count);
+    const alloc = Math.min(sizes[i], share);
+    if (alloc < sizes[i] && (!shrinkable(values[i]) || alloc < MIN_SLOT)) {
+      return null;
+    }
+    allocation[i] = alloc;
+    remaining -= alloc;
+    count--;
+  }
+  return allocation;
+}
+
+/** Largest `k` in `[0, max]` for which `feasible(k)` holds; feasibility is monotone. */
+function largestFeasible(
+  max: number,
+  feasible: (k: number) => boolean
+): number {
+  let lo = 0;
+  let hi = max;
+  while (lo < hi) {
+    const mid = Math.ceil((lo + hi) / 2);
+    if (feasible(mid)) lo = mid;
+    else hi = mid - 1;
+  }
+  return lo;
+}
+
+function shrinkArray(items: Json[], maxChars: number): Json[] {
+  const marker = (dropped: number) =>
+    `${TRUNCATION_MARKER} ${dropped.toLocaleString()} more items`;
+
+  // Keep the longest prefix whose members can share the budget; the tail is
+  // dropped because item order usually carries meaning (rows, pages, steps).
+  const plan = (keep: number): number[] | null => {
+    const dropped = items.length - keep;
+    const tail = dropped > 0 ? size(marker(dropped)) + (keep > 0 ? 1 : 0) : 0;
+    const overhead = 2 + Math.max(0, keep - 1) + tail;
+    if (overhead > maxChars) return null;
+    return allocate(items.slice(0, keep), maxChars - overhead);
+  };
+
+  const keep = largestFeasible(items.length, (k) => plan(k) !== null);
+  const allocation = plan(keep) ?? [];
+  const out = items
+    .slice(0, keep)
+    .map((item, i) => shrink(item, allocation[i]));
+  if (keep < items.length) out.push(marker(items.length - keep));
+  return out;
+}
+
+function shrinkObject(
+  value: { [key: string]: Json },
+  maxChars: number
+): { [key: string]: Json } {
+  const entries = Object.entries(value);
+  const marker = (omitted: string[]) =>
+    `${omitted.length.toLocaleString()} keys omitted: ${omitted.join(", ")}`;
+
+  // Keys are all equally meaningful, so entries are dropped largest-first and
+  // only when sharing the budget across the remaining values is impossible.
+  const byValueSize = entries
+    .map((entry, i) => ({ i, size: size(entry[1]) }))
+    .sort((a, b) => b.size - a.size)
+    .map((e) => e.i);
+
+  const plan = (
+    keep: number
+  ): { kept: [string, Json][]; omitted: string[]; alloc: number[] } | null => {
+    const omitted = byValueSize
+      .slice(0, entries.length - keep)
+      .sort((a, b) => a - b);
+    const drop = new Set(omitted);
+    const kept = entries.filter((_, i) => !drop.has(i));
+    const omittedKeys = omitted.map((i) => entries[i][0]);
+    const markerEntry: [string, Json][] =
+      omittedKeys.length > 0 ? [[TRUNCATION_MARKER, marker(omittedKeys)]] : [];
+    const all = [...kept, ...markerEntry];
+    const overhead =
+      2 +
+      Math.max(0, all.length - 1) +
+      all.reduce((n, [k]) => n + size(k) + 1, 0) +
+      markerEntry.reduce((n, [, v]) => n + size(v), 0);
+    if (overhead > maxChars) return null;
+    const alloc = allocate(
+      kept.map(([, v]) => v),
+      maxChars - overhead
+    );
+    return alloc ? { kept, omitted: omittedKeys, alloc } : null;
+  };
+
+  const keep = largestFeasible(entries.length, (k) => plan(k) !== null);
+  const chosen = plan(keep);
+  if (!chosen) {
+    return { [TRUNCATION_MARKER]: marker(entries.map(([k]) => k)) };
+  }
+  const out: { [key: string]: Json } = {};
+  chosen.kept.forEach(([k, v], i) => {
+    out[k] = shrink(v, chosen.alloc[i]);
+  });
+  if (chosen.omitted.length > 0) {
+    out[TRUNCATION_MARKER] = marker(chosen.omitted);
+  }
+  return out;
 }


### PR DESCRIPTION
Closes #2009, closes #2143, closes #2182, closes #2138. Supersedes #2041.

## What was wrong

Three open issues are the same bug from different angles: the model-facing cap on a Code Mode result cut serialized JSON at a character count.

- #2009: `codeMcpServer` / `openApiMcpServer` pretty-printed a structured result and sliced it at 24,000 characters, so the outer tool returned half a JSON document.
- #2143 / #2182: `runPass` applied `transformResult` (Think's default is `truncateResult`) to `result` only, then echoed the full durable `calls` log — every connector call's args and result — on the same tool output. Measured in production at 342 KB on one tool output and ~140k input tokens per request.
- #2138: compaction summaries rendered structured tool outputs as `[object Object]`.

#2041 proposed a new `transformResult` hook on `codeMcpServer` so applications could work around this. This PR fixes the truncation itself instead and adds no options.

## What changed

**`truncateResult` truncates structurally.** An oversized value is shrunk in place, largest values first, so the output is always valid JSON of the original shape:

- strings are clipped with a `--- TRUNCATED --- <n> chars` suffix
- arrays keep their leading items and end with a `--- TRUNCATED --- <n> more items` element
- an object only loses entries (largest first, named in a `"--- TRUNCATED ---"` entry) when its values cannot share the budget

Budget is shared by water-filling: every child is owed a floor, small siblings keep their full size, and the largest absorb the cut, recursively. Containers only drop children when the floors cannot fit, and every marker is clipped to the room left, so the output honours the budget by construction (a seeded fuzz over 2,000 random structures pins this). Small values still pass through untouched (same reference). The signature and the `{ maxChars?, maxTokens? }` options are unchanged.

**The MCP servers use it.** The sandbox-side string truncator in `openApiMcpServer` is gone; both servers shape the result on the host with `truncateResult`. The budget applies to the emitted text: pretty-printed while that fits, compact otherwise.

**The Code Mode tool carries a `toModelOutput` that drops `calls` and bounds `logs`.** The full output, call log included, stays on the persisted tool part for UIs and audit. The model sees `status`, `executionId`, the transformed `result`, bounded `logs`, `pending` or `error`. The projection never throws (BigInt rendered, cycles reported). Think passes tools to `convertToModelMessages` on replay, so it applies on every later turn too. `browser_execute` drops `calls` from its own projection for the same reason.

**Compaction** serializes tool outputs with `JSON.stringify`, matching inputs.

## Not in this PR

#2014 (Think's read-time `truncateOlderMessages` producing `__truncated` marker keys that fail strict output schemas) is a different mechanism in `agents/chat` that also backs row-size enforcement, and closing it without adding options means changing that module's marker policy. Left for its own change.

## Review round

A multi-agent review plus Devin found and confirmed five defects in the first cut, all fixed in the second commit: the array prefix search assumed a monotone predicate and could drop everything when the whole array fit; the object fallback marker was unbounded, so a list of ~400 small records fell back to the string slice this PR removes; the MCP text was measured compact but emitted pretty; `toModelOutput` threw on BigInt or cycles; the marker key could shadow a real property.

## Testing

- New unit tests: shape preserved under the cap, largest-first cutting, object entry dropping only under pressure, nested call-log shape, skeleton fallback, serialization-aware view.
- MCP test: a 70,000-character structured result parses as JSON with the marker inside the clipped string.
- Runtime handle test: `toModelOutput` drops `calls` and leaves the persisted output intact.
- `sherif`, `check:exports`, `oxfmt --check .`, `oxlint`, `typecheck`, codemode suite, Think execute suites, agents chat and sessions suites.
