### PR TITLE
fix(sessions): keep attachment references a rewritten message still points at

### DIFF
--- a/packages/agents/src/sessions/attachment-ingest.ts
+++ b/packages/agents/src/sessions/attachment-ingest.ts
@@ -143,6 +143,15 @@ export interface ExtractionResult {
   message: SessionMessage;
   /** Payloads to write, deduplicated by address, in encounter order. */
   attachments: PendingAttachment[];
+  /**
+   * Every address the stored message points at: the payloads extracted on
+   * this pass plus pointers it already carried. A message can be written
+   * back with its pointers in place — a read that left one unresolved, or a
+   * host that patches a stored form — and the references that give those
+   * payloads their lifetime must follow what the row SAYS, not what this
+   * pass happened to extract.
+   */
+  references: string[];
 }
 
 /**
@@ -154,6 +163,7 @@ export interface ExtractionResult {
 export function extractAttachments(message: SessionMessage): ExtractionResult {
   const attachments: PendingAttachment[] = [];
   const seen = new Set<string>();
+  const references = new Set<string>();
 
   const walk = (value: unknown, depth: number): unknown => {
     if (depth > MAX_WALK_DEPTH || value === null || typeof value !== "object") {
@@ -176,6 +186,7 @@ export function extractAttachments(message: SessionMessage): ExtractionResult {
       // Hashing is pure CPU, so the address is known here and the write
       // transaction never has to hash anything.
       const hash = hashPayload(media.bytes);
+      references.add(hash);
       if (!seen.has(hash)) {
         seen.add(hash);
         attachments.push({
@@ -193,6 +204,15 @@ export function extractAttachments(message: SessionMessage): ExtractionResult {
       };
     }
 
+    // A pointer left by an earlier extraction is not media to store, but it
+    // is a reference to keep.
+    const pointed =
+      parseAttachmentUrl(record.url) ?? parseAttachmentUrl(record.data);
+    if (pointed) {
+      references.add(pointed);
+      return value;
+    }
+
     let changed = false;
     const next: Record<string, unknown> = {};
     for (const [key, entry] of Object.entries(record)) {
@@ -203,10 +223,13 @@ export function extractAttachments(message: SessionMessage): ExtractionResult {
     return changed ? next : value;
   };
 
-  if (message.parts.length === 0) return { message, attachments };
+  if (message.parts.length === 0) {
+    return { message, attachments, references: [] };
+  }
   const parts = walk(message.parts, 0) as SessionMessagePart[];
-  if (parts === message.parts) return { message, attachments };
-  return { message: { ...message, parts }, attachments };
+  const result = { attachments, references: [...references] };
+  if (parts === message.parts) return { message, ...result };
+  return { message: { ...message, parts }, ...result };
 }
 
 /**

--- a/packages/agents/src/sessions/core.ts
+++ b/packages/agents/src/sessions/core.ts
@@ -940,7 +940,11 @@ export class SessionsCore {
     // Inline media leaves the message before it is serialized, so the row
     // holds a pointer and never the payload. Addresses are computed here, out
     // of the transaction; the transaction only writes.
-    const { message: staged, attachments } = extractAttachments(message);
+    const {
+      message: staged,
+      attachments,
+      references
+    } = extractAttachments(message);
     const slices = splitContent(JSON.stringify(staged));
     const seq = tail.nextSeq;
     this.io.transaction(() => {
@@ -964,11 +968,7 @@ export class SessionsCore {
         ]
       );
       this.#writeContinuations(sessionId, message.id, slices);
-      this.#attachments.addRefs(
-        sessionId,
-        message.id,
-        attachments.map((attachment) => attachment.hash)
-      );
+      this.#attachments.addRefs(sessionId, message.id, references);
       this.#indexFts(sessionId, staged, false);
     });
 
@@ -1024,7 +1024,11 @@ export class SessionsCore {
           (this.#continuations(sessionId, [message.id]).get(message.id) ?? "");
     // Compare in stored form: a re-sent identical image extracts to the same
     // address, so an unchanged update still writes nothing.
-    const { message: staged, attachments } = extractAttachments(message);
+    const {
+      message: staged,
+      attachments,
+      references
+    } = extractAttachments(message);
     const json = JSON.stringify(staged);
     if (oldContent === json) return "unchanged";
 
@@ -1058,11 +1062,7 @@ export class SessionsCore {
       this.#writeContinuations(sessionId, message.id, slices);
       // Payloads are stored before references move, so a hash this message
       // still uses is never momentarily unreferenced and collected.
-      this.#attachments.replaceRefs(
-        sessionId,
-        message.id,
-        attachments.map((attachment) => attachment.hash)
-      );
+      this.#attachments.replaceRefs(sessionId, message.id, references);
       this.#indexFts(sessionId, staged, true);
     });
     const memo = this.#pathTokens.get(sessionId);
@@ -1293,7 +1293,11 @@ export class SessionsCore {
     message: SessionMessage,
     options: { parentId: string | null; createdAt: number }
   ): boolean {
-    const { message: staged, attachments } = extractAttachments(message);
+    const {
+      message: staged,
+      attachments,
+      references
+    } = extractAttachments(message);
     const slices = splitContent(JSON.stringify(staged));
     const tail = this.#tail(sessionId);
     let inserted = 0;
@@ -1319,11 +1323,7 @@ export class SessionsCore {
       );
       if (inserted === 0) return;
       this.#writeContinuations(sessionId, message.id, slices);
-      this.#attachments.addRefs(
-        sessionId,
-        message.id,
-        attachments.map((attachment) => attachment.hash)
-      );
+      this.#attachments.addRefs(sessionId, message.id, references);
       this.#indexFts(sessionId, staged, false);
     });
     if (inserted === 0) return false;

--- a/packages/agents/src/tests/capabilities/sessions.ts
+++ b/packages/agents/src/tests/capabilities/sessions.ts
@@ -139,6 +139,20 @@ export class SessionHarnessObject extends DurableObject<Cloudflare.Env> {
   }
 
   /** Stored size of one message row, excluding anything it points at. */
