### PR TITLE
fix(agents): preserve fiber result when cleanup fails

### DIFF
--- a/.changeset/quiet-fibers-finish.md
+++ b/.changeset/quiet-fibers-finish.md
@@ -1,0 +1,5 @@
+---
+"agents": patch
+---
+
+Preserve a legacy `runFiber` result when deleting its bookkeeping row fails. The cleanup error is logged and the row is left for the existing recovery pass instead of replacing the fiber body's outcome.

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -4657,17 +4657,24 @@ export class Agent<
       }
     } finally {
       this._runFiberActiveFibers.delete(id);
-      this._withAgentSpan(
-        "finalize_fiber",
-        "fiber",
-        {
-          "cloudflare.agents.fiber.id": id,
-          "cloudflare.agents.fiber.name": name
-        },
-        () => {
-          this.sql`DELETE FROM cf_agents_runs WHERE id = ${id}`;
-        }
-      );
+      try {
+        this._withAgentSpan(
+          "finalize_fiber",
+          "fiber",
+          {
+            "cloudflare.agents.fiber.id": id,
+            "cloudflare.agents.fiber.name": name
+          },
+          () => {
+            this.sql`DELETE FROM cf_agents_runs WHERE id = ${id}`;
+          }
+        );
+      } catch (error) {
+        console.error(
+          `[Agent] Failed to finalize fiber "${name}" (${id}); leaving run row for recovery:`,
+          error
+        );
+      }
       dispose();
       if (root && registeredFacetRun) {
         try {

--- a/packages/agents/src/tests/agents/run-fiber.ts
+++ b/packages/agents/src/tests/agents/run-fiber.ts
@@ -57,6 +57,23 @@ export class TestRunFiberAgent extends Agent {
     });
   }
 
+  async runWithFailingCleanup(value: string): Promise<string> {
+    this.sql`
+      CREATE TRIGGER fail_run_fiber_cleanup
+      BEFORE DELETE ON cf_agents_runs
+      WHEN OLD.name = 'cleanup-failure'
+      BEGIN
+        SELECT RAISE(FAIL, 'simulated fiber cleanup failure');
+      END
+    `;
+
+    try {
+      return await this.runFiber("cleanup-failure", async () => value);
+    } finally {
+      this.sql`DROP TRIGGER fail_run_fiber_cleanup`;
+    }
+  }
+
   async runWithCheckpoint(steps: string[]): Promise<string[]> {
     return this.runFiber("checkpoint", async (ctx) => {
       const completed: string[] = [];

--- a/packages/agents/src/tests/run-fiber.test.ts
+++ b/packages/agents/src/tests/run-fiber.test.ts
@@ -48,6 +48,21 @@ describe("runFiber", () => {
       expect(log).toContain("executed:hello");
     });
 
+    it("preserves a successful result when fiber cleanup fails", async () => {
+      const agent = await getAgentByName(
+        env.TestRunFiberAgent,
+        "run-cleanup-failure"
+      );
+
+      await expect(agent.runWithFailingCleanup("completed")).resolves.toBe(
+        "completed"
+      );
+      expect((await agent.getRunningFiberCount()) as unknown as number).toBe(1);
+
+      await agent.triggerRecoveryCheck();
+      expect((await agent.getRunningFiberCount()) as unknown as number).toBe(0);
+    });
+
     it("should delete the fiber row on completion", async () => {
       const agent = await getAgentByName(env.TestRunFiberAgent, "run-cleanup");
 


### PR DESCRIPTION
## Summary

- Treat deletion of a completed legacy `runFiber` bookkeeping row as best-effort finalization.
- Log a cleanup failure and leave the row for the existing recovery pass instead of replacing the fiber body's outcome.
- Add a Workers regression using a real SQLite trigger that fails only the final `cf_agents_runs` delete.

## Proof

The regression calls public `runFiber` through `TestRunFiberAgent`. Its body returns `"completed"`, while a SQLite trigger raises `SQLITE_CONSTRAINT_TRIGGER` during finalization.

Before the fix, the RPC rejected with the cleanup `SqlError`:

```text
AssertionError: promise rejected "SqlError: SQL query failed: simulated fiber cleanup failure"
instead of resolving
```

After the fix, the test proves all three observable outcomes:

1. `runFiber` returns `"completed"`.
2. The undeleted row remains available for recovery.
3. The existing recovery pass removes the row.

## Validation

- Focused `run-fiber.test.ts`: 49/49 passed.
- `pnpm run check`: exports, formatting, lint, and all 119 TypeScript projects passed.
- `agents` package build passed.
- Full Agents test retry reached 197/198 files and 3,186 passing tests; the remaining file did not start because its local pool worker connection was refused. Running that file alone passed 10/10.

Fixes #2104

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/agents/pull/2244" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->