### PR TITLE
perf(sessions,think): memoise the auto-compaction estimate and drop per-turn config re-reads

### DIFF
--- a/packages/agents/src/sessions/core.ts
+++ b/packages/agents/src/sessions/core.ts
@@ -63,6 +63,20 @@ type PathRow = { id: string; bytes: number };
 /** The newest row of a session: what an append attaches to and numbers from. */
 type Tail = { leafId: string | null; nextSeq: number };
 
+/**
+ * The memoised context-size estimate for a session's active path: the leaf it
+ * was computed for, the ids on that path whose own estimate counts (rows under
+ * a compaction overlay are replaced by the summary and do not), and the total.
+ * A tail append and an update of a counted row adjust it in place; every other
+ * write (branch append, delete, clear, compaction, import) drops it, and the
+ * next `tokenEstimate` re-derives it from one path walk.
+ */
+type PathTokens = {
+  leafId: string | null;
+  counted: Set<string>;
+  total: number;
+};
+
 export type UpdateOutcome = "missing" | "unchanged" | "updated";
 
 export class SessionsCore {
@@ -70,6 +84,7 @@ export class SessionsCore {
   readonly #reservedMetadataKeys: readonly string[];
   readonly #listeners = new Set<SessionChangeListener>();
   readonly #tails = new Map<string, Tail>();
+  readonly #pathTokens = new Map<string, PathTokens>();
   readonly #attachments: AttachmentStore;
   #tablesEnsured = false;
   /** True once the FTS index exists; it is built on the first `search()`. */
@@ -198,6 +213,7 @@ export class SessionsCore {
    * belongs to Think, which lifts and drops it itself.
    */
   migrateLegacy(): boolean {
+    this.#pathTokens.clear();
     let complete = true;
     const drop = (name: string): void => {
       if (this.#tableExists(name)) this.io.sqlWrite(`DROP TABLE ${name}`, []);
@@ -788,7 +804,13 @@ export class SessionsCore {
    * triggers only, and model-reported usage stays authoritative.
    */
   tokenEstimate(sessionId: string): number {
+    const leafId = this.latestLeafId(sessionId);
+    const memo = this.#pathTokens.get(sessionId);
+    if (memo && memo.leafId === leafId)
+      return Math.max(0, Math.ceil(memo.total));
+
     const stats = this.pathRowStats(sessionId);
+    const counted = new Set(stats.map((row) => row.id));
     let tokens = stats.reduce((sum, row) => sum + row.tokenEstimate, 0);
     for (const span of planOverlays(
       stats.map((row) => row.id),
@@ -796,9 +818,11 @@ export class SessionsCore {
     )) {
       for (let i = span.startIndex; i <= span.endIndex; i++) {
         tokens -= stats[i].tokenEstimate;
+        counted.delete(stats[i].id);
       }
       tokens += estimateStringTokens(span.compaction.summary);
     }
+    this.#pathTokens.set(sessionId, { leafId, counted, total: tokens });
     return Math.max(0, Math.ceil(tokens));
   }
 
@@ -877,8 +901,12 @@ export class SessionsCore {
     parentId: string | null | undefined,
     tokenEstimate: number
   ): { inserted: boolean; message: SessionMessage } {
-    const existing = this.getMessage(sessionId, message.id);
-    if (existing) return { inserted: false, message: existing };
+    // A repeated append is answered from storage; the common path (a fresh
+    // id) costs a key-only probe rather than a content read.
+    if (this.exists(sessionId, message.id)) {
+      const existing = this.getMessage(sessionId, message.id);
+      if (existing) return { inserted: false, message: existing };
+    }
 
     // `undefined` attaches to the tail and needs no validation read. A
     // caller-supplied id is untrusted and falls back to a root append when
@@ -929,6 +957,17 @@ export class SessionsCore {
     // The freshly inserted row is the most recent childless node, so it is
     // now the latest leaf — true even for an explicit-parent branch append.
     this.#tails.set(sessionId, { leafId: message.id, nextSeq: seq + 1 });
+    const memo = this.#pathTokens.get(sessionId);
+    if (memo) {
+      if (memo.leafId === parent) {
+        // The row extends the memoised path: count it, no re-walk.
+        memo.leafId = message.id;
+        memo.counted.add(message.id);
+        memo.total += tokenEstimate;
+      } else {
+        this.#pathTokens.delete(sessionId);
+      }
+    }
     this.io.emit("session:message:appended", {
       sessionId,
       messageId: message.id,
@@ -947,8 +986,12 @@ export class SessionsCore {
     message: SessionMessage,
     tokenEstimate: number
   ): UpdateOutcome {
-    const oldRows = this.io.sql<{ content: string; content_chunks: number }>(
-      "SELECT content, content_chunks FROM cf_agents_session_messages WHERE session_id = ? AND id = ?",
+    const oldRows = this.io.sql<{
+      content: string;
+      content_chunks: number;
+      token_estimate: number;
+    }>(
+      "SELECT content, content_chunks, token_estimate FROM cf_agents_session_messages WHERE session_id = ? AND id = ?",
       [sessionId, message.id]
     );
     if (oldRows.length === 0) return "missing";
@@ -1001,6 +1044,10 @@ export class SessionsCore {
       );
       this.#indexFts(sessionId, staged, true);
     });
+    const memo = this.#pathTokens.get(sessionId);
+    if (memo?.counted.has(message.id)) {
+      memo.total += tokenEstimate - (old.token_estimate ?? 0);
+    }
     this.io.emit("session:message:updated", {
       sessionId,
       messageId: message.id
@@ -1072,6 +1119,7 @@ export class SessionsCore {
     });
     // The leaf may be among the deleted rows; re-derive on the next append.
     this.#tails.delete(sessionId);
+    this.#pathTokens.delete(sessionId);
     this.io.emit("session:messages:deleted", {
       sessionId,
       count: uniqueIds.length
@@ -1101,6 +1149,7 @@ export class SessionsCore {
       }
     });
     this.#tails.set(sessionId, { leafId: null, nextSeq: 1 });
+    this.#pathTokens.delete(sessionId);
     this.io.emit("session:cleared", { sessionId });
   }
 
@@ -1125,6 +1174,8 @@ export class SessionsCore {
        VALUES (?, ?, ?, ?, ?, ?, ?)`,
       [sessionId, id, seq, summary, fromMessageId, toMessageId, now]
     );
+    // The new overlay changes which rows count; re-derive on the next read.
+    this.#pathTokens.delete(sessionId);
     this.io.emit("session:compacted", { sessionId, compactionId: id });
     return {
       id,
@@ -1259,6 +1310,7 @@ export class SessionsCore {
       leafId: message.id,
       nextSeq: tail.nextSeq + 1
     });
+    this.#pathTokens.delete(sessionId);
     return true;
   }
 

--- a/packages/agents/src/sessions/core.ts
+++ b/packages/agents/src/sessions/core.ts
@@ -75,6 +75,8 @@ type PathTokens = {
   leafId: string | null;
   counted: Set<string>;
   total: number;
+  /** Rows the walk returned: the memo is only extended while under the path cap. */
+  depth: number;
 };
 
 export type UpdateOutcome = "missing" | "unchanged" | "updated";
@@ -399,6 +401,17 @@ export class SessionsCore {
       : { leafId: null, nextSeq: 1 };
     this.#tails.set(sessionId, tail);
     return tail;
+  }
+
+  /**
+   * Drop the in-memory tail and token-total caches for a session. For a
+   * caller whose enclosing transaction rolled back after an append or update
+   * ran inside it: the rows are gone but the caches already moved. The next
+   * read re-derives both from storage.
+   */
+  forgetCaches(sessionId: string): void {
+    this.#tails.delete(sessionId);
+    this.#pathTokens.delete(sessionId);
   }
 
   latestLeafId(sessionId: string): string | null {
@@ -822,7 +835,12 @@ export class SessionsCore {
       }
       tokens += estimateStringTokens(span.compaction.summary);
     }
-    this.#pathTokens.set(sessionId, { leafId, counted, total: tokens });
+    this.#pathTokens.set(sessionId, {
+      leafId,
+      counted,
+      total: tokens,
+      depth: stats.length
+    });
     return Math.max(0, Math.ceil(tokens));
   }
 
@@ -959,12 +977,15 @@ export class SessionsCore {
     this.#tails.set(sessionId, { leafId: message.id, nextSeq: seq + 1 });
     const memo = this.#pathTokens.get(sessionId);
     if (memo) {
-      if (memo.leafId === parent) {
+      if (memo.leafId === parent && memo.depth <= MAX_PATH_DEPTH) {
         // The row extends the memoised path: count it, no re-walk.
         memo.leafId = message.id;
         memo.counted.add(message.id);
         memo.total += tokenEstimate;
+        memo.depth += 1;
       } else {
+        // A branch, or a path at the cap: the walk would drop its oldest
+        // row, which the memo cannot see. Re-derive on the next read.
         this.#pathTokens.delete(sessionId);
       }
     }

--- a/packages/agents/src/sessions/handle.ts
+++ b/packages/agents/src/sessions/handle.ts
@@ -249,16 +249,20 @@ export class Session {
    * caller owns startup ordering) and defers everything that follows a
    * write — the change-feed dispatch and auto-compaction: call the returned
    * `after()` once the transaction commits, or subscribers (the host's
-   * message mirror) never hear about the write. Will break without notice;
-   * never use from application code.
+   * message mirror) never hear about the write. If the transaction rolls
+   * back after an `upsert` ran inside it, call `abandon()`: the write is
+   * gone but the in-memory tail and token-total caches already moved.
+   * Will break without notice; never use from application code.
    */
   __DO_NOT_USE_WILL_BREAK__sync(): {
     upsert(
       message: SessionMessage,
       options?: AppendOptions
     ): { result: AppendResult; after: () => Promise<void> };
+    abandon(): void;
   } {
     return {
+      abandon: () => this.#core.forgetCaches(this.sessionId),
       upsert: (message, options = {}) => {
         const prepared = this.#prepare(message, options.source);
         if (!this.#core.exists(this.sessionId, message.id)) {

--- a/packages/agents/src/tests/capabilities/sessions.ts
+++ b/packages/agents/src/tests/capabilities/sessions.ts
@@ -79,6 +79,23 @@ export class SessionHarnessObject extends DurableObject<Cloudflare.Env> {
     });
   }
 
+  /**
+   * Append through the synchronous aperture inside a transaction that then
+   * throws, the way a stream cutover fails after its message write. The
+   * row rolls back; the aperture's `abandon()` drops the caches that moved.
+   */
+  appendThenRollback(message: SessionMessage): void {
+    const sync = this.sessions.session().__DO_NOT_USE_WILL_BREAK__sync();
+    try {
+      this.ctx.storage.transactionSync(() => {
+        sync.upsert(message);
+        throw new Error("cutover failed after the message write");
+      });
+    } catch {
+      sync.abandon();
+    }
+  }
+
   /** Telemetry events of one type, in dispatch order. */
   eventsOfType(type: string): RecordedEvent[] {
     return this.events.filter((event) => event.type === type);

--- a/packages/agents/src/tests/capabilities/sessions.ts
+++ b/packages/agents/src/tests/capabilities/sessions.ts
@@ -366,6 +366,33 @@ export class SessionBenchObject extends DurableObject<Cloudflare.Env> {
     return { rowsWritten: this.#billed.stop() };
   }
 
+  /**
+   * Rows read by tail appends on a session with an auto-compaction threshold
+   * the transcript never reaches. The threshold check runs after every
+   * insert; its cost must not grow with the transcript.
+   */
+  async benchThresholdAppends(
+    count: number,
+    textBytes: number
+  ): Promise<{ rowsRead: number }> {
+    await this.lifecycle.start();
+    const session = this.sessions.session();
+    session
+      .onCompaction(async () => null)
+      .compactAfter(Number.MAX_SAFE_INTEGER);
+    await session.getLatestLeaf();
+    const filler = "x".repeat(textBytes);
+    this.#billed.start();
+    for (let i = 0; i < count; i++) {
+      await session.appendMessage({
+        id: `bench-${i}`,
+        role: i % 2 === 0 ? "user" : "assistant",
+        parts: [{ type: "text", text: `${i}:${filler}` }]
+      });
+    }
+    return { rowsRead: this.#billed.stopAll().rowsRead };
+  }
+
   /** An update whose serialized row is byte-identical writes nothing. */
   async benchNoOpUpdate(
     id: string,

--- a/packages/agents/src/tests/sessions/capability.test.ts
+++ b/packages/agents/src/tests/sessions/capability.test.ts
@@ -332,6 +332,74 @@ describe("Sessions capability", () => {
     });
   });
 
+  it("forgets a rolled-back append's share of the estimate and the tail", async () => {
+    const stub = env.SessionHarnessObject.getByName(crypto.randomUUID());
+    await runInDurableObject(stub, async (instance: SessionHarnessObject) => {
+      const session = instance.sessions.session();
+      let compactions = 0;
+      session
+        .onCompaction(async (messages) => {
+          compactions++;
+          if (messages.length < 2) return null;
+          return {
+            fromMessageId: messages[0].id,
+            toMessageId: messages[messages.length - 2].id,
+            summary: "auto summary"
+          };
+        })
+        .compactAfter(100);
+
+      await session.appendMessage(text("r1", "short"));
+      expect(compactions).toBe(0);
+
+      // A large row is written inside a transaction that then rolls back.
+      // Its estimate and its place as the leaf must go with it.
+      instance.appendThenRollback(text("r2", "y".repeat(600), "assistant"));
+      expect(await session.getMessage("r2")).toBeNull();
+
+      await session.appendMessage(text("r3", "short", "assistant"));
+      expect(compactions).toBe(0);
+      expect((await session.getHistory()).map((m) => m.id)).toEqual([
+        "r1",
+        "r3"
+      ]);
+    });
+  });
+
+  it("re-derives the estimate once the path reaches the walk cap", async () => {
+    const stub = env.SessionHarnessObject.getByName(crypto.randomUUID());
+    await runInDurableObject(stub, async (instance: SessionHarnessObject) => {
+      const session = instance.sessions.session();
+      let parentId: string | null = null;
+      for (let i = 0; i < 10_000; i++) {
+        await session.importMessage(text(`cap-${i}`, "x"), {
+          parentId,
+          createdAt: i
+        });
+        parentId = `cap-${i}`;
+      }
+      // Every row estimates the same; the walk returns at most 10,001 rows,
+      // so once the path is that long the estimate stops growing.
+      const perRow = (await session.getHistoryRowStats())[0].tokenEstimate;
+      let compactions = 0;
+      session
+        .onCompaction(async () => {
+          compactions++;
+          return null;
+        })
+        .compactAfter(perRow * 10_001);
+
+      // Row 10,001 fills the window exactly: at the threshold, not over.
+      await session.appendMessage(text("cap-10000", "x"));
+      expect(compactions).toBe(0);
+      // Rows past the cap slide the window. A memo that kept adding would
+      // cross the threshold here; the re-derived estimate does not.
+      await session.appendMessage(text("cap-10001", "x"));
+      await session.appendMessage(text("cap-10002", "x"));
+      expect(compactions).toBe(0);
+    });
+  }, 120_000);
+
   it("streams history in bounded batches", async () => {
     const stub = env.SessionHarnessObject.getByName(crypto.randomUUID());
     await runInDurableObject(stub, async (instance: SessionHarnessObject) => {

--- a/packages/agents/src/tests/sessions/capability.test.ts
+++ b/packages/agents/src/tests/sessions/capability.test.ts
@@ -293,6 +293,45 @@ describe("Sessions capability", () => {
     });
   });
 
+  it("keeps the auto-compaction estimate current across updates and branches", async () => {
+    const stub = env.SessionHarnessObject.getByName(crypto.randomUUID());
+    await runInDurableObject(stub, async (instance: SessionHarnessObject) => {
+      const session = instance.sessions.session();
+      let compactions = 0;
+      session
+        .onCompaction(async (messages) => {
+          compactions++;
+          if (messages.length < 2) return null;
+          return {
+            fromMessageId: messages[0].id,
+            toMessageId: messages[messages.length - 2].id,
+            summary: "auto summary"
+          };
+        })
+        .compactAfter(100);
+
+      // Two small rows: the memoised total sits under the threshold.
+      await session.appendMessage(text("u1", "short"));
+      await session.appendMessage(text("u2", "short", "assistant"));
+      expect(compactions).toBe(0);
+
+      // An update that grows a counted row moves the total with it: the
+      // next append sees the transcript over the threshold.
+      await session.updateMessage(text("u2", "y".repeat(600), "assistant"));
+      await session.appendMessage(text("u3", "short"));
+      expect(compactions).toBe(1);
+
+      // A branch append leaves the grown row off the active path, so the
+      // total is re-derived for the new leaf rather than carried over.
+      await session.appendMessage(text("b1", "short", "assistant"), {
+        parentId: "u1"
+      });
+      expect(compactions).toBe(1);
+      await session.appendMessage(text("b2", "short"));
+      expect(compactions).toBe(1);
+    });
+  });
+
   it("streams history in bounded batches", async () => {
     const stub = env.SessionHarnessObject.getByName(crypto.randomUUID());
     await runInDurableObject(stub, async (instance: SessionHarnessObject) => {

--- a/packages/agents/src/tests/sessions/storage-ops-bench.test.ts
+++ b/packages/agents/src/tests/sessions/storage-ops-bench.test.ts
@@ -36,6 +36,17 @@ describe("Sessions storage-ops benchmark", () => {
     });
   });
 
+  it("checks the auto-compaction threshold without re-walking the path", async () => {
+    const stub = env.SessionBenchObject.getByName(crypto.randomUUID());
+    await runInDurableObject(stub, async (instance: SessionBenchObject) => {
+      // The first append derives the path total with one walk; every later
+      // tail append extends it in place. Without the memo each append pays a
+      // sized path walk, so 200 appends read O(200^2) rows.
+      const appends = await instance.benchThresholdAppends(200, 120);
+      expect(appends.rowsRead).toBeLessThan(200 * 6);
+    });
+  });
+
   it("adds an FTS delete and insert per changed row once the index exists", async () => {
     const stub = env.SessionSearchHarnessObject.getByName(crypto.randomUUID());
     await runInDurableObject(

--- a/packages/ai-chat/src/index.ts
+++ b/packages/ai-chat/src/index.ts
@@ -5794,14 +5794,21 @@ export class AIChatAgent<
       this.#pendingCutover = null;
       const sync = this.#session.__DO_NOT_USE_WILL_BREAK__sync();
       const afters: Array<() => Promise<void>> = [];
-      this._resumableStream.cutover(
-        cutover.streamId,
-        () => {
-          for (const message of toWrite)
-            afters.push(sync.upsert(message).after);
-        },
-        { discard: cutover.discard }
-      );
+      try {
+        this._resumableStream.cutover(
+          cutover.streamId,
+          () => {
+            for (const message of toWrite)
+              afters.push(sync.upsert(message).after);
+          },
+          { discard: cutover.discard }
+        );
+      } catch (error) {
+        // The settle transaction rolled back: no row landed, but the
+        // session's in-memory caches already counted the writes.
+        sync.abandon();
+        throw error;
+      }
       for (const after of afters) await after();
     } else {
       for (const message of toWrite) await this.#session.upsertMessage(message);

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -13630,16 +13630,23 @@ export class Think<
     }
     const sync = this.sessions.session().__DO_NOT_USE_WILL_BREAK__sync();
     let after: (() => Promise<void>) | undefined;
-    this._resumableStream.cutover(
-      streamId,
-      () => {
-        after = sync.upsert(toPersist as SessionMessage, {
-          parentId,
-          source: "server"
-        }).after;
-      },
-      { discard: options.discard ?? true }
-    );
+    try {
+      this._resumableStream.cutover(
+        streamId,
+        () => {
+          after = sync.upsert(toPersist as SessionMessage, {
+            parentId,
+            source: "server"
+          }).after;
+        },
+        { discard: options.discard ?? true }
+      );
+    } catch (error) {
+      // The settle transaction rolled back: the row never landed, but the
+      // session's in-memory caches already counted it.
+      sync.abandon();
+      throw error;
+    }
     await after?.();
   }
 

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -5403,10 +5403,12 @@ export class Think<
         }
       });
 
-      const previous = this._configGet("skillsFingerprint");
+      const previous = (this._skillsFingerprint ??=
+        this._configGet("skillsFingerprint") ?? null);
       if (previous !== registry.fingerprint) {
         await this.context.refreshSystemPrompt();
         this._configSet("skillsFingerprint", registry.fingerprint);
+        this._skillsFingerprint = registry.fingerprint;
       }
     } catch (error) {
       console.warn(
@@ -5477,6 +5479,12 @@ export class Think<
     return null;
   }
 
+  /**
+   * The persisted skills fingerprint, read from `think_config` once per
+   * object lifetime; `null` once read and absent. Saves the per-turn probe.
+   */
+  private _skillsFingerprint: string | null | undefined;
+
   private async _refreshSkillsIfChanged(): Promise<void> {
     if (!this._skillRegistry) return;
 
@@ -5486,10 +5494,12 @@ export class Think<
       await this._skillRegistry.refresh();
       this._logSkillWarnings(this._skillRegistry);
       await this._configureSkillWorkspace(this._skillRegistry);
-      const previous = this._configGet("skillsFingerprint");
+      const previous = (this._skillsFingerprint ??=
+        this._configGet("skillsFingerprint") ?? null);
       if (previous !== this._skillRegistry.fingerprint) {
         await this.context.refreshSystemPrompt();
         this._configSet("skillsFingerprint", this._skillRegistry.fingerprint);
+        this._skillsFingerprint = this._skillRegistry.fingerprint;
       }
     } catch (error) {
       console.warn(

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -13795,16 +13795,38 @@ export class Think<
     await this._upsertMessageInHistory(resolved, undefined, "client");
   }
 
-  private _persistClientTools(): void {
-    if (this._lastClientTools) {
-      this._configSet("lastClientTools", JSON.stringify(this._lastClientTools));
+  /**
+   * The serialized form last written to (or read from) `think_config` for a
+   * request-context key. Every chat request re-sends its client tools and
+   * body; comparing here turns the per-request write into a no-op when
+   * nothing changed. `undefined` means "not persisted" (row absent).
+   */
+  private _persistedRequestContext: {
+    lastClientTools?: string;
+    lastBody?: string;
+  } = {};
+
+  private _persistRequestContextKey(
+    key: "lastClientTools" | "lastBody",
+    value: unknown
+  ): void {
+    const json = value ? JSON.stringify(value) : undefined;
+    if (this._persistedRequestContext[key] === json) return;
+    if (json === undefined) {
+      this._configDelete(key);
     } else {
-      this._configDelete("lastClientTools");
+      this._configSet(key, json);
     }
+    this._persistedRequestContext[key] = json;
+  }
+
+  private _persistClientTools(): void {
+    this._persistRequestContextKey("lastClientTools", this._lastClientTools);
   }
 
   private _restoreClientTools(): void {
     const raw = this._configGet("lastClientTools");
+    this._persistedRequestContext.lastClientTools = raw;
     if (raw) {
       try {
         this._lastClientTools = JSON.parse(raw);
@@ -13815,15 +13837,12 @@ export class Think<
   }
 
   private _persistBody(): void {
-    if (this._lastBody) {
-      this._configSet("lastBody", JSON.stringify(this._lastBody));
-    } else {
-      this._configDelete("lastBody");
-    }
+    this._persistRequestContextKey("lastBody", this._lastBody);
   }
 
   private _restoreBody(): void {
     const raw = this._configGet("lastBody");
+    this._persistedRequestContext.lastBody = raw;
     if (raw) {
       try {
         this._lastBody = JSON.parse(raw);


### PR DESCRIPTION
## What

Follow-up to #2219, working down the per-turn storage ledger.

- **Sessions core memoises the active path's token total.** The auto-compaction threshold check (`#maybeAutoCompact`) ran the sized path CTE after every insert, so a turn's cost grew with the transcript. The core now keeps the total in memory: a tail append extends it, an update of a counted row shifts it by the delta, and any write that changes the path or its overlays (branch append, delete, clear, compaction, import, legacy migration) drops it so the next read re-derives it from one walk. Rows under a compaction overlay are excluded from the counted set, matching the existing estimate.
- **A fresh-id append probes existence by key** before reading the row's content, so the common path (every assistant persist and cutover) no longer reads content plus continuation chunks for an id that is not there.
- **Think skips the per-request `think_config` writes** for `lastClientTools` and `lastBody` when the serialized value is unchanged, and reads `skillsFingerprint` once per object instead of once per turn.

## Numbers

New bench `checks the auto-compaction threshold without re-walking the path`: 200 tail appends with a threshold set.

| | rows read |
|---|---|
| before | 120,800 |
| after | < 1,200 |

## Tests

- Sessions bench pins the rows-read bound; it fails on main.
- Capability test covers the memo across an update that grows a counted row (compaction then fires on the next append) and a branch append (total re-derived for the new leaf).
- Full Think suite and sessions suites green; typecheck, oxfmt, oxlint clean.
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/agents/pull/2226" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->