### PR TITLE
fix(agents): preserve sub-agent onConnect connection state

### DIFF
--- a/.changeset/quiet-owls-connect.md
+++ b/.changeset/quiet-owls-connect.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Preserve sub-agent connection state set in `onConnect` for the first client message by completing queued connection operations before the connect handler returns.

--- a/packages/agents/src/dynamic-agents/dynamic-agents.ts
+++ b/packages/agents/src/dynamic-agents/dynamic-agents.ts
@@ -1245,6 +1245,9 @@ export class DynamicAgentsInternal extends LifecycleCapability {
       this.storeVirtualConnection(connection);
       await this.#host.onConnect(connection, { request });
       this.storeVirtualConnection(connection);
+      // Publish onConnect state to the root before the first client frame can
+      // replace the virtual connection's state with root-owned metadata.
+      await this.#connectionOperationTails.get(meta.id);
     });
   }
 

--- a/packages/think/src/tests/agents/connection-state.ts
+++ b/packages/think/src/tests/agents/connection-state.ts
@@ -1,0 +1,33 @@
+import { Agent } from "agents";
+import type { Connection, WSMessage } from "agents";
+import { Think } from "../../think";
+
+/** Routes real WebSocket connections to a Think sub-agent. */
+export class ConnectionStateParent extends Agent {}
+
+/** Reports connection state through the application's public hooks. */
+export class ConnectionStateThink extends Think {
+  /** Set application state after Think's initial connection frames. */
+  override onConnect(connection: Connection): void {
+    connection.setState({ userId: "user-123" });
+    connection.send(
+      JSON.stringify({
+        type: "connected",
+        connectionId: connection.id,
+        state: connection.state
+      })
+    );
+  }
+
+  /** Echo the state observed while handling the actual client message. */
+  override onMessage(connection: Connection, message: WSMessage): void {
+    connection.send(
+      JSON.stringify({
+        type: "message",
+        connectionId: connection.id,
+        message,
+        state: connection.state
+      })
+    );
+  }
+}

--- a/packages/think/src/tests/connection-state.test.ts
+++ b/packages/think/src/tests/connection-state.test.ts
@@ -1,0 +1,58 @@
+import { exports } from "cloudflare:workers";
+import { expect, it } from "vitest";
+import { z } from "zod";
+
+const connectionFrame = z.object({
+  type: z.enum(["connected", "message"]),
+  connectionId: z.string(),
+  state: z.object({ userId: z.string() }).nullable(),
+  message: z.string().optional()
+});
+
+it.each([
+  ["root", "connection-state-think"],
+  ["sub-agent", "connection-state-parent"]
+])(
+  "preserves onConnect state for the first Think %s client message",
+  async (route, rootClass) => {
+    const subPath = route === "root" ? "" : "/sub/connection-state-think/child";
+    const response = await exports.default.fetch(
+      `http://example.com/agents/${rootClass}/${crypto.randomUUID()}${subPath}`,
+      { headers: { Upgrade: "websocket" } }
+    );
+    expect(response.status).toBe(101);
+    const ws = response.webSocket;
+    if (!ws) throw new Error("Connection state test: missing WebSocket");
+
+    const frames: z.infer<typeof connectionFrame>[] = [];
+    const replied = new Promise<void>((resolve) => {
+      ws.addEventListener("message", (event) => {
+        if (typeof event.data !== "string") return;
+        const frame = connectionFrame.safeParse(JSON.parse(event.data));
+        if (!frame.success) return;
+        frames.push(frame.data);
+        if (frame.data.type === "message") resolve();
+      });
+    });
+    ws.accept();
+    try {
+      ws.send("first client message");
+      await replied;
+      expect(frames).toEqual([
+        {
+          type: "connected",
+          connectionId: expect.any(String),
+          state: { userId: "user-123" }
+        },
+        {
+          type: "message",
+          connectionId: frames[0]?.connectionId,
+          message: "first client message",
+          state: { userId: "user-123" }
+        }
+      ]);
+    } finally {
+      ws.close();
+    }
+  }
+);

--- a/packages/think/src/tests/worker.ts
+++ b/packages/think/src/tests/worker.ts
@@ -3,6 +3,10 @@ import { routeAgentRequest } from "agents";
 import { createBrowserRuntime, createBrowserTools } from "../tools/browser";
 
 export { HostBridgeLoopback } from "../extensions";
+export {
+  ConnectionStateParent,
+  ConnectionStateThink
+} from "./agents/connection-state";
 
 // Facet class behind tools built on createCodemodeRuntime (execute tool).
 export { CodemodeRuntime } from "@cloudflare/codemode";

--- a/packages/think/src/tests/wrangler.jsonc
+++ b/packages/think/src/tests/wrangler.jsonc
@@ -12,6 +12,14 @@
   "durable_objects": {
     "bindings": [
       {
+        "class_name": "ConnectionStateParent",
+        "name": "ConnectionStateParent"
+      },
+      {
+        "class_name": "ConnectionStateThink",
+        "name": "ConnectionStateThink"
+      },
+      {
         "class_name": "TestAssistantToolsAgent",
         "name": "TestAssistantToolsAgent"
       },
@@ -181,6 +189,8 @@
   "migrations": [
     {
       "new_sqlite_classes": [
+        "ConnectionStateParent",
+        "ConnectionStateThink",
         "TestAssistantToolsAgent",
         "TestAssistantAgentAgent",
         "BareAssistantAgent",


### PR DESCRIPTION
Connection state set in `onConnect` could disappear before the first client message when connecting through a parent Agent.

Wait for that connection’s queued operations before finishing the child connect handler.

```text
onConnect → finish queued state write → first client message
```

Validated with a real WebSocket regression and red/green reversal, 3,451 Workers tests, repeated/concurrent connections, the full build, and `pnpm run check`.

Fixes #2206

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/agents/pull/2233" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->