+  /** One message row exactly as stored: pointers in place of payloads. */
+  storedMessage(sessionId: string, messageId: string): SessionMessage {
+    return JSON.parse(
+      this.ctx.storage.sql
+        .exec<{ content: string }>(
+          `SELECT content FROM cf_agents_session_messages
+           WHERE session_id = ? AND id = ?`,
+          sessionId,
+          messageId
+        )
+        .one().content
+    ) as SessionMessage;
+  }
+
   messageRowBytes(sessionId: string, messageId: string): number {
     return Number(
       this.ctx.storage.sql

--- a/packages/agents/src/tests/sessions/attachments.test.ts
+++ b/packages/agents/src/tests/sessions/attachments.test.ts
@@ -220,6 +220,48 @@ describe("Sessions attachments", () => {
     });
   });
 
+  it("keeps a pointer's reference when the message is written back", async () => {
+    const stub = env.SessionHarnessObject.getByName(crypto.randomUUID());
+    await runInDurableObject(stub, async (instance: SessionHarnessObject) => {
+      const session = instance.sessions.session();
+      const url = dataUrl("image/png", 80_000);
+      await session.appendMessage(fileMessage("m1", url, "image/png"));
+
+      // The stored form: the same message with a pointer where the bytes
+      // were. A host can hold this form — a read whose payload did not
+      // resolve, or code that works on the row — and write it back.
+      const pointer = instance.storedMessage("", "m1");
+      expect((pointer.parts[1] as { url: string }).url).toMatch(
+        /^attachment:sha256:[0-9a-f]{64}$/
+      );
+
+      // An update that changes anything else must keep the reference. It
+      // used to be replaced with what the write extracted — nothing — and
+      // the payload was collected under a live pointer.
+      await session.updateMessage({
+        ...pointer,
+        parts: [
+          { type: "text", text: "see attached (edited)" },
+          pointer.parts[1]
+        ]
+      });
+      expect(instance.attachmentRecords()).toHaveLength(1);
+      expect(instance.attachmentRefCount()).toBe(1);
+      const [full] = await session.getHistory();
+      expect((full.parts[1] as { url: string }).url).toBe(url);
+
+      // A copy under a new id takes its own reference, so deleting the
+      // original does not take the bytes with it.
+      await session.appendMessage({ ...pointer, id: "m2" });
+      expect(instance.attachmentRefCount()).toBe(2);
+      await session.deleteMessages(["m1"]);
+      expect(instance.attachmentRecords()).toHaveLength(1);
+      const copy = await session.getMessage("m2");
+      expect(copy).not.toBeNull();
+      expect((copy!.parts[1] as { url: string }).url).toBe(url);
+    });
+  });
+
   it("returns null for an update whose target is gone and stores nothing", async () => {
     const stub = env.SessionHarnessObject.getByName(crypto.randomUUID());
     await runInDurableObject(stub, async (instance: SessionHarnessObject) => {


### PR DESCRIPTION
## The bug

Sessions stores a message's media out of the row as a content-addressed pointer (`attachment:sha256:<hash>` in the field that held the payload) and gives the payload its lifetime through `cf_agents_session_attachment_refs`: when the last reference goes, the bytes are collected.

The writers derived those references only from media **extracted on that write** (`extractAttachments(...).attachments`). A part that already carries a pointer is not inline media, so it extracts to nothing. That gives two hazards for any message written back in its stored form — a read whose payload did not resolve, or host code that works on the row:

1. **`updateMessage` collects the bytes under a live pointer.** `replaceRefs(id, [])` drops every reference the message held and `#collect` deletes the meta and chunk rows unless another message shares the hash. The row keeps its pointer, so the message is permanently unresolvable. The byte-identical no-op guard hides this only when nothing else in the message changed.
2. **`appendMessage` / `importMessage` of a pointer-form copy under a new id records no reference.** The copy free-rides on the original's reference, and the bytes are collected as soon as the original is deleted or its session cleared.

## The fix

`extractAttachments` now reports `references`: every address the stored message points at — payloads extracted on this pass plus pointers it already carried. `append`, `update` and `import` record those instead of the extracted subset. References follow what the row says, not what one write happened to extract.

No change to what is stored, read, or billed for messages that carry inline media or none. The new test fails on `main` and passes here.

## Review fixes (`b568dbca`)

- **Patch changeset added** (`.changeset/sessions-attachment-refs.md`). It also notes that rows already orphaned by the old behaviour are not repaired — those bytes are gone — only that no new write can orphan one.
- **Recording a pointer no longer ends the extraction walk.** The first cut returned early at a pointer-bearing record, which silently stopped offloading inline media nested beside a pointer (a thumbnail beside the image it previews) and left that payload in the row the offload policy exists to protect. The record's other fields are walked now, whether it holds a pointer or is itself inline media, so extraction converges in one pass.
- **Reads are symmetric.** `resolveAttachments` used to stop at a resolved pointer, so that nested media would never have come back. It now restores the pointer in place and keeps walking.
- **Pointers below the rewrite depth cap are still referenced.** Whether to *rewrite* a node is a judgement call and stopping early only leaves a payload inline; whether a node holds a *pointer* is not, because missing one collects bytes the stored row still names. Reference collection therefore continues past `MAX_WALK_DEPTH` to its own far looser cap, which exists only so a cyclic input cannot spin forever.
- **Doc comment moved back** onto `messageRowBytes` in the test harness, where it belongs.

## Tests

- `packages/agents`: `pnpm vitest --run --project workers` — **125 files / 1946 tests passed**. Three sessions-attachment tests cover this fix; all three fail on the pre-fix tree (verified by reverting `attachment-ingest.ts` in place: 2 failed / 14 passed).
  - pointer-form update keeps its reference, and a pointer-form copy under a new id survives deleting the original;
  - media nested beside a pointer is offloaded and restored;
  - a pointer nested past the rewrite depth cap is still referenced, so deleting the message that carried the bytes leaves them in place.
- `oxfmt --check .`, `oxlint examples/ packages/ guides/ openai-sdk/ site/`, `npm run typecheck` (122 projects): clean.

The one red check on the earlier push was `@cloudflare/voice:test` — a `withVoice` `Object.is` module-identity flake in `packages/voice/src/compatibility.test.ts`, unrelated to this PR (it touches no voice source; the agents suite was green in the same run) and it passes locally on `main`.

