### PR TITLE
docs(mcp): clarify unsupported bus option and notification scope

### DIFF
--- a/docs/agents/mcp-servers.md
+++ b/docs/agents/mcp-servers.md
@@ -78,7 +78,11 @@ createMcpHandler(() => createServer(), {
 });
 ```
 
-All upstream SDK v2 handler options pass through. Use `createLegacyMcpHandler` for WorkerTransport, storage, session, and event-store options.
+`createMcpHandler` supports upstream SDK v2 handler options except `bus`, which is not exposed by the Agents SDK. Supplying `bus` throws a `TypeError`.
+
+To publish change events, use the returned handler's `notify` methods, such as `handler.notify.toolsChanged()`. Create the handler once at module scope and reuse it for requests and notifications. Notifications are isolate-local: they do not reach subscriptions in other Worker isolates. See the [handler notification API](https://developers.cloudflare.com/agents/model-context-protocol/apis/handler-api/#publish-list-and-resource-changes) for the available methods.
+
+Use `createLegacyMcpHandler` for SDK v1 WorkerTransport, storage, session, and event-store options. The SDK v2 `bus` option is not available on that handler either.
 
 The handler validates every present `Origin` header before serving the request. It rejects malformed, opaque, and non-HTTP origins. Requests without `Origin` remain valid for non-browser MCP clients.
 


### PR DESCRIPTION
## Summary

Fixes #2189.

Correct the MCP server guide based on the current handler implementation and supported API:

- Identify `bus` as the excluded SDK v2 option and document the `TypeError` when it is supplied.
- Point users to the returned handler's `notify` methods, including the requirement to reuse a handler instance and the isolate-local notification scope.
- Distinguish SDK v1 transport/session/event-store options from the unsupported SDK v2 `bus` option; the legacy handler is not an alternative for supplying it.

The options type explicitly omits `bus`, the runtime guard rejects it, and the returned handler exposes `notify`. This changes documentation only, not those intentional runtime boundaries. The linked official notification API already documents handler lifetime and isolate-local delivery.

No changeset.

## Validation

- `pnpm run build` — passed (20 projects).
- `pnpm run check` — passed, including all 119 TypeScript projects.
- `pnpm --filter agents exec vitest run --config src/tests/vitest.config.ts src/tests/mcp/handler-stateless.test.ts` — all 33 tests passed, including rejection of `bus` and the typed notification surface.
- `git diff --check` — passed.

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/agents/pull/2228" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->