### PR TITLE
fix(think): bash tool deletes workspace directories under sandbox roots

### DIFF
--- a/.changeset/think-bash-sandbox-root-sync.md
+++ b/.changeset/think-bash-sandbox-root-sync.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/think": patch
+---
+
+Fix the bash tool deleting pre-existing workspace directories under `/tmp`, `/bin`, `/usr`, `/dev`, `/proc` and `/sys` after every run. The sync pass now treats workspace-owned directories below a sandbox root like any other directory and skips only the roots themselves.

--- a/packages/think/src/tests/assistant-tools.test.ts
+++ b/packages/think/src/tests/assistant-tools.test.ts
@@ -526,6 +526,39 @@ exit 9`)) as {
     expect(read.content).toContain("keep me");
   });
 
+  it("leaves workspace content under sandbox roots alone", async () => {
+    const agent = await freshAgent("bash-sandbox-root-content");
+    await agent.seed([
+      { path: "/tmp/cache/data.txt", content: "cached\n" },
+      { path: "/usr/notes.txt", content: "notes\n" }
+    ]);
+
+    // A script that never touches /tmp or /usr must not disturb them: the
+    // sync used to treat every pre-existing directory under a sandbox root
+    // as deleted and rm -rf it after writing its files back.
+    await agent.toolBash("echo hi > /hi.txt");
+
+    const cached = (await agent.toolRead("/tmp/cache/data.txt")) as {
+      content: string;
+    };
+    expect(cached.content).toContain("cached");
+    const notes = (await agent.toolRead("/usr/notes.txt")) as {
+      content: string;
+    };
+    expect(notes.content).toContain("notes");
+
+    // A script that does delete such a directory is still honoured.
+    const result = (await agent.toolBash("rm -rf /tmp/cache")) as {
+      changedFiles: { deleted: string[]; directoriesDeleted: string[] };
+    };
+    expect(result.changedFiles.deleted).toContain("/tmp/cache/data.txt");
+    expect(result.changedFiles.directoriesDeleted).toContain("/tmp/cache");
+    const removed = (await agent.toolRead("/tmp/cache/data.txt")) as {
+      error: string;
+    };
+    expect(removed.error).toContain("File not found");
+  });
+
   it("persists empty directory creates and deletes", async () => {
     const agent = await freshAgent("bash-empty-dirs");
     await agent.seedDir("/remove-empty");

--- a/packages/think/src/tools/workspace.ts
+++ b/packages/think/src/tools/workspace.ts
@@ -1368,7 +1368,16 @@ async function syncBashFilesToWorkspace({
 
   for (const rawPath of bash.fs.getAllPaths()) {
     const path = normalizeWorkspacePath(rawPath);
-    if (!shouldSyncBashPath(path, initialFiles, protectedPaths)) continue;
+    if (
+      !shouldSyncBashPath(
+        path,
+        initialFiles,
+        initialDirectories,
+        protectedPaths
+      )
+    ) {
+      continue;
+    }
     const stat = await bash.fs.stat(path).catch(() => null);
     if (stat?.isDirectory) {
       finalDirectories.add(path);
@@ -1431,6 +1440,11 @@ async function syncBashFilesToWorkspace({
     b.localeCompare(a)
   )) {
     if (path === "/" || finalDirectories.has(path)) continue;
+    // The shell always materializes the sandbox roots, so their presence in
+    // the final tree says nothing about the script; never delete the roots
+    // themselves. Workspace-owned directories *below* a root were mounted
+    // from the snapshot and sync like any other directory.
+    if (isBashSandboxRoot(path)) continue;
     if (hasProtectedDescendant(path, protectedPaths)) {
       errors.push(`Skipped deleting protected workspace directory: ${path}`);
       continue;
@@ -1505,13 +1519,27 @@ async function writeWorkspaceBytes(
     });
 }
 
+function isBashSandboxRoot(path: string): boolean {
+  return path === "/tmp" || BASH_EXCLUDED_SYNC_ROOTS.includes(path);
+}
+
+/**
+ * Whether a path in the shell's final tree belongs to the workspace.
+ *
+ * Anything the workspace already held syncs both ways, including files and
+ * directories that happen to live under a sandbox root such as `/tmp`. Paths
+ * the script created under a sandbox root are the shell's own scratch and
+ * builtins and never persist.
+ */
 function shouldSyncBashPath(
   path: string,
   initialFiles: Map<string, Uint8Array>,
+  initialDirectories: Set<string>,
   protectedPaths: Set<string>
 ): boolean {
   if (path === "/") return false;
   if (initialFiles.has(path)) return true;
+  if (initialDirectories.has(path)) return true;
   if (protectedPaths.has(path)) return true;
   if (path === "/tmp" || path.startsWith("/tmp/")) return false;
   return !BASH_EXCLUDED_SYNC_ROOTS.some(


### PR DESCRIPTION
## Summary

Think's `bash` tool runs scripts against an in-memory snapshot of the Workspace and syncs changes back afterwards. The final sync pass deletes any directory that existed before the run and is missing from the shell's final tree. Three pieces interacted badly:

- the snapshot walk records every workspace directory, including anything under `/tmp`, `/bin`, `/usr`, `/dev`, `/proc`, `/sys`;
- `shouldSyncBashPath` filtered every path under those roots out of the final tree;
- the deletion pass then saw those directories as "existed before, gone now" and ran `rm(path, { recursive: true, force: true })`.

So a Workspace holding `/tmp/cache/data.txt` lost `/tmp/cache` on every bash call, even one that never touched it. Files under those roots were synced back in an earlier pass and wiped by the directory pass moments later.

Fix: workspace-owned directories below a sandbox root are treated like any other directory (they were mounted from the snapshot, so their absence from the final tree does mean the script removed them), and only the roots themselves are skipped since the shell always materializes those.

Found while porting this sync engine into the pi harness in #2229, where Devin flagged the same bug in the copy.

## Test plan

- [x] New test in `assistant-tools.test.ts`: seeded `/tmp/cache/data.txt` and `/usr/notes.txt` survive an unrelated script, and `rm -rf /tmp/cache` is still honoured. Verified red without the fix.
- [x] Full Think suite (`pnpm vitest --run -c src/tests/vitest.config.ts` in `packages/think`)
- [x] oxfmt, oxlint, repo-wide typecheck

## Review fixes

### Round 1

- **Ownership is now decided by ancestry, not exact path** (`shouldSyncBashPath`). Devin's inline comment was right: with exact-path ownership, a file created or renamed inside a workspace-owned directory below a sandbox root was filtered out of the final tree while the deletion pass still removed the rename source, so `mv /tmp/cache/data.txt /tmp/cache/renamed.txt` destroyed the content and `echo x > /tmp/cache/new.txt` was silently dropped. A path now syncs if it is, or descends from, an initial workspace directory; the sandbox roots themselves are excluded as ancestors, so scratch written directly under `/tmp` or `/usr` still never persists.
- **Collapsed the duplicated `/tmp` special case** into one `BASH_SANDBOX_ROOTS = ["/tmp", ...BASH_EXCLUDED_SYNC_ROOTS]` used by both `isBashSandboxRoot` and the sync predicate.
- **New test** covering create, `mkdir`, and rename beneath `/tmp/cache` and beneath a workspace-owned `/usr/project`, asserting the renamed file keeps its content (Devin's repro) and that `/tmp/loose.txt` written directly under the root is still discarded.
- Changeset reworded to describe the full data-loss fix (still `patch`).

### Round 2

- **Synthetic builtins no longer leak through owned directories.** just-bash writes a file per command into `/bin` and `/usr/bin` while constructing the shell (confirmed: a bare `Bash` boots with ~190 such paths). A workspace that happens to hold `/usr/bin` therefore claimed all of them under the new ancestry rule. `shellInfrastructurePaths()` derives the excluded subtrees by booting one throwaway `Bash({ files: {}, cwd: "/" })` and reading `fs.getAllPaths()` — no hand-copied list, so the set tracks whatever the installed just-bash actually materializes — and memoizes it. Those paths are skipped as ancestry owners; an exact initial file such as `/usr/bin/custom-tool` still syncs, because `shouldSyncBashPath` matches it by path first.
- **Renames onto a sandbox root keep their content.** `mv /tmp/cache /tmp/archive` left the destination with no initial ancestor, so it was dropped while the deletion pass removed the source. just-bash exposes no rename/mutation events and no journal on its in-memory fs, so provenance is inferred from the before/after trees by `detectMovedWorkspaceEntries()`: a new entry directly under a sandbox root is workspace content when an initial workspace path under that same root has vanished from the final tree *and* the new entry's contents match it exactly — same set of relative file paths, same bytes. Empty vanished subtrees are not matched (nothing to lose, and emptiness alone would adopt unrelated scratch). The rule is documented in the function's doc comment.
- **New tests**: builtins under `/usr/bin` never appear in `changedFiles` or the workspace while a seeded `/usr/bin/custom-tool` survives; `mv /tmp/cache /tmp/archive` and `mv /tmp/notes/note.txt /tmp/note.txt` both keep their content, with the existing assertion that `echo scratch > /tmp/loose.txt` is still discarded.

### Round 3

Devin's three follow-ups were all consequences of inferring moves from content equality, so the inference is gone: `detectMovedWorkspaceEntries` and its content-matching helpers are deleted and replaced with a real filesystem journal.

- **The sandbox now runs on a journalling filesystem.** just-bash accepts a caller-supplied `IFileSystem` (`BashOptions.fs`) and exports `InMemoryFs`, so `createJournalingBashFs()` builds the snapshot's `InMemoryFs` and wraps `mv`, `cp` and `rm` to record every mutation. Verified against the installed just-bash: these methods always receive absolute paths already resolved against the script's cwd, including under `cd /tmp && mv archive arch2`.
- **Ownership propagates by provenance.** `resolveMovedWorkspaceEntries()` replays the journal: a move whose source is workspace-owned *at that point in the script* makes its destination workspace-owned, and with it every path below. That applies transitively, so it survives edits made after the move, covers empty directories, chains through repeated moves and crosses sandbox roots. A move from unowned scratch, and a later `rm` of a destination, revoke it again.
- **Copy events are recorded but grant nothing.** A directory `mv` is implemented inside just-bash as a `cp` of each entry plus an `rm` of the source (confirmed by journalling a real run), so a copy event cannot be distinguished from a move's own machinery. Events are recorded before the operation runs for the same reason — the outer `mv` must be replayed ahead of the calls it decomposes into.
- **Nothing else directly under a sandbox root is adopted**, so byte-identical scratch after an unrelated `rm` stays scratch.
- **New tests**, the three reported cases verbatim plus the two requested extras: `mv` then append; `mv` of an empty directory; `rm` followed by identical scratch that must not be adopted; a cross-root move (`/tmp/cache/data.txt` -> `/usr/project/data.txt`) together with a chained move (`/tmp/chain` -> `/tmp/first` -> `/usr/second`). The round-2 move tests and the loose-`/tmp`-scratch assertion are unchanged and still pass.

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/agents/pull/2239" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

