### PR TITLE
fix(e2e): make the nightly e2e suites green

### DIFF
--- a/.changeset/think-pre-stream-retry.md
+++ b/.changeset/think-pre-stream-retry.md
@@ -1,0 +1,5 @@
+---
+"@cloudflare/think": patch
+---
+
+Recover an interrupted Think turn that had opened its stream but persisted no content by re-running its user message instead of trying to continue it. Think opens the resumable stream row before inference, so a Durable Object reset in the window before the first chunk left a turn with a stream id, no partial, and a user message as the latest leaf; recovery classified it as `continue`, found no assistant message to continue from, and marked the incident `skipped`. A parent tailing such a child through agent tools then sealed the run as an error. This mirrors `AIChatAgent`'s empty-partial new-turn rule (#1691).

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Get Playwright version
         id: playwright-version
-        run: echo "version=$(node -p 'require(\"playwright/package.json\").version')" >> $GITHUB_OUTPUT
+        run: echo "version=$(node -p "require('playwright/package.json').version")" >> $GITHUB_OUTPUT
 
       - name: Cache Playwright browsers
         uses: actions/cache@v5
@@ -72,7 +72,7 @@ jobs:
 
       - name: Get Playwright version
         id: playwright-version
-        run: echo "version=$(node -p 'require(\"playwright/package.json\").version')" >> $GITHUB_OUTPUT
+        run: echo "version=$(node -p "require('playwright/package.json').version")" >> $GITHUB_OUTPUT
 
       - name: Cache Playwright browsers
         uses: actions/cache@v5
@@ -214,7 +214,7 @@ jobs:
 
       - name: Get Playwright version
         id: playwright-version
-        run: echo "version=$(node -p 'require(\"playwright/package.json\").version')" >> $GITHUB_OUTPUT
+        run: echo "version=$(node -p "require('playwright/package.json').version")" >> $GITHUB_OUTPUT
 
       - name: Cache Playwright browsers
         uses: actions/cache@v5
@@ -249,7 +249,7 @@ jobs:
 
       - name: Get Playwright version
         id: playwright-version
-        run: echo "version=$(node -p 'require(\"playwright/package.json\").version')" >> $GITHUB_OUTPUT
+        run: echo "version=$(node -p "require('playwright/package.json').version")" >> $GITHUB_OUTPUT
 
       - name: Cache Playwright browsers
         uses: actions/cache@v5
@@ -295,7 +295,7 @@ jobs:
 
       - name: Get Playwright version
         id: playwright-version
-        run: echo "version=$(node -p 'require(\"playwright/package.json\").version')" >> $GITHUB_OUTPUT
+        run: echo "version=$(node -p "require('playwright/package.json').version")" >> $GITHUB_OUTPUT
 
       - name: Cache Playwright browsers
         uses: actions/cache@v5

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Get Playwright version
         id: playwright-version
-        run: echo "version=$(node -p 'require(\"playwright/package.json\").version')" >> $GITHUB_OUTPUT
+        run: echo "version=$(node -p "require('playwright/package.json').version")" >> $GITHUB_OUTPUT
 
       - name: Cache Playwright browsers
         uses: actions/cache@v5

--- a/packages/agents/src/e2e-tests/fiber-eviction.test.ts
+++ b/packages/agents/src/e2e-tests/fiber-eviction.test.ts
@@ -81,28 +81,6 @@ function killProcessOnPort(port: number): void {
   }
 }
 
-function killProcessTree(pid: number): void {
-  let children: number[] = [];
-  try {
-    children = execSync(`pgrep -P ${pid} 2>/dev/null || true`)
-      .toString()
-      .trim()
-      .split("\n")
-      .filter(Boolean)
-      .map(Number);
-  } catch {
-    // pgrep may be unavailable; killing the parent is still useful.
-  }
-  for (const childPid of children) {
-    killProcessTree(childPid);
-  }
-  try {
-    process.kill(pid, "SIGKILL");
-  } catch {
-    // Already dead
-  }
-}
-
 function startWrangler(): ChildProcess {
   const configPath = path.join(__dirname, "wrangler.jsonc");
   const child = spawn(
@@ -122,6 +100,9 @@ function startWrangler(): ChildProcess {
     {
       cwd: __dirname,
       stdio: ["pipe", "pipe", "pipe"],
+      // A process-group leader, so killProcess() can take down wrangler and
+      // every workerd it spawns in one signal.
+      detached: true,
       env: { ...process.env, NODE_ENV: "test" }
     }
   );
@@ -178,7 +159,20 @@ function killProcess(child: ChildProcess): Promise<void> {
       clearTimeout(fallback);
       resolve();
     });
-    killProcessTree(child.pid);
+    // The child is a process-group leader (spawned detached): one signal
+    // takes down npm exec, wrangler, esbuild, and every workerd. Walking the
+    // tree with pgrep and killing children first leaves a window in which
+    // wrangler respawns workerd; that orphan keeps the port and the restart
+    // fails with "Address already in use".
+    try {
+      process.kill(-child.pid, "SIGKILL");
+    } catch {
+      try {
+        process.kill(child.pid, "SIGKILL");
+      } catch {
+        // Already dead.
+      }
+    }
   });
 }
 

--- a/packages/agents/src/e2e-tests/recovery-helpers.ts
+++ b/packages/agents/src/e2e-tests/recovery-helpers.ts
@@ -71,28 +71,6 @@ export function killProcessOnPort(port: number): void {
   }
 }
 
-function killProcessTree(pid: number): void {
-  let children: number[] = [];
-  try {
-    children = execSync(`pgrep -P ${pid} 2>/dev/null || true`)
-      .toString()
-      .trim()
-      .split("\n")
-      .filter(Boolean)
-      .map(Number);
-  } catch {
-    // pgrep may be unavailable; killing the parent is still useful.
-  }
-  for (const childPid of children) {
-    killProcessTree(childPid);
-  }
-  try {
-    process.kill(pid, "SIGKILL");
-  } catch {
-    // Already dead
-  }
-}
-
 export function startWrangler(h: Harness): ChildProcess {
   const child = spawn(
     "npx",
@@ -111,6 +89,9 @@ export function startWrangler(h: Harness): ChildProcess {
     {
       cwd: h.configPath.replace(/\/wrangler\.jsonc$/, ""),
       stdio: ["pipe", "pipe", "pipe"],
+      // A process-group leader, so killProcess() can take down wrangler and
+      // every workerd it spawns in one signal.
+      detached: true,
       env: { ...process.env, NODE_ENV: "test" }
     }
   );
@@ -177,7 +158,20 @@ export function killProcess(child: ChildProcess): Promise<void> {
       clearTimeout(fallback);
       resolve();
     });
-    killProcessTree(child.pid);
+    // The child is a process-group leader (spawned detached): one signal
+    // takes down npm exec, wrangler, esbuild, and every workerd. Walking the
+    // tree with pgrep and killing children first leaves a window in which
+    // wrangler respawns workerd; that orphan keeps the port and the restart
+    // fails with "Address already in use".
+    try {
+      process.kill(-child.pid, "SIGKILL");
+    } catch {
+      try {
+        process.kill(child.pid, "SIGKILL");
+      } catch {
+        // Already dead.
+      }
+    }
   });
 }
 

