### PR TITLE
fix(think): pass compacted messages to beforeStep

### DIFF
--- a/.changeset/tiny-trees-think.md
+++ b/.changeset/tiny-trees-think.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/think": patch
+---
+
+Pass proactively compacted messages to `beforeStep` so hooks that append context do not restore the original history. Explicit message overrides still take precedence.

--- a/packages/think/src/tests/agents/assistant-agent-loop.ts
+++ b/packages/think/src/tests/agents/assistant-agent-loop.ts
@@ -5,7 +5,7 @@
  * without needing a real LLM provider.
  */
 
-import type { LanguageModel, ToolSet, UIMessage } from "ai";
+import type { LanguageModel, ModelMessage, ToolSet, UIMessage } from "ai";
 import { tool } from "ai";
 import { z } from "zod";
 import type { Session } from "../../think";
@@ -19,6 +19,8 @@ import type {
   ToolCallDecision,
   ToolCallResultContext,
   StepContext,
+  PrepareStepContext,
+  StepConfig,
   TurnContext
 } from "../../think";
 
@@ -112,7 +114,9 @@ function createMockModel(): LanguageModel {
   } as LanguageModel;
 }
 
-function createMockToolModel(onCall?: () => void): LanguageModel {
+function createMockToolModel(
+  onCall?: (options: unknown) => void
+): LanguageModel {
   let toolCallCount = 0;
   return {
     specificationVersion: "v3",
@@ -123,7 +127,7 @@ function createMockToolModel(onCall?: () => void): LanguageModel {
       throw new Error("doGenerate not implemented in mock");
     },
     doStream(options: Record<string, unknown>) {
-      onCall?.();
+      onCall?.(options);
       toolCallCount++;
       const messages = (options as { prompt?: unknown[] }).prompt ?? [];
       const hasToolResult = messages.some(
@@ -432,6 +436,7 @@ function promptIncludesMarker(options: unknown): boolean {
  * actually substituted the recompacted head — not just that the turn finished.
  */
 function extractToolPairing(options: unknown): {
+  prompt: string;
   toolCalls: string[];
   toolResults: string[];
   hasSummary: boolean;
@@ -454,6 +459,7 @@ function extractToolPairing(options: unknown): {
   }
   const json = JSON.stringify(prompt);
   return {
+    prompt: json,
     toolCalls,
     toolResults,
     hasSummary: json.includes("compacted-summary"),
@@ -698,7 +704,9 @@ export class OverflowRecoveryTestAgent extends Think {
   modelCalls = 0;
   proactiveMode = false;
   proactiveMultiFire = false;
+  stepMessages?: "append" | ModelMessage[];
   compactionNoOp = false;
+  compactionThrows = false;
   alwaysOverflow = false;
   emitPartialBeforeOverflow = false;
   abortDuringRecovery = false;
@@ -712,6 +720,7 @@ export class OverflowRecoveryTestAgent extends Think {
   compactionEventPayloads: Array<Record<string, unknown>> = [];
   /** Tool-call/result pairing + recompacted-head presence per model step (multi-fire). */
   proactiveStepPrompts: Array<{
+    prompt: string;
     toolCalls: string[];
     toolResults: string[];
     hasSummary: boolean;
@@ -723,6 +732,22 @@ export class OverflowRecoveryTestAgent extends Think {
 
   override beforeTurn(ctx: TurnContext): void {
     this.beforeTurnContinuations.push(ctx.continuation);
+  }
+
+  override beforeStep(
+    ctx: PrepareStepContext
+  ): (StepConfig & { messages: ModelMessage[] }) | void {
+    if (this.stepMessages === "append") {
+      return {
+        messages: [
+          ...ctx.messages,
+          { role: "user", content: "Additional per-step context" }
+        ]
+      };
+    }
+    if (ctx.stepNumber > 0 && this.stepMessages) {
+      return { messages: this.stepMessages };
+    }
   }
 
   override _emit(
@@ -765,7 +790,7 @@ export class OverflowRecoveryTestAgent extends Think {
       // prompt (to assert compaction actually removed it on the retry).
       const onCall = (options?: unknown) => {
         this.modelCalls++;
-        if (this.proactiveMultiFire) {
+        if (this.proactiveMode) {
           // Capture the spliced prompt's tool pairing + recompacted-head
           // presence per step, so the multi-fire test can assert structural
           // integrity (not just a clean completion).
@@ -814,6 +839,7 @@ export class OverflowRecoveryTestAgent extends Think {
   override configureSession(session: Session): Session {
     return session.onCompaction(async (messages) => {
       this.compactionCount++;
+      if (this.compactionThrows) throw new Error("Test compaction failed");
       // `compactionNoOp` simulates a history that can't be shortened (e.g. one
       // tool result alone exceeds the window) so the reactive backstop must
       // fall through to a terminal error instead of looping.
@@ -997,6 +1023,7 @@ export class OverflowRecoveryTestAgent extends Think {
   /** Per-step tool pairing + recompacted-head presence (multi-fire proactive). */
   async getProactiveStepPrompts(): Promise<
     Array<{
+      prompt: string;
       toolCalls: string[];
       toolResults: string[];
       hasSummary: boolean;
@@ -1012,7 +1039,11 @@ export class OverflowRecoveryTestAgent extends Think {
    * mid-turn before the next step. Reactive backstop is left off to isolate the
    * proactive path.
    */
-  async testProactive(message: string): Promise<OverflowChatResult> {
+  async testProactive(
+    message: string,
+    stepMessages?: "append" | ModelMessage[]
+  ): Promise<OverflowChatResult> {
+    this.stepMessages = stepMessages;
     this.proactiveMode = true;
     this.compactionNoOp = false;
     this.compactionCount = 0;
@@ -1116,7 +1147,12 @@ export class OverflowRecoveryTestAgent extends Think {
    * that a persistent no-op cannot emit/compact on every step. The turn still
    * completes (proactive failure is best-effort; the step proceeds uncompacted).
    */
-  async testProactiveNoOp(message: string): Promise<OverflowChatResult> {
+  async testProactiveNoOp(
+    message: string,
+    compactionThrows = false
+  ): Promise<OverflowChatResult> {
+    this.stepMessages = "append";
+    this.compactionThrows = compactionThrows;
     this.proactiveMode = true;
     this.proactiveMultiFire = true;
     this.compactionNoOp = true;

--- a/packages/think/src/tests/assistant-agent-loop.test.ts
+++ b/packages/think/src/tests/assistant-agent-loop.test.ts
@@ -642,6 +642,56 @@ describe("Think — agentic loop", () => {
       });
     });
 
+    it("beforeStep can append context without undoing proactive compaction", async () => {
+      const agent = await getAgentByName(
+        env.OverflowRecoveryTestAgent,
+        crypto.randomUUID()
+      );
+
+      const result = await agent.testProactive("use the echo tool", "append");
+      expect(result.error).toBeUndefined();
+      expect(result.done).toBe(true);
+      expect(result.compactionEvents).toBe(1);
+      const { compactionEventPayloads } = await agent.getOverflowStats();
+      expect(compactionEventPayloads[0]).toMatchObject({
+        reason: "proactive",
+        shortened: true
+      });
+
+      const prompts = await agent.getProactiveStepPrompts();
+      expect(prompts).toHaveLength(2);
+      expect(prompts[0].prompt).toContain("earlier question");
+      expect(prompts[0].prompt).toContain("Additional per-step context");
+      expect(prompts[1].prompt).toContain("compacted-summary");
+      expect(prompts[1].prompt).not.toContain("earlier question");
+      expect(prompts[1].prompt).toContain("Additional per-step context");
+      expect(prompts[1].toolCalls).toHaveLength(1);
+      expect(prompts[1].toolResults).toEqual(prompts[1].toolCalls);
+    });
+
+    it("beforeStep can explicitly replace compacted messages", async () => {
+      const agent = await getAgentByName(
+        env.OverflowRecoveryTestAgent,
+        crypto.randomUUID()
+      );
+
+      const result = await agent.testProactive("use the echo tool", [
+        { role: "user", content: "Replacement context" }
+      ]);
+      expect(result.error).toBeUndefined();
+      expect(result.done).toBe(true);
+      expect(result.compactionEvents).toBe(1);
+      const prompts = await agent.getProactiveStepPrompts();
+      expect(prompts).toHaveLength(2);
+      expect(JSON.parse(prompts[1].prompt)).toEqual([
+        expect.objectContaining({ role: "system" }),
+        {
+          role: "user",
+          content: [{ type: "text", text: "Replacement context" }]
+        }
+      ]);
+    });
+
     it("proactive guard fires twice in one turn (maxCompactions:2) without corrupting the spliced prompt", async () => {
       const room = crypto.randomUUID();
       const agent = (await getAgentByName(
@@ -708,28 +758,46 @@ describe("Think — agentic loop", () => {
       );
     });
 
-    it("proactive no-op compaction consumes its single slot and does not re-attempt on later steps", async () => {
-      const room = crypto.randomUUID();
-      const agent = (await getAgentByName(
-        env.OverflowRecoveryTestAgent,
-        room
-      )) as unknown as OverflowAgent;
+    it.each([false, true])(
+      "proactive no-op compaction consumes its single slot and preserves beforeStep context (throws: %s)",
+      async (compactionThrows) => {
+        const agent = await getAgentByName(
+          env.OverflowRecoveryTestAgent,
+          crypto.randomUUID()
+        );
 
-      // 3-step tool turn, default budget (proactive cap 1), compaction is a
-      // no-op. The guard trips before step 2, attempts once (a no-op), and is
-      // then spent — so it must NOT compact again before step 3.
-      const result = await agent.testProactiveNoOp("use the echo tool");
+        // A no-op or failed compaction consumes the guard's single attempt,
+        // so step 3 must proceed without trying again.
+        const result = await agent.testProactiveNoOp(
+          "use the echo tool",
+          compactionThrows
+        );
 
-      // The turn still completes — a proactive no-op is best-effort, the step
-      // just proceeds uncompacted.
-      expect(result.error).toBeUndefined();
-      expect(result.done).toBe(true);
-      expect(result.modelCalls).toBe(3);
-      // Exactly one compaction attempt (and one event) for the whole run — a
-      // persistent no-op does not compact/emit on every step.
-      expect(result.compactionCount).toBe(1);
-      expect(result.compactionEvents).toBe(1);
-    });
+        // The turn still completes — a proactive no-op is best-effort, the step
+        // just proceeds uncompacted.
+        expect(result.error).toBeUndefined();
+        expect(result.done).toBe(true);
+        expect(result.modelCalls).toBe(3);
+        // Exactly one compaction attempt (and one event) for the whole run — a
+        // persistent no-op does not compact/emit on every step.
+        expect(result.compactionCount).toBe(1);
+        expect(result.compactionEvents).toBe(1);
+        const { compactionEventPayloads } = await agent.getOverflowStats();
+        expect(compactionEventPayloads[0]).toMatchObject({
+          reason: "proactive",
+          shortened: false
+        });
+        const prompts = await agent.getProactiveStepPrompts();
+        expect(prompts).toHaveLength(3);
+        for (const prompt of prompts) {
+          expect(prompt.prompt).toContain("earlier question");
+          expect(prompt.prompt).not.toContain("compacted-summary");
+          expect(prompt.prompt).toContain("Additional per-step context");
+          expect(prompt.toolResults).toEqual(prompt.toolCalls);
+        }
+        expect(prompts[2].toolCalls).toHaveLength(2);
+      }
+    );
   });
 
   describe("defaultContextOverflowClassifier", () => {

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -6557,7 +6557,9 @@ export class Think<
         // Proactive context guard (Layer 1) runs first so `beforeStep` sees the
         // recompacted messages and can still override them if it wants to.
         const guarded = await this._maybeProactiveContextCompact(event);
-        const result = await this.beforeStep(event);
+        const result = await this.beforeStep(
+          guarded ? { ...event, messages: guarded } : event
+        );
         const base = result == null ? {} : result;
         // Only apply the guard's recompacted messages when the subclass didn't
         // set its own `messages` override for this step.


### PR DESCRIPTION
When `beforeStep` appends context, it can bring back history that Think just compacted. Pass the compacted messages to the hook while preserving explicit message overrides.

```diff
 compact history
-beforeStep(original messages)
+beforeStep(compacted messages)
 send hook result
```

Validated the regression red → green, `pnpm run build`, `pnpm run check` (119 projects), 894 Think Workers tests on both AI SDK 6 and 7, 2 React tests, and v6 package typechecking. Seven compaction/hook tests also pass against the built package on v6.

Supplemental v6 fixture-only typechecking has eight unchanged errors on main.

Fixes #2212

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/agents/pull/2230" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->