### PR TITLE
fix(voice): avoid concurrent compatibility imports

### DIFF
--- a/packages/voice/src/compatibility.test.ts
+++ b/packages/voice/src/compatibility.test.ts
@@ -9,10 +9,9 @@ const pairs = [
 
 describe("@cloudflare/voice compatibility exports", () => {
   it.each(pairs)("re-exports %s from %s", async (legacyPath, agentsPath) => {
-    const [legacy, canonical] = await Promise.all([
-      import(legacyPath),
-      import(agentsPath)
-    ]);
+    // Import sequentially to avoid a Vite module-cache race between entrypoints.
+    const legacy = await import(legacyPath);
+    const canonical = await import(agentsPath);
 
     expect(Object.keys(legacy).sort()).toEqual(Object.keys(canonical).sort());
     for (const name of Object.keys(canonical)) {


### PR DESCRIPTION
Import compatibility entrypoints sequentially to avoid a Vite module-cache race that intermittently fails export identity checks.

Tested: voice compatibility suite (20 fresh runs); pnpm run check.
<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/agents/pull/2237" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->