--- a/packages/ai-chat/src/e2e-tests/worker.ts
+++ b/packages/ai-chat/src/e2e-tests/worker.ts
@@ -154,9 +154,9 @@ export class ChatAbortedExhaustAgent extends ExhaustionBaseAgent {
 /**
  * Exhausts recovery via `work_budget_exceeded`: `maxRecoveryWork: 0` seals the
  * incident as soon as the turn produces ANY recovery work. Unlike the base
- * agent, this one emits enough chunks to bump the durable progress/work meter
- * (a `text-start` past the flush threshold) BEFORE hanging, so each detection
- * sees work accrue beyond the baseline.
+ * agent, this one emits enough chunks to land one durable segment in the
+ * stream log BEFORE hanging, so each detection sees work accrue beyond the
+ * baseline.
  */
 export class ChatWorkBudgetExhaustAgent extends ExhaustionBaseAgent {
   override chatRecovery: ChatRecoveryConfig = {
@@ -170,15 +170,19 @@ export class ChatWorkBudgetExhaustAgent extends ExhaustionBaseAgent {
     _onFinish: unknown,
     _options?: OnChatMessageOptions
   ): Promise<Response> {
-    // Emit a single `text-start` then hang. `text-start` bumps the durable
-    // recovery work/progress meter at production time (independent of flush),
-    // so each interruption banks one unit of work. Staying below the 10-chunk
-    // flush threshold keeps the recoverable partial empty (the retry path),
-    // which avoids the continuation suppression that would swallow a re-emitted
-    // text-start on the continue path.
+    // The work meter is derived from the stream log: a chunk counts once its
+    // packed segment (ten chunks) is flushed, so a lone `text-start` banks
+    // nothing. Emit exactly one segment's worth of chunks — enough to flush —
+    // then hang, so each attempt banks one unit of work and the second
+    // interruption exceeds a zero budget.
     const chunks: Array<{ type: string; [k: string]: unknown }> = [
       { type: "start", messageId: `asst-${Date.now()}` },
-      { type: "text-start" }
+      { type: "text-start", id: "t1" },
+      ...Array.from({ length: 8 }, (_, i) => ({
+        type: "text-delta",
+        id: "t1",
+        delta: `work-${i} `
+      }))
     ];
     const encoder = new TextEncoder();
     let index = 0;

--- a/packages/think/src/e2e-tests/action-ledger-recovery.test.ts
+++ b/packages/think/src/e2e-tests/action-ledger-recovery.test.ts
@@ -11,7 +11,8 @@
  *     exactly once — never stuck behind a permanent `ActionPendingError`
  */
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
-import { spawn, execSync, type ChildProcess } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
+import { killProcess, killProcessOnPort } from "./wrangler-process";
 import { setDefaultAutoSelectFamily } from "node:net";
 import "./harden-net";
 import path from "node:path";
@@ -33,49 +34,6 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function killProcessOnPort(port: number): void {
-  try {
-    const output = execSync(
-      `lsof -tiTCP:${port} -sTCP:LISTEN 2>/dev/null || true`
-    )
-      .toString()
-      .trim();
-    if (output) {
-      for (const pid of output.split("\n").filter(Boolean)) {
-        try {
-          process.kill(Number(pid), "SIGKILL");
-        } catch {
-          // Already dead
-        }
-      }
-    }
-  } catch {
-    // lsof not available
-  }
-}
-
-function killProcessTree(pid: number): void {
-  let children: number[] = [];
-  try {
-    children = execSync(`pgrep -P ${pid} 2>/dev/null || true`)
-      .toString()
-      .trim()
-      .split("\n")
-      .filter(Boolean)
-      .map(Number);
-  } catch {
-    // pgrep may be unavailable; killing the parent is still useful.
-  }
-  for (const childPid of children) {
-    killProcessTree(childPid);
-  }
-  try {
-    process.kill(pid, "SIGKILL");
-  } catch {
-    // Already dead
-  }
-}
-
 function startWrangler(): ChildProcess {
   const configPath = path.join(__dirname, "wrangler.jsonc");
   const child = spawn(
@@ -95,6 +53,9 @@ function startWrangler(): ChildProcess {
     {
       cwd: __dirname,
       stdio: ["pipe", "pipe", "pipe"],
+      // A process-group leader, so killProcess() can take down wrangler and
+      // every workerd it spawns in one signal.
+      detached: true,
       env: { ...process.env, NODE_ENV: "test" }
     }
   );
@@ -136,21 +97,6 @@ async function waitForPortFree(maxAttempts = 30, delayMs = 500): Promise<void> {
     await sleep(delayMs);
   }
   throw new Error(`Port ${PORT} did not free in time`);
-}
-
-function killProcess(child: ChildProcess): Promise<void> {
-  return new Promise((resolve) => {
-    if (!child.pid) {
-      resolve();
-      return;
-    }
-    const fallback = setTimeout(resolve, 3000);
-    child.on("exit", () => {
-      clearTimeout(fallback);
-      resolve();
-    });
-    killProcessTree(child.pid);
-  });
 }
 
 async function restartWrangler(child: ChildProcess): Promise<ChildProcess> {

--- a/packages/think/src/e2e-tests/action-pause-recovery.test.ts
+++ b/packages/think/src/e2e-tests/action-pause-recovery.test.ts
@@ -11,7 +11,8 @@
  *     the connection-independent continuation drives the model to completion
  */
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
-import { spawn, execSync, type ChildProcess } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
+import { killProcess, killProcessOnPort } from "./wrangler-process";
 import { setDefaultAutoSelectFamily } from "node:net";
 import "./harden-net";
 import path from "node:path";
@@ -33,49 +34,6 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function killProcessOnPort(port: number): void {
-  try {
-    const output = execSync(
-      `lsof -tiTCP:${port} -sTCP:LISTEN 2>/dev/null || true`
-    )
-      .toString()
-      .trim();
-    if (output) {
-      for (const pid of output.split("\n").filter(Boolean)) {
-        try {
-          process.kill(Number(pid), "SIGKILL");
-        } catch {
-          // Already dead
-        }
-      }
-    }
-  } catch {
-    // lsof not available
-  }
-}
-
-function killProcessTree(pid: number): void {
-  let children: number[] = [];
-  try {
-    children = execSync(`pgrep -P ${pid} 2>/dev/null || true`)
-      .toString()
-      .trim()
-      .split("\n")
-      .filter(Boolean)
-      .map(Number);
-  } catch {
-    // pgrep may be unavailable; killing the parent is still useful.
-  }
-  for (const childPid of children) {
-    killProcessTree(childPid);
-  }
-  try {
-    process.kill(pid, "SIGKILL");
-  } catch {
-    // Already dead
-  }
-}
-
 function startWrangler(): ChildProcess {
   const configPath = path.join(__dirname, "wrangler.jsonc");
   const child = spawn(
@@ -95,6 +53,9 @@ function startWrangler(): ChildProcess {
     {
       cwd: __dirname,
       stdio: ["pipe", "pipe", "pipe"],
+      // A process-group leader, so killProcess() can take down wrangler and
+      // every workerd it spawns in one signal.
+      detached: true,
       env: { ...process.env, NODE_ENV: "test" }
     }
   );
@@ -136,21 +97,6 @@ async function waitForPortFree(maxAttempts = 30, delayMs = 500): Promise<void> {
     await sleep(delayMs);
   }
   throw new Error(`Port ${PORT} did not free in time`);
-}
-
-function killProcess(child: ChildProcess): Promise<void> {
-  return new Promise((resolve) => {
-    if (!child.pid) {
-      resolve();
-      return;
-    }
-    const fallback = setTimeout(resolve, 3000);
-    child.on("exit", () => {
-      clearTimeout(fallback);
-      resolve();
-    });
-    killProcessTree(child.pid);
-  });
 }
 
 async function restartWrangler(child: ChildProcess): Promise<ChildProcess> {

--- a/packages/think/src/e2e-tests/assistant-e2e.test.ts
+++ b/packages/think/src/e2e-tests/assistant-e2e.test.ts
@@ -6,7 +6,8 @@
  * streaming chat, and workspace tool usage with a real LLM.
  */
 import { describe, it, expect, afterAll, beforeAll } from "vitest";
-import { spawn, execSync, type ChildProcess } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
+import { killProcess, killProcessOnPort } from "./wrangler-process";
 import { setDefaultAutoSelectFamily } from "node:net";
 import "./harden-net";
 import path from "node:path";
@@ -36,49 +37,6 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function killProcessOnPort(port: number): void {
-  try {
-    const output = execSync(`lsof -ti tcp:${port} 2>/dev/null || true`)
-      .toString()
-      .trim();
-    if (output) {
-      const pids = output.split("\n").filter(Boolean);
-      for (const pid of pids) {
-        try {
-          process.kill(Number(pid), "SIGKILL");
-          console.log(`[setup] Killed stale process ${pid} on port ${port}`);
-        } catch {
-          // Process may have already exited
-        }
-      }
-    }
-  } catch {
-    // ignore
-  }
-}
-
-function killProcessTree(pid: number): void {
-  let children: number[] = [];
-  try {
-    children = execSync(`pgrep -P ${pid} 2>/dev/null || true`)
-      .toString()
-      .trim()
-      .split("\n")
-      .filter(Boolean)
-      .map(Number);
-  } catch {
-    // pgrep may be unavailable; killing the parent is still useful.
-  }
-  for (const childPid of children) {
-    killProcessTree(childPid);
-  }
-  try {
-    process.kill(pid, "SIGKILL");
-  } catch {
-    // Already dead
-  }
-}
-
 function startWrangler(): ChildProcess {
   const configPath = path.join(__dirname, "wrangler.jsonc");
   const child = spawn(
@@ -98,6 +56,9 @@ function startWrangler(): ChildProcess {
     {
       cwd: __dirname,
       stdio: ["pipe", "pipe", "pipe"],
+      // A process-group leader, so killProcess() can take down wrangler and
+      // every workerd it spawns in one signal.
+      detached: true,
       env: { ...process.env, NODE_ENV: "test" }
     }
   );
@@ -126,24 +87,6 @@ async function waitForReady(maxAttempts = 60, delayMs = 1000): Promise<void> {
     await sleep(delayMs);
   }
   throw new Error(`Wrangler did not start within ${maxAttempts * delayMs}ms`);
-}
-
-function killProcess(child: ChildProcess): Promise<void> {
-  return new Promise((resolve) => {
-    if (!child.pid) {
-      resolve();
-      return;
-    }
-    // Clear the fallback timer once the child exits — an uncleared timer keeps
-    // the vitest worker's event loop alive and can push teardown past the pool's
-    // termination window ("Timeout terminating forks worker").
-    const fallback = setTimeout(resolve, 3000);
-    child.on("exit", () => {
-      clearTimeout(fallback);
-      resolve();
-    });
-    killProcessTree(child.pid);
-  });
 }
 
 /**

--- a/packages/think/src/e2e-tests/chat-recovery.test.ts
+++ b/packages/think/src/e2e-tests/chat-recovery.test.ts
@@ -8,7 +8,8 @@
  * 5. Verify: onChatRecovery fired, partial text persisted, fiber row cleaned up
  */
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
-import { spawn, execSync, type ChildProcess } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
+import { killProcess, killProcessOnPort } from "./wrangler-process";
 import { setDefaultAutoSelectFamily } from "node:net";
 import "./harden-net";
 import path from "node:path";
@@ -54,49 +55,6 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function killProcessOnPort(port: number): void {
-  try {
-    const output = execSync(
-      `lsof -tiTCP:${port} -sTCP:LISTEN 2>/dev/null || true`
-    )
-      .toString()
-      .trim();
-    if (output) {
-      for (const pid of output.split("\n").filter(Boolean)) {
-        try {
-          process.kill(Number(pid), "SIGKILL");
-        } catch {
-          // Already dead
-        }
-      }
-    }
-  } catch {
-    // lsof not available
-  }
-}
-
-function killProcessTree(pid: number): void {
-  let children: number[] = [];
-  try {
-    children = execSync(`pgrep -P ${pid} 2>/dev/null || true`)
-      .toString()
-      .trim()
-      .split("\n")
-      .filter(Boolean)
-      .map(Number);
-  } catch {
-    // pgrep may be unavailable; killing the parent is still useful.
-  }
-  for (const childPid of children) {
-    killProcessTree(childPid);
-  }
-  try {
-    process.kill(pid, "SIGKILL");
-  } catch {
-    // Already dead
-  }
-}
-
 function startWrangler(): ChildProcess {
   const configPath = path.join(__dirname, "wrangler.jsonc");
   const child = spawn(
@@ -116,6 +74,9 @@ function startWrangler(): ChildProcess {
     {
       cwd: __dirname,
       stdio: ["pipe", "pipe", "pipe"],
+      // A process-group leader, so killProcess() can take down wrangler and
+      // every workerd it spawns in one signal.
+      detached: true,
       env: { ...process.env, NODE_ENV: "test" }
     }
   );
@@ -157,21 +118,6 @@ async function waitForPortFree(maxAttempts = 30, delayMs = 500): Promise<void> {
     await sleep(delayMs);
   }
   throw new Error(`Port ${PORT} did not free in time`);
-}
-
-function killProcess(child: ChildProcess): Promise<void> {
-  return new Promise((resolve) => {
-    if (!child.pid) {
-      resolve();
-      return;
-    }
-    const fallback = setTimeout(resolve, 3000);
-    child.on("exit", () => {
-      clearTimeout(fallback);
-      resolve();
-    });
-    killProcessTree(child.pid);
-  });
 }
 
 async function restartWrangler(child: ChildProcess): Promise<ChildProcess> {
@@ -557,9 +503,16 @@ describe("Think chat recovery e2e", () => {
     expect(status.messageCount).toBe(1);
     expect(status.assistantMessages).toBe(0);
 
-    // This documents the observability gap from the report: the request catch
-    // broadcasts a chat error frame, but it does not route through onError.
-    expect((await callAgent("getOnErrorLog")) as string[]).toEqual([]);
+    // The turn runs as a Tasks run; its failure is reported through `onError`
+    // (the observability gap from the original report is closed) as well as
+    // through the chat error frame and `onChatError` below.
+    const onErrorLog = await pollUntil(
+      "onError hook",
+      () => callAgent("getOnErrorLog") as Promise<string[]>,
+      (log) => log.some((entry) => entry.includes("forced beforeTurn failure")),
+      { attempts: 10, delayMs: 250 }
+    );
+    expect(onErrorLog).toContain("forced beforeTurn failure");
     const chatErrorLog = await pollUntil(
       "chat error hook",
       () => callAgent("getOnChatErrorLog") as Promise<string[]>,

--- a/packages/think/src/e2e-tests/context-overflow-recovery.test.ts
+++ b/packages/think/src/e2e-tests/context-overflow-recovery.test.ts
@@ -14,7 +14,8 @@
  * this exercises the full recovery path quickly and reliably.
  */
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
-import { spawn, execSync, type ChildProcess } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
+import { killProcess, killProcessOnPort } from "./wrangler-process";
 import { setDefaultAutoSelectFamily } from "node:net";
 import "./harden-net";
 import path from "node:path";
@@ -44,49 +45,6 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function killProcessOnPort(port: number): void {
-  try {
-    const output = execSync(
-      `lsof -tiTCP:${port} -sTCP:LISTEN 2>/dev/null || true`
-    )
-      .toString()
-      .trim();
-    if (output) {
-      for (const pid of output.split("\n").filter(Boolean)) {
-        try {
-          process.kill(Number(pid), "SIGKILL");
-        } catch {
-          // Already dead
-        }
-      }
-    }
-  } catch {
-    // lsof not available
-  }
-}
-
-function killProcessTree(pid: number): void {
-  let children: number[] = [];
-  try {
-    children = execSync(`pgrep -P ${pid} 2>/dev/null || true`)
-      .toString()
-      .trim()
-      .split("\n")
-      .filter(Boolean)
-      .map(Number);
-  } catch {
-    // pgrep may be unavailable; killing the parent is still useful.
-  }
-  for (const childPid of children) {
-    killProcessTree(childPid);
-  }
-  try {
-    process.kill(pid, "SIGKILL");
-  } catch {
-    // Already dead
-  }
-}
-
 function startWrangler(): ChildProcess {
   const configPath = path.join(__dirname, "wrangler.jsonc");
   const child = spawn(
@@ -106,6 +64,9 @@ function startWrangler(): ChildProcess {
     {
       cwd: __dirname,
       stdio: ["pipe", "pipe", "pipe"],
+      // A process-group leader, so killProcess() can take down wrangler and
+      // every workerd it spawns in one signal.
+      detached: true,
       env: { ...process.env, NODE_ENV: "test" }
     }
   );
@@ -134,21 +95,6 @@ async function waitForReady(maxAttempts = 60, delayMs = 1000): Promise<void> {
     await sleep(delayMs);
   }
   throw new Error("Wrangler did not start in time");
-}
-
-function killProcess(child: ChildProcess): Promise<void> {
-  return new Promise((resolve) => {
-    if (!child.pid) {
-      resolve();
-      return;
-    }
-    const fallback = setTimeout(resolve, 3000);
-    child.on("exit", () => {
-      clearTimeout(fallback);
-      resolve();
-    });
-    killProcessTree(child.pid);
-  });
 }
 
 async function callAgent(

--- a/packages/think/src/e2e-tests/messenger-recovery.test.ts
+++ b/packages/think/src/e2e-tests/messenger-recovery.test.ts
@@ -14,7 +14,8 @@
  * adapter that records into agent SQL.
  */
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
-import { spawn, execSync, type ChildProcess } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
+import { killProcess, killProcessOnPort } from "./wrangler-process";
 import { setDefaultAutoSelectFamily } from "node:net";
 import "./harden-net";
 import path from "node:path";
@@ -32,49 +33,6 @@ const PERSIST_DIR = path.join(__dirname, ".wrangler-think-messenger-e2e-state");
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
-function killProcessOnPort(port: number): void {
-  try {
-    const output = execSync(
-      `lsof -tiTCP:${port} -sTCP:LISTEN 2>/dev/null || true`
-    )
-      .toString()
-      .trim();
-    if (output) {
-      for (const pid of output.split("\n").filter(Boolean)) {
-        try {
-          process.kill(Number(pid), "SIGKILL");
-        } catch {
-          // Already dead
-        }
-      }
-    }
-  } catch {
-    // lsof not available
-  }
-}
-
-function killProcessTree(pid: number): void {
-  let children: number[] = [];
-  try {
-    children = execSync(`pgrep -P ${pid} 2>/dev/null || true`)
-      .toString()
-      .trim()
-      .split("\n")
-      .filter(Boolean)
-      .map(Number);
-  } catch {
-    // pgrep may be unavailable; killing the parent is still useful.
-  }
-  for (const childPid of children) {
-    killProcessTree(childPid);
-  }
-  try {
-    process.kill(pid, "SIGKILL");
-  } catch {
-    // Already dead
-  }
 }
 
 function startWrangler(): ChildProcess {
@@ -96,6 +54,9 @@ function startWrangler(): ChildProcess {
     {
       cwd: __dirname,
       stdio: ["pipe", "pipe", "pipe"],
+      // A process-group leader, so killProcess() can take down wrangler and
+      // every workerd it spawns in one signal.
+      detached: true,
       env: { ...process.env, NODE_ENV: "test" }
     }
   );
@@ -137,21 +98,6 @@ async function waitForPortFree(maxAttempts = 30, delayMs = 500): Promise<void> {
     await sleep(delayMs);
   }
   throw new Error(`Port ${PORT} did not free in time`);
-}
-
-function killProcess(child: ChildProcess): Promise<void> {
-  return new Promise((resolve) => {
-    if (!child.pid) {
-      resolve();
-      return;
-    }
-    const fallback = setTimeout(resolve, 3000);
-    child.on("exit", () => {
-      clearTimeout(fallback);
-      resolve();
-    });
-    killProcessTree(child.pid);
-  });
 }
 
 async function restartWrangler(child: ChildProcess): Promise<ChildProcess> {

--- a/packages/think/src/e2e-tests/persist-false-preserves.test.ts
+++ b/packages/think/src/e2e-tests/persist-false-preserves.test.ts
@@ -14,7 +14,8 @@
  * fails on the pre-R1 code and passes after it.
  */
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
-import { spawn, execSync, type ChildProcess } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
+import { killProcess, killProcessOnPort } from "./wrangler-process";
 import { setDefaultAutoSelectFamily } from "node:net";
 import "./harden-net";
 import path from "node:path";
@@ -45,47 +46,6 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function killProcessOnPort(port: number): void {
-  try {
-    const output = execSync(
-      `lsof -tiTCP:${port} -sTCP:LISTEN 2>/dev/null || true`
-    )
-      .toString()
-      .trim();
-    if (output) {
-      for (const pid of output.split("\n").filter(Boolean)) {
-        try {
-          process.kill(Number(pid), "SIGKILL");
-        } catch {
-          // already dead
-        }
-      }
-    }
-  } catch {
-    // lsof unavailable
-  }
-}
-
-function killProcessTree(pid: number): void {
-  let children: number[] = [];
-  try {
-    children = execSync(`pgrep -P ${pid} 2>/dev/null || true`)
-      .toString()
-      .trim()
-      .split("\n")
-      .filter(Boolean)
-      .map(Number);
-  } catch {
-    // pgrep unavailable
-  }
-  for (const child of children) killProcessTree(child);
-  try {
-    process.kill(pid, "SIGKILL");
-  } catch {
-    // already dead
-  }
-}
-
 function startWrangler(): ChildProcess {
   const configPath = path.join(__dirname, "wrangler.jsonc");
   const child = spawn(
@@ -105,6 +65,9 @@ function startWrangler(): ChildProcess {
     {
       cwd: __dirname,
       stdio: ["pipe", "pipe", "pipe"],
+      // A process-group leader, so killProcess() can take down wrangler and
+      // every workerd it spawns in one signal.
+      detached: true,
       env: { ...process.env, NODE_ENV: "test" }
     }
   );
@@ -144,21 +107,6 @@ async function waitForPortFree(maxAttempts = 60, delayMs = 500): Promise<void> {
     await sleep(delayMs);
   }
   throw new Error(`Port ${PORT} did not free in time`);
-}
-
-function killProcess(child: ChildProcess): Promise<void> {
-  return new Promise((resolve) => {
-    if (!child.pid) {
-      resolve();
-      return;
-    }
-    const fallback = setTimeout(resolve, 3000);
-    child.on("exit", () => {
-      clearTimeout(fallback);
-      resolve();
-    });
-    killProcessTree(child.pid);
-  });
 }
 
 async function restartWrangler(child: ChildProcess): Promise<ChildProcess> {

--- a/packages/think/src/e2e-tests/reattach-budget.test.ts
+++ b/packages/think/src/e2e-tests/reattach-budget.test.ts
@@ -35,7 +35,8 @@
  * `packages/think/src/tests/agent-tool-reattach-recovery.test.ts`.
  */
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
-import { spawn, execSync, type ChildProcess } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
+import { killProcess, killProcessOnPort } from "./wrangler-process";
 import { setDefaultAutoSelectFamily } from "node:net";
 import "./harden-net";
 import path from "node:path";
@@ -72,47 +73,6 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function killProcessOnPort(port: number): void {
-  try {
-    const output = execSync(
-      `lsof -tiTCP:${port} -sTCP:LISTEN 2>/dev/null || true`
-    )
-      .toString()
-      .trim();
-    if (output) {
-      for (const pid of output.split("\n").filter(Boolean)) {
-        try {
-          process.kill(Number(pid), "SIGKILL");
-        } catch {
-          // already dead
-        }
-      }
-    }
-  } catch {
-    // lsof unavailable
-  }
-}
-
-function killProcessTree(pid: number): void {
-  let children: number[] = [];
-  try {
-    children = execSync(`pgrep -P ${pid} 2>/dev/null || true`)
-      .toString()
-      .trim()
-      .split("\n")
-      .filter(Boolean)
-      .map(Number);
-  } catch {
-    // pgrep unavailable
-  }
-  for (const child of children) killProcessTree(child);
-  try {
-    process.kill(pid, "SIGKILL");
-  } catch {
-    // already dead
-  }
-}
-
 function startWrangler(): ChildProcess {
   const configPath = path.join(__dirname, "wrangler.jsonc");
   const child = spawn(
@@ -132,6 +92,9 @@ function startWrangler(): ChildProcess {
     {
       cwd: __dirname,
       stdio: ["pipe", "pipe", "pipe"],
+      // A process-group leader, so killProcess() can take down wrangler and
+      // every workerd it spawns in one signal.
+      detached: true,
       env: { ...process.env, NODE_ENV: "test" }
     }
   );
@@ -171,21 +134,6 @@ async function waitForPortFree(maxAttempts = 60, delayMs = 500): Promise<void> {
     await sleep(delayMs);
   }
   throw new Error(`Port ${PORT} did not free in time`);
-}
-
-function killProcess(child: ChildProcess): Promise<void> {
-  return new Promise((resolve) => {
-    if (!child.pid) {
-      resolve();
-      return;
-    }
-    const fallback = setTimeout(resolve, 3000);
-    child.on("exit", () => {
-      clearTimeout(fallback);
-      resolve();
-    });
-    killProcessTree(child.pid);
-  });
 }
 
 async function restartWrangler(child: ChildProcess): Promise<ChildProcess> {

--- a/packages/think/src/e2e-tests/stall-recovery.test.ts
+++ b/packages/think/src/e2e-tests/stall-recovery.test.ts
@@ -14,7 +14,8 @@
  * a terminal stream error.
  */
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
-import { spawn, execSync, type ChildProcess } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
+import { killProcess, killProcessOnPort } from "./wrangler-process";
 import { setDefaultAutoSelectFamily } from "node:net";
 import "./harden-net";
 import path from "node:path";
@@ -40,27 +41,6 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function killProcessOnPort(port: number): void {
-  try {
-    const output = execSync(
-      `lsof -tiTCP:${port} -sTCP:LISTEN 2>/dev/null || true`
-    )
-      .toString()
-      .trim();
-    if (output) {
-      for (const pid of output.split("\n").filter(Boolean)) {
-        try {
-          process.kill(Number(pid), "SIGKILL");
-        } catch {
-          // already dead
-        }
-      }
-    }
-  } catch {
-    // lsof unavailable
-  }
-}
-
 function startWrangler(): ChildProcess {
   const configPath = path.join(__dirname, "wrangler.jsonc");
   const child = spawn(
@@ -80,6 +60,9 @@ function startWrangler(): ChildProcess {
     {
       cwd: __dirname,
       stdio: ["pipe", "pipe", "pipe"],
+      // A process-group leader, so killProcess() can take down wrangler and
+      // every workerd it spawns in one signal.
+      detached: true,
       env: { ...process.env, NODE_ENV: "test" }
     }
   );
@@ -106,41 +89,6 @@ async function waitForReady(maxAttempts = 60, delayMs = 1000): Promise<void> {
     await sleep(delayMs);
   }
   throw new Error("Wrangler did not start in time");
-}
-
-function killProcessTree(pid: number): void {
-  let children: number[] = [];
-  try {
-    children = execSync(`pgrep -P ${pid} 2>/dev/null || true`)
-      .toString()
-      .trim()
-      .split("\n")
-      .filter(Boolean)
-      .map(Number);
-  } catch {
-    // pgrep unavailable
-  }
-  for (const child of children) killProcessTree(child);
-  try {
-    process.kill(pid, "SIGKILL");
-  } catch {
-    // already dead
-  }
-}
-
-function killProcess(child: ChildProcess): Promise<void> {
-  return new Promise((resolve) => {
-    if (!child.pid) {
-      resolve();
-      return;
-    }
-    const fallback = setTimeout(resolve, 3000);
-    child.on("exit", () => {
-      clearTimeout(fallback);
-      resolve();
-    });
-    killProcessTree(child.pid);
-  });
 }
 
 function sendChatMessage(text: string): Promise<void> {

--- a/packages/think/src/e2e-tests/step-prompt-structured.test.ts
+++ b/packages/think/src/e2e-tests/step-prompt-structured.test.ts
@@ -17,7 +17,8 @@
  *   OPENAI_API_KEY=sk-... ANTHROPIC_API_KEY=sk-ant-... pnpm run test:e2e
  */
 import { describe, it, expect, afterAll, beforeAll } from "vitest";
-import { spawn, execSync, type ChildProcess } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
+import { killProcess, killProcessOnPort } from "./wrangler-process";
 import { setDefaultAutoSelectFamily } from "node:net";
 import "./harden-net";
 import path from "node:path";
@@ -52,45 +53,6 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function killProcessOnPort(port: number): void {
-  try {
-    const output = execSync(`lsof -ti tcp:${port} 2>/dev/null || true`)
-      .toString()
-      .trim();
-    if (output) {
-      for (const pid of output.split("\n").filter(Boolean)) {
-        try {
-          process.kill(Number(pid), "SIGKILL");
-        } catch {
-          // already exited
-        }
-      }
-    }
-  } catch {
-    // ignore
-  }
-}
-
-function killProcessTree(pid: number): void {
-  let children: number[] = [];
-  try {
-    children = execSync(`pgrep -P ${pid} 2>/dev/null || true`)
-      .toString()
-      .trim()
-      .split("\n")
-      .filter(Boolean)
-      .map(Number);
-  } catch {
-    // pgrep may be unavailable
-  }
-  for (const childPid of children) killProcessTree(childPid);
-  try {
-    process.kill(pid, "SIGKILL");
-  } catch {
-    // already dead
-  }
-}
-
 function startWrangler(): ChildProcess {
   const configPath = path.join(__dirname, "wrangler.jsonc");
   const args = [
@@ -117,6 +79,9 @@ function startWrangler(): ChildProcess {
   const child = spawn("npx", args, {
     cwd: __dirname,
     stdio: ["pipe", "pipe", "pipe"],
+    // A process-group leader, so killProcess() can take down wrangler and
+    // every workerd it spawns in one signal.
+    detached: true,
     env: { ...process.env, NODE_ENV: "test" }
   });
 
@@ -144,21 +109,6 @@ async function waitForReady(maxAttempts = 60, delayMs = 1000): Promise<void> {
     await sleep(delayMs);
   }
   throw new Error(`Wrangler did not start within ${maxAttempts * delayMs}ms`);
-}
-
-function killProcess(child: ChildProcess): Promise<void> {
-  return new Promise((resolve) => {
-    if (!child.pid) {
-      resolve();
-      return;
-    }
-    const fallback = setTimeout(resolve, 3000);
-    child.on("exit", () => {
-      clearTimeout(fallback);
-      resolve();
-    });
-    killProcessTree(child.pid);
-  });
 }
 
 /** Call a @callable method on the agent via WebSocket RPC. */

--- a/packages/think/src/e2e-tests/submission-recovery.test.ts
+++ b/packages/think/src/e2e-tests/submission-recovery.test.ts
@@ -14,7 +14,8 @@
  * mid-stream SIGKILL.
  */
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
-import { spawn, execSync, type ChildProcess } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
+import { killProcess, killProcessOnPort } from "./wrangler-process";
 import { setDefaultAutoSelectFamily } from "node:net";
 import "./harden-net";
 import path from "node:path";
@@ -38,49 +39,6 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function killProcessOnPort(port: number): void {
-  try {
-    const output = execSync(
-      `lsof -tiTCP:${port} -sTCP:LISTEN 2>/dev/null || true`
-    )
-      .toString()
-      .trim();
-    if (output) {
-      for (const pid of output.split("\n").filter(Boolean)) {
-        try {
-          process.kill(Number(pid), "SIGKILL");
-        } catch {
-          // Already dead
-        }
-      }
-    }
-  } catch {
-    // lsof not available
-  }
-}
-
-function killProcessTree(pid: number): void {
-  let children: number[] = [];
-  try {
-    children = execSync(`pgrep -P ${pid} 2>/dev/null || true`)
-      .toString()
-      .trim()
-      .split("\n")
-      .filter(Boolean)
-      .map(Number);
-  } catch {
-    // pgrep may be unavailable; killing the parent is still useful.
-  }
-  for (const childPid of children) {
-    killProcessTree(childPid);
-  }
-  try {
-    process.kill(pid, "SIGKILL");
-  } catch {
-    // Already dead
-  }
-}
-
 function startWrangler(): ChildProcess {
   const configPath = path.join(__dirname, "wrangler.jsonc");
   const child = spawn(
@@ -100,6 +58,9 @@ function startWrangler(): ChildProcess {
     {
       cwd: __dirname,
       stdio: ["pipe", "pipe", "pipe"],
+      // A process-group leader, so killProcess() can take down wrangler and
+      // every workerd it spawns in one signal.
+      detached: true,
       env: { ...process.env, NODE_ENV: "test" }
     }
   );
@@ -141,21 +102,6 @@ async function waitForPortFree(maxAttempts = 30, delayMs = 500): Promise<void> {
     await sleep(delayMs);
   }
   throw new Error(`Port ${PORT} did not free in time`);
-}
-
-function killProcess(child: ChildProcess): Promise<void> {
-  return new Promise((resolve) => {
-    if (!child.pid) {
-      resolve();
-      return;
-    }
-    const fallback = setTimeout(resolve, 3000);
-    child.on("exit", () => {
-      clearTimeout(fallback);
-      resolve();
-    });
-    killProcessTree(child.pid);
-  });
 }
 
 async function restartWrangler(child: ChildProcess): Promise<ChildProcess> {

--- a/packages/think/src/e2e-tests/task-amplification.test.ts
+++ b/packages/think/src/e2e-tests/task-amplification.test.ts
@@ -14,7 +14,8 @@
  * parent re-running the in-flight task amplifies into a full child re-run.
  */
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
-import { spawn, execSync, type ChildProcess } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
+import { killProcess, killProcessOnPort } from "./wrangler-process";
 import { setDefaultAutoSelectFamily } from "node:net";
 import "./harden-net";
 import path from "node:path";
@@ -64,47 +65,6 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function killProcessOnPort(port: number): void {
-  try {
-    const output = execSync(
-      `lsof -tiTCP:${port} -sTCP:LISTEN 2>/dev/null || true`
-    )
-      .toString()
-      .trim();
-    if (output) {
-      for (const pid of output.split("\n").filter(Boolean)) {
-        try {
-          process.kill(Number(pid), "SIGKILL");
-        } catch {
-          // already dead
-        }
-      }
-    }
-  } catch {
-    // lsof unavailable
-  }
-}
-
-function killProcessTree(pid: number): void {
-  let children: number[] = [];
-  try {
-    children = execSync(`pgrep -P ${pid} 2>/dev/null || true`)
-      .toString()
-      .trim()
-      .split("\n")
-      .filter(Boolean)
-      .map(Number);
-  } catch {
-    // pgrep unavailable
-  }
-  for (const child of children) killProcessTree(child);
-  try {
-    process.kill(pid, "SIGKILL");
-  } catch {
-    // already dead
-  }
-}
-
 function startWrangler(): ChildProcess {
   const configPath = path.join(__dirname, "wrangler.jsonc");
   const child = spawn(
@@ -124,6 +84,9 @@ function startWrangler(): ChildProcess {
     {
       cwd: __dirname,
       stdio: ["pipe", "pipe", "pipe"],
+      // A process-group leader, so killProcess() can take down wrangler and
+      // every workerd it spawns in one signal.
+      detached: true,
       env: { ...process.env, NODE_ENV: "test" }
     }
   );
@@ -163,21 +126,6 @@ async function waitForPortFree(maxAttempts = 60, delayMs = 500): Promise<void> {
     await sleep(delayMs);
   }
   throw new Error(`Port ${PORT} did not free in time`);
-}
-
-function killProcess(child: ChildProcess): Promise<void> {
-  return new Promise((resolve) => {
-    if (!child.pid) {
-      resolve();
-      return;
-    }
-    const fallback = setTimeout(resolve, 3000);
-    child.on("exit", () => {
-      clearTimeout(fallback);
-      resolve();
-    });
-    killProcessTree(child.pid);
-  });
 }
 
 async function restartWrangler(child: ChildProcess): Promise<ChildProcess> {

--- a/packages/think/src/e2e-tests/tool-rollback.test.ts
+++ b/packages/think/src/e2e-tests/tool-rollback.test.ts
@@ -16,7 +16,8 @@
  * steps — a framework reconstruction gap.
  */
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
-import { spawn, execSync, type ChildProcess } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
+import { killProcess, killProcessOnPort } from "./wrangler-process";
 import { setDefaultAutoSelectFamily } from "node:net";
 import "./harden-net";
 import path from "node:path";
@@ -48,47 +49,6 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function killProcessOnPort(port: number): void {
-  try {
-    const output = execSync(
-      `lsof -tiTCP:${port} -sTCP:LISTEN 2>/dev/null || true`
-    )
-      .toString()
-      .trim();
-    if (output) {
-      for (const pid of output.split("\n").filter(Boolean)) {
-        try {
-          process.kill(Number(pid), "SIGKILL");
-        } catch {
-          // already dead
-        }
-      }
-    }
-  } catch {
-    // lsof unavailable
-  }
-}
-
-function killProcessTree(pid: number): void {
-  let children: number[] = [];
-  try {
-    children = execSync(`pgrep -P ${pid} 2>/dev/null || true`)
-      .toString()
-      .trim()
-      .split("\n")
-      .filter(Boolean)
-      .map(Number);
-  } catch {
-    // pgrep unavailable
-  }
-  for (const child of children) killProcessTree(child);
-  try {
-    process.kill(pid, "SIGKILL");
-  } catch {
-    // already dead
-  }
-}
-
 function startWrangler(): ChildProcess {
   const configPath = path.join(__dirname, "wrangler.jsonc");
   const child = spawn(
@@ -108,6 +68,9 @@ function startWrangler(): ChildProcess {
     {
       cwd: __dirname,
       stdio: ["pipe", "pipe", "pipe"],
+      // A process-group leader, so killProcess() can take down wrangler and
+      // every workerd it spawns in one signal.
+      detached: true,
       env: { ...process.env, NODE_ENV: "test" }
     }
   );
@@ -147,21 +110,6 @@ async function waitForPortFree(maxAttempts = 60, delayMs = 500): Promise<void> {
     await sleep(delayMs);
   }
   throw new Error(`Port ${PORT} did not free in time`);
-}
-
-function killProcess(child: ChildProcess): Promise<void> {
-  return new Promise((resolve) => {
-    if (!child.pid) {
-      resolve();
-      return;
-    }
-    const fallback = setTimeout(resolve, 3000);
-    child.on("exit", () => {
-      clearTimeout(fallback);
-      resolve();
-    });
-    killProcessTree(child.pid);
-  });
 }
 
 async function restartWrangler(child: ChildProcess): Promise<ChildProcess> {

--- a/packages/think/src/e2e-tests/worker.ts
+++ b/packages/think/src/e2e-tests/worker.ts
@@ -230,7 +230,8 @@ export class ThinkToolRollbackE2EAgent extends Think<Env> {
       SELECT idx, COUNT(*) as count FROM tool_ledger GROUP BY idx ORDER BY idx
     `;
     const fiberRows = this.sql<{ c: number }>`
-      SELECT COUNT(*) as c FROM cf_agents_runs
+      SELECT (SELECT COUNT(*) FROM cf_agents_runs)
+           + (SELECT COUNT(*) FROM cf_agents_task_runs) as c
     `;
     return {
       totalExecutions: rows.reduce((n, r) => n + r.count, 0),
@@ -320,7 +321,8 @@ export class ThinkPersistFalseE2EAgent extends Think<Env> {
       SELECT idx, COUNT(*) as count FROM tool_ledger GROUP BY idx ORDER BY idx
     `;
     const fiberRows = this.sql<{ c: number }>`
-      SELECT COUNT(*) as c FROM cf_agents_runs
+      SELECT (SELECT COUNT(*) FROM cf_agents_runs)
+           + (SELECT COUNT(*) FROM cf_agents_task_runs) as c
     `;
     const assistant = this.messages.filter((m) => m.role === "assistant");
     const settledToolPartsInTranscript = assistant.reduce((n, m) => {
@@ -538,8 +540,12 @@ export class ThinkRecoveryE2EAgent extends Think<Env> {
 
   @callable()
   async hasFiberRows(): Promise<boolean> {
+    // Chat turns run on the Tasks capability (cf_agents_task_runs); facet
+    // turns stay on the legacy fiber engine (cf_agents_runs). An in-flight
+    // durable turn exists if either engine holds a row.
     const rows = this.sql<{ count: number }>`
-      SELECT COUNT(*) as count FROM cf_agents_runs
+      SELECT (SELECT COUNT(*) FROM cf_agents_runs)
+           + (SELECT COUNT(*) FROM cf_agents_task_runs) as count
     `;
     return rows[0].count > 0;
   }
@@ -630,7 +636,8 @@ export class ThinkStallRecoveryE2EAgent extends Think<Env> {
           .join("")
       : "";
     const fiberRows = this.sql<{ c: number }>`
-      SELECT COUNT(*) as c FROM cf_agents_runs
+      SELECT (SELECT COUNT(*) FROM cf_agents_runs)
+           + (SELECT COUNT(*) FROM cf_agents_task_runs) as c
     `;
     return {
       assistantMessages: assistant.length,
@@ -781,7 +788,8 @@ export class ThinkTaskParentE2EAgent extends Think<Env> {
       this.sql<{ c: number }>`SELECT COUNT(*) as c FROM parent_task_log`[0]
         ?.c ?? 0;
     const fiberRows = this.sql<{ c: number }>`
-      SELECT COUNT(*) as c FROM cf_agents_runs
+      SELECT (SELECT COUNT(*) FROM cf_agents_runs)
+           + (SELECT COUNT(*) FROM cf_agents_task_runs) as c
     `;
     let child: {
       totalExecutions: number;
@@ -887,7 +895,8 @@ export class ThinkAgentToolNaturalParentE2EAgent extends Think<Env> {
       LIMIT 1
     `;
     const fiberRows = this.sql<{ c: number }>`
-      SELECT COUNT(*) as c FROM cf_agents_runs
+      SELECT (SELECT COUNT(*) FROM cf_agents_runs)
+           + (SELECT COUNT(*) FROM cf_agents_task_runs) as c
     `;
     let child: {
       totalExecutions: number;
@@ -1005,7 +1014,8 @@ export class ThinkSlowChildE2EAgent extends Think<Env> {
       SELECT idx, COUNT(*) as count FROM tool_ledger GROUP BY idx ORDER BY idx
     `;
     const fiberRows = this.sql<{ c: number }>`
-      SELECT COUNT(*) as c FROM cf_agents_runs
+      SELECT (SELECT COUNT(*) FROM cf_agents_runs)
+           + (SELECT COUNT(*) FROM cf_agents_task_runs) as c
     `;
     return {
       totalExecutions: rows.reduce((n, r) => n + r.count, 0),
@@ -1077,7 +1087,8 @@ export class ThinkSlowChildParentE2EAgent extends Think<Env> {
       LIMIT 1
     `;
     const fiberRows = this.sql<{ c: number }>`
-      SELECT COUNT(*) as c FROM cf_agents_runs
+      SELECT (SELECT COUNT(*) FROM cf_agents_runs)
+           + (SELECT COUNT(*) FROM cf_agents_task_runs) as c
     `;
     let child: {
       maxIndex: number;
@@ -1768,8 +1779,10 @@ export class ThinkSubmissionRecoveryE2EAgent extends Think<Env> {
 
   @callable()
   async hasFiberRows(): Promise<boolean> {
+    // Either durable engine may hold the in-flight turn (see hasFiberRows above).
     const rows = this.sql<{ c: number }>`
-      SELECT COUNT(*) as c FROM cf_agents_runs
+      SELECT (SELECT COUNT(*) FROM cf_agents_runs)
+           + (SELECT COUNT(*) FROM cf_agents_task_runs) as c
     `;
     return (rows[0]?.c ?? 0) > 0;
   }
@@ -1945,8 +1958,10 @@ export class ThinkMessengerRecoveryE2EAgent extends Think<Env> {
 
   @callable()
   async hasFiberRows(): Promise<boolean> {
+    // Either durable engine may hold the in-flight turn (see hasFiberRows above).
     const rows = this.sql<{ c: number }>`
-      SELECT COUNT(*) as c FROM cf_agents_runs
+      SELECT (SELECT COUNT(*) FROM cf_agents_runs)
+           + (SELECT COUNT(*) FROM cf_agents_task_runs) as c
     `;
     return (rows[0]?.c ?? 0) > 0;
   }
@@ -2074,8 +2089,10 @@ export class ThinkWorkflowRecoveryE2EAgent extends Think<Env> {
 
   @callable()
   async hasFiberRows(): Promise<boolean> {
+    // Either durable engine may hold the in-flight turn (see hasFiberRows above).
     const rows = this.sql<{ c: number }>`
-      SELECT COUNT(*) as c FROM cf_agents_runs
+      SELECT (SELECT COUNT(*) FROM cf_agents_runs)
+           + (SELECT COUNT(*) FROM cf_agents_task_runs) as c
     `;
     return (rows[0]?.c ?? 0) > 0;
   }
@@ -2257,8 +2274,10 @@ export class ThinkActionPauseRecoveryE2EAgent extends Think<Env> {
 
   @callable()
   async hasFiberRows(): Promise<boolean> {
+    // Either durable engine may hold the in-flight turn (see hasFiberRows above).
     const rows = this.sql<{ c: number }>`
-      SELECT COUNT(*) as c FROM cf_agents_runs
+      SELECT (SELECT COUNT(*) FROM cf_agents_runs)
+           + (SELECT COUNT(*) FROM cf_agents_task_runs) as c
     `;
     return (rows[0]?.c ?? 0) > 0;
   }

--- a/packages/think/src/e2e-tests/workflow-recovery.test.ts
+++ b/packages/think/src/e2e-tests/workflow-recovery.test.ts
@@ -12,7 +12,8 @@
  *     via the workflow-notification drain replay
  */
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
-import { spawn, execSync, type ChildProcess } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
+import { killProcess, killProcessOnPort } from "./wrangler-process";
 import { setDefaultAutoSelectFamily } from "node:net";
 import "./harden-net";
 import path from "node:path";
@@ -34,49 +35,6 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function killProcessOnPort(port: number): void {
-  try {
-    const output = execSync(
-      `lsof -tiTCP:${port} -sTCP:LISTEN 2>/dev/null || true`
-    )
-      .toString()
-      .trim();
-    if (output) {
-      for (const pid of output.split("\n").filter(Boolean)) {
-        try {
-          process.kill(Number(pid), "SIGKILL");
-        } catch {
-          // Already dead
-        }
-      }
-    }
-  } catch {
-    // lsof not available
-  }
-}
-
-function killProcessTree(pid: number): void {
-  let children: number[] = [];
-  try {
-    children = execSync(`pgrep -P ${pid} 2>/dev/null || true`)
-      .toString()
-      .trim()
-      .split("\n")
-      .filter(Boolean)
-      .map(Number);
-  } catch {
-    // pgrep may be unavailable; killing the parent is still useful.
-  }
-  for (const childPid of children) {
-    killProcessTree(childPid);
-  }
-  try {
-    process.kill(pid, "SIGKILL");
-  } catch {
-    // Already dead
-  }
-}
-
 function startWrangler(): ChildProcess {
   const configPath = path.join(__dirname, "wrangler.jsonc");
   const child = spawn(
@@ -96,6 +54,9 @@ function startWrangler(): ChildProcess {
     {
       cwd: __dirname,
       stdio: ["pipe", "pipe", "pipe"],
+      // A process-group leader, so killProcess() can take down wrangler and
+      // every workerd it spawns in one signal.
+      detached: true,
       env: { ...process.env, NODE_ENV: "test" }
     }
   );
@@ -137,21 +98,6 @@ async function waitForPortFree(maxAttempts = 30, delayMs = 500): Promise<void> {
     await sleep(delayMs);
   }
   throw new Error(`Port ${PORT} did not free in time`);
-}
-
-function killProcess(child: ChildProcess): Promise<void> {
-  return new Promise((resolve) => {
-    if (!child.pid) {
-      resolve();
-      return;
-    }
-    const fallback = setTimeout(resolve, 3000);
-    child.on("exit", () => {
-      clearTimeout(fallback);
-      resolve();
-    });
-    killProcessTree(child.pid);
-  });
 }
 
 async function restartWrangler(child: ChildProcess): Promise<ChildProcess> {

--- a/packages/think/src/e2e-tests/wrangler-process.ts
+++ b/packages/think/src/e2e-tests/wrangler-process.ts
@@ -1,0 +1,65 @@
+import { execSync, type ChildProcess } from "node:child_process";
+
+/**
+ * SIGKILL whatever still listens on `port` — a server left behind by an
+ * aborted earlier run.
+ */
+export function killProcessOnPort(port: number): void {
+  try {
+    const output = execSync(
+      `lsof -tiTCP:${port} -sTCP:LISTEN 2>/dev/null || true`
+    )
+      .toString()
+      .trim();
+    for (const pid of output.split("\n").filter(Boolean)) {
+      try {
+        process.kill(Number(pid), "SIGKILL");
+      } catch {
+        // Already dead.
+      }
+    }
+  } catch {
+    // lsof unavailable.
+  }
+}
+
+/**
+ * SIGKILL a `wrangler dev` process and everything it spawned, atomically.
+ *
+ * The child must have been spawned with `detached: true`, which makes it the
+ * leader of its own process group; killing the group takes down `npm exec`,
+ * wrangler, esbuild, and every workerd in one signal.
+ *
+ * Walking the tree with `pgrep -P` and killing children first does not
+ * work: each `pgrep` takes milliseconds, and in that window wrangler — still
+ * alive — notices workerd died and respawns it. The respawned workerd is
+ * not in the snapshot, survives the walk as an orphan, and keeps the port,
+ * so the "restarted" wrangler fails with "Address already in use" and the
+ * interrupted turn the test meant to recover simply finishes on the old
+ * server instead.
+ */
+export function killProcess(child: ChildProcess): Promise<void> {
+  return new Promise((resolve) => {
+    if (!child.pid) {
+      resolve();
+      return;
+    }
+    // Clear the fallback timer once the child exits — an uncleared timer
+    // keeps the vitest worker's event loop alive and can push teardown past
+    // the pool's termination window.
+    const fallback = setTimeout(resolve, 3000);
+    child.on("exit", () => {
+      clearTimeout(fallback);
+      resolve();
+    });
+    try {
+      process.kill(-child.pid, "SIGKILL");
+    } catch {
+      try {
+        process.kill(child.pid, "SIGKILL");
+      } catch {
+        // Already dead.
+      }
+    }
+  });
+}

--- a/packages/think/src/think.ts
+++ b/packages/think/src/think.ts
@@ -15181,10 +15181,16 @@ export class Think<
   }
 
   /**
-   * Classify a recovered turn as `retry` or `continue`. A pre-stream turn with no
-   * partial re-runs its user message (`retryTargetUserId`), unless the stream is
-   * already terminal — a terminal stream is never retried (it completed), only
-   * its submission is reconciled in dispatch.
+   * Classify a recovered turn as `retry` or `continue`. A turn that left no
+   * persisted partial re-runs its user message (`retryTargetUserId`), unless
+   * the stream is already terminal — a terminal stream is never retried (it
+   * completed), only its submission is reconciled in dispatch.
+   *
+   * The stream row is opened before inference, so an interrupted turn can
+   * have a stream id and still nothing to continue from; what decides retry is
+   * the absence of persisted content and a leaf that is still the turn's user
+   * message. Mirrors `AIChatAgent`'s empty-partial new-turn rule (#1691): a
+   * `continue` here would find no assistant message and skip the turn.
    */
   private async _classifyRecoveredThinkTurn(
     input: ClassifyRecoveredTurnInput
@@ -15196,7 +15202,6 @@ export class Think<
       input.streamStatus === "completed" || input.streamStatus === "error";
     const retryTargetUserId = await this._recoverablePreStreamUserId(
       input.snapshot,
-      input.streamId,
       input.partial
     );
     const shouldRetryBase = retryTargetUserId !== null && !streamIsTerminal;
@@ -15338,14 +15343,12 @@ export class Think<
 
   private async _recoverablePreStreamUserId(
     snapshot: ChatFiberSnapshot | null,
-    streamId: string,
     partial: { text: string; parts: unknown[] }
   ): Promise<string | null> {
     if (
       !snapshot ||
       snapshot.continuation ||
       !snapshot.latestUserMessageId ||
-      streamId ||
       partial.text ||
       partial.parts.length > 0
     ) {


### PR DESCRIPTION
## Why the nightly has been red

The Nightly E2E workflow has failed every night since Aug 24 (last green Aug 23). Three jobs fail; the diagnosis below is from running each failing file locally against an untouched `main` checkout and comparing against the fix.

### 1. `E2E: think (chat recovery)` and `E2E: agents (fiber eviction)`: the harness could not actually kill wrangler

Every Think e2e file and the agents e2e helpers killed `wrangler dev` by walking the process tree with `pgrep -P` and SIGKILLing children first. Each `pgrep` is a synchronous spawn that takes milliseconds; in that window wrangler, still alive, saw workerd die and respawned it. The respawned workerd was not in the snapshot, survived the walk as an orphan (parent pid 1), and kept listening on the test's fixed port. Symptoms in every red run: `Address already in use (127.0.0.1:1879x)` on the restart, `Updated and ready` printed by a process the test believed dead, `Port 1879x did not free in time`, and "interrupted" turns that simply finished on the old server so nothing was ever recovered.

Fix: spawn wrangler `detached: true` (a process-group leader) and SIGKILL the group, which takes down `npm exec`, wrangler, esbuild and every workerd in one signal. This is what the ai-chat harness already did. The 14 Think copies of the helper are replaced by one shared `packages/think/src/e2e-tests/wrangler-process.ts`; the agents copies are fixed in place.

With the harness fixed, three real problems surfaced underneath:

- **Think `hasFiberRows` probes only counted `cf_agents_runs`.** Chat turns run on the Tasks capability (`cf_agents_task_runs`) since #2194, so "is a turn in flight" answered no. The probes now count both engines, as ai-chat's already did.
- **The "post-persist chat request failure surface" test asserted `onError` is not called.** Since chat turns are Tasks runs, a failed turn is reported through `onError` (Agent wires `onError` into Tasks). The test now expects the failure in the `onError` log as well as the chat error frame; the gap it documented is closed.
- **A Think turn interrupted before its first chunk was never retried** (real bug, `@cloudflare/think` patch changeset). Think opens the resumable stream row before inference, so such a turn has a stream id, no persisted partial, and a user message as its latest leaf. `_recoverablePreStreamUserId` returned null as soon as a stream id existed, the turn was classified `continue`, `continueLastTurn` found no assistant message and marked the incident `skipped`, and a parent tailing that child through agent tools sealed the run as `error: Agent tool run was interrupted before the child could finish.` The stream id is no longer treated as evidence of content; the absence of a persisted partial plus a leaf that is still the turn's user message decides retry, mirroring `AIChatAgent`'s empty-partial new-turn rule (#1691).

### 2. `E2E: ai-chat (SIGKILL recovery)`: the work-budget exhaustion agent relied on the old work counter

`ChatWorkBudgetExhaustAgent` emitted a single `text-start` and hung, relying on the KV work counter that credited a chunk at production time. Since #2223 the work meter is derived from the stream log, where a chunk counts once its packed segment (`CHUNK_BUFFER_SIZE`, ten chunks) is flushed, so the agent banked zero work and a zero budget could never be exceeded. The agent now emits exactly one segment's worth of chunks before hanging.

### 3. `E2E: agents (browser connector)`: broken shell quoting in the workflow

```yaml
run: echo "version=$(node -p 'require(\"playwright/package.json\").version')" >> $GITHUB_OUTPUT
```

Inside single quotes bash passes `\"` through literally, so node sees `require(\"...\")` and throws `SyntaxError: Invalid or unexpected token`. The step still exits 0 (the `echo` succeeds with an empty version), so it never failed the job, but the Playwright cache key has been empty in every run. Fixed in the five nightly steps and the one in `pullrequest.yml`. The browser-connector job's actual red state is a separate, intermittent `[vitest-pool]: Worker exited unexpectedly` after all 13 tests pass (green on Sep 9 and 10, red on Sep 8 and 11); that test file already carries EPIPE hardening for it and this PR does not change it.

## Verification (local, `wrangler dev` per file)

| Suite | Before (main) | After |
| --- | --- | --- |
| Think e2e, all 14 files | `chat-recovery` 5/5 failed, `reattach-budget` failed | 29 passed, 4 skipped, 0 port/reload incidents |
| ai-chat e2e (`test:e2e`) | `work_budget_exceeded` case failed | 6 files, 11 tests passed |
| agents e2e (`test:e2e`) | `fiber-eviction` failed on the restart | 9 files, 19 tests passed |
| Think unit suite | unaffected | unchanged, green |

`oxfmt --check .` and `oxlint` clean.

<!-- devin-review-badge-begin -->

---

<a href="https://cloudflare.devinenterprise.com/review/cloudflare/agents/pull/2256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->