### PR TITLE
refactor(agents): WebSockets owns the Agent protocol's state sync and connection flags

### DIFF
--- a/.changeset/capnweb-transport.md
+++ b/.changeset/capnweb-transport.md
@@ -4,7 +4,7 @@
 
 `WebSockets` speaks the Agent protocol for plain hosts, and gains a Cap'n Web transport.
 
-- A plain Durable Object composed with `WebSockets` now works with `useAgent` and `AgentClient`: the capability sends the identity frame on connect (`identity: false` opts out) and serves `callables` — an `RpcTarget` whose prototype methods are the host's remote interface.
+- A plain Durable Object composed with `WebSockets` now works with `useAgent` and `AgentClient`: the capability sends the identity frame on connect (`protocol: false` leaves the connect sequence to the host) and serves `callables` — an `RpcTarget` whose prototype methods are the host's remote interface.
 - `useAgent({ transport })` and `AgentClient({ transport })` pick the wire. `"cf-websocket"` (default) is the hibernating socket; `call()`/`stub` send JSON `rpc` frames. `"capnweb"` runs one Cap'n Web session that carries protocol frames and serves `callables` natively: `call()`/`stub` invoke them directly, an `RpcTarget` result is a live stub, a `ReadableStream` streams, calls pipeline. The Durable Object stays in memory while a capnweb connection is open. PartySocket still owns reconnection on both.
 - `@callable()` decorators remain the JSON-wire interface of `Agent`; an Agent wanting native calls passes `callables`.
 - The experimental `?__agents_rpc=capnweb` endpoint from 0.23.0 is removed.

--- a/.changeset/websockets-state.md
+++ b/.changeset/websockets-state.md
@@ -2,12 +2,8 @@
 "agents": minor
 ---
 
-`WebSockets` syncs a `State` capability over connections, so `useAgent().state` and `setState()` work against a plain Durable Object.
+The `WebSockets` capability now owns the Agent protocol's state sync and per-connection flags, for `Agent` and plain hosts alike.
 
-```ts
-readonly state = new State({ initialState: { count: 0 } });
-readonly webSockets = new WebSockets({ state: this.state });
-readonly lifecycle = Lifecycle.install(this).use(this.state).use(this.webSockets);
-```
-
-The current value is pushed to each new connection after the identity frame, a client's `cf_agent_state` frame is validated by the host's `validateStateChange` and applied (a rejected one is answered with `cf_agent_state_error`), and every change is broadcast to the other connections. `broadcastState()` pushes a host-side change. Works on both transports. Without the option, state is never sent or accepted over connections.
+- `state` takes a `State` capability. The current value is pushed to each new connection after identity, a client's `cf_agent_state` frame goes through the host's `validateStateChange` (a readonly connection is refused, a rejected change gets a generic `cf_agent_state_error`), and `broadcastState(source)` pushes a change to every protocol-enabled connection but its source — wire it to the `State`'s `onChanged`. So `useAgent().state` and `setState()` work against a plain Durable Object.
+- `protocol` and `readonly` are per-connection policies decided at accept time; `sendIdentity()`, `sendState()`, `applyStateFrame()`, `isReadonly()`/`setReadonly()`, and `isProtocolEnabled()`/`setProtocolEnabled()` are the capability's surface for hosts that drive the sequence themselves. The `identity` option from the previous changeset is replaced by `protocol`.
+- The readonly and no-protocol flags, their `_cf_` storage in connection state, and the wrapper that hides them from `connection.state` move out of `Agent` into `agents/websockets` (`registerInternalConnectionKeys` for a host's own keys). `Agent`'s public methods and wire behaviour are unchanged; it passes `protocol: false` and drives its connect sequence through the capability after its facet routing decision.

--- a/.changeset/websockets-state.md
+++ b/.changeset/websockets-state.md
@@ -1,0 +1,13 @@
+---
+"agents": minor
+---
+
+`WebSockets` syncs a `State` capability over connections, so `useAgent().state` and `setState()` work against a plain Durable Object.
+
+```ts
+readonly state = new State({ initialState: { count: 0 } });
+readonly webSockets = new WebSockets({ state: this.state });
+readonly lifecycle = Lifecycle.install(this).use(this.state).use(this.webSockets);
+```
+
+The current value is pushed to each new connection after the identity frame, a client's `cf_agent_state` frame is validated by the host's `validateStateChange` and applied (a rejected one is answered with `cf_agent_state_error`), and every change is broadcast to the other connections. `broadcastState()` pushes a host-side change. Works on both transports. Without the option, state is never sent or accepted over connections.

--- a/docs/agents/lifecycle.md
+++ b/docs/agents/lifecycle.md
@@ -315,13 +315,10 @@ it claims upgrades, dispatches handlers inside the host invocation boundary,
 and answers `getConnections()`:
 
 ```ts
-import { State } from "agents/state";
 import { WebSockets } from "agents/websockets";
 
 export class MyObject extends DurableObject<Env> {
-  readonly state = new State({ initialState: { count: 0 } });
   readonly webSockets = new WebSockets({
-    state: this.state,
     handlers: {
       onConnect: (connection) => {
         connection.setState({ authenticated: true });
@@ -332,9 +329,7 @@ export class MyObject extends DurableObject<Env> {
     },
     callables: new MyCallables(this)
   });
-  readonly lifecycle = Lifecycle.install(this)
-    .use(this.state)
-    .use(this.webSockets);
+  readonly lifecycle = Lifecycle.install(this).use(this.webSockets);
 }
 ```
 
@@ -357,15 +352,27 @@ Durable Object is reachable from `useAgent` and `AgentClient` exactly like an
   calling, a `ReadableStream` streams, and chained calls pipeline. Methods
   run through the host invocation boundary with the calling connection in
   scope.
-- `state` takes a `State` capability (from `agents/state`) and syncs it
-  over connections: the current value is pushed to each new connection
-  after identity, a client's `cf_agent_state` frame is validated by the
-  host and applied, a rejected one is answered with
-  `cf_agent_state_error`, and every change is broadcast to the other
-  connections. Call `webSockets.broadcastState()` after a host-side
-  `set()` to push it. Without this option state is never sent or accepted
-  over connections. So `useAgent().state` and `setState()` work against a
-  plain Durable Object.
+- `state` takes a `State` capability (from `agents/state`) and syncs it over
+  connections, so `useAgent().state` and `setState()` work against a plain
+  host:
+
+  ```ts
+  readonly state = new State({ initialState: { count: 0 } });
+  readonly webSockets = new WebSockets({ state: this.state });
+  readonly lifecycle = Lifecycle.install(this)
+    .use(this.state)
+    .use(this.webSockets);
+  ```
+
+  The current value is pushed to each new connection after identity. A
+  client's `cf_agent_state` frame goes through the `State` capability, so the
+  host's own `validateStateChange` decides; a rejected change is answered
+  with `cf_agent_state_error` and applies nothing. Accepted changes broadcast
+  to the other connections, and `webSockets.broadcastState()` pushes a
+  host-side `set()`. This is distinct from `connection.setState()`, which is
+  per-connection and never leaves the host. Without the option, state is
+  never sent or accepted over connections.
+
 - Any other frame goes to `handlers.onMessage`.
 
 An `Agent` adds no new surface for this: its `@callable()`-decorated methods

--- a/docs/agents/lifecycle.md
+++ b/docs/agents/lifecycle.md
@@ -315,10 +315,13 @@ it claims upgrades, dispatches handlers inside the host invocation boundary,
 and answers `getConnections()`:
 
 ```ts
+import { State } from "agents/state";
 import { WebSockets } from "agents/websockets";
 
 export class MyObject extends DurableObject<Env> {
+  readonly state = new State({ initialState: { count: 0 } });
   readonly webSockets = new WebSockets({
+    state: this.state,
     handlers: {
       onConnect: (connection) => {
         connection.setState({ authenticated: true });
@@ -329,7 +332,9 @@ export class MyObject extends DurableObject<Env> {
     },
     callables: new MyCallables(this)
   });
-  readonly lifecycle = Lifecycle.install(this).use(this.webSockets);
+  readonly lifecycle = Lifecycle.install(this)
+    .use(this.state)
+    .use(this.webSockets);
 }
 ```
 
@@ -352,6 +357,15 @@ Durable Object is reachable from `useAgent` and `AgentClient` exactly like an
   calling, a `ReadableStream` streams, and chained calls pipeline. Methods
   run through the host invocation boundary with the calling connection in
   scope.
+- `state` takes a `State` capability (from `agents/state`) and syncs it
+  over connections: the current value is pushed to each new connection
+  after identity, a client's `cf_agent_state` frame is validated by the
+  host and applied, a rejected one is answered with
+  `cf_agent_state_error`, and every change is broadcast to the other
+  connections. Call `webSockets.broadcastState()` after a host-side
+  `set()` to push it. Without this option state is never sent or accepted
+  over connections. So `useAgent().state` and `setState()` work against a
+  plain Durable Object.
 - Any other frame goes to `handlers.onMessage`.
 
 An `Agent` adds no new surface for this: its `@callable()`-decorated methods

--- a/docs/agents/lifecycle.md
+++ b/docs/agents/lifecycle.md
@@ -342,8 +342,20 @@ Durable Object is reachable from `useAgent` and `AgentClient` exactly like an
 `Agent`:
 
 - On connect it sends the identity frame, which resolves the client's
-  `ready` and `identified`. Pass `identity: false` to opt out; `Agent` does,
-  because it sends its own under `sendIdentityOnConnect`.
+  `ready` and `identified`, then the current state when `state` is set.
+  `protocol` controls this: `true` (default) for every connection, a
+  function to decide per connection — `false` marks it no-protocol, so it
+  gets no protocol text frames on connect or by broadcast but still sends
+  and receives ordinary messages and callables — or `false` to have the
+  host drive the sequence itself with `sendIdentity()` and `sendState()`.
+  `Agent` passes `false`, because it must decide whether a connection
+  belongs to a facet before any frame is sent.
+- `readonly` decides per connection whether state writes over the wire are
+  refused; `setReadonly()` flips it later. Both flags are stored in the
+  connection's own state under `_cf_` keys, hidden from `connection.state`
+  and preserved across `setState`, so they survive hibernation. `Agent`'s
+  `isConnectionReadonly`, `setConnectionReadonly`, and
+  `isConnectionProtocolEnabled` delegate to the same storage.
 - `callables` is an `RpcTarget` whose prototype methods are the host's
   complete remote interface, reached through `call()` and `stub`. On the
   `cf-websocket` wire the capability answers them as JSON `rpc` frames. On
@@ -357,7 +369,11 @@ Durable Object is reachable from `useAgent` and `AgentClient` exactly like an
   host:
 
   ```ts
-  readonly state = new State({ initialState: { count: 0 } });
+  readonly state = new State({
+    initialState: { count: 0 },
+    // The state owner decides who hears about a change.
+    onChanged: (_state, source) => this.webSockets.broadcastState(source)
+  });
   readonly webSockets = new WebSockets({ state: this.state });
   readonly lifecycle = Lifecycle.install(this)
     .use(this.state)
@@ -365,13 +381,14 @@ Durable Object is reachable from `useAgent` and `AgentClient` exactly like an
   ```
 
   The current value is pushed to each new connection after identity. A
-  client's `cf_agent_state` frame goes through the `State` capability, so the
-  host's own `validateStateChange` decides; a rejected change is answered
-  with `cf_agent_state_error` and applies nothing. Accepted changes broadcast
-  to the other connections, and `webSockets.broadcastState()` pushes a
-  host-side `set()`. This is distinct from `connection.setState()`, which is
-  per-connection and never leaves the host. Without the option, state is
-  never sent or accepted over connections.
+  client's `cf_agent_state` frame goes through the `State` capability, so
+  the host's own `validateStateChange` decides; a readonly connection is
+  refused, and a rejected change is logged server-side and answered with a
+  generic `cf_agent_state_error`. `broadcastState(source)` pushes the
+  current value to every protocol-enabled connection except `source`. This
+  is distinct from `connection.setState()`, which is per-connection and
+  never leaves the host. Without the option, state is never sent or
+  accepted over connections.
 
 - Any other frame goes to `handlers.onMessage`.
 

--- a/examples/next/websockets/README.md
+++ b/examples/next/websockets/README.md
@@ -70,8 +70,8 @@ reports that an `RpcTarget` cannot be put in a JSON frame.
   request, the shape a webhook or scheduled job takes to reach clients.
 - **One validation path.** Every write — socket frame, callable, HTTP —
   goes through `post()`, so nickname and message bounds apply everywhere.
-- **`identity: false`** turns the identity frame off for hosts that speak
-  their own protocol. `Agent` passes it.
+- **`protocol`** decides which connections get the identity and state
+  frames; `false` leaves the connect sequence to the host, as `Agent` does.
 
 This is a demo: anyone who knows a room name can join it. Put
 authentication in front of `routeAgentRequest` before deploying something

--- a/packages/agents/src/dynamic-agents/dynamic-agents.ts
+++ b/packages/agents/src/dynamic-agents/dynamic-agents.ts
@@ -1,4 +1,9 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import {
+  ensureConnectionWrapped,
+  getConnectionRawState,
+  setConnectionProtocolEnabled
+} from "../websockets/connection-flags";
 import { nanoid } from "nanoid";
 import type {
   Connection,
@@ -948,7 +953,7 @@ export class DynamicAgentsInternal extends LifecycleCapability {
     if (!connection || !this.connectionHasChildTarget(connection)) {
       return null;
     }
-    this.#host._ensureConnectionWrapped(connection);
+    ensureConnectionWrapped(connection);
     connection.setState(state);
     return this.getForwardedState(connection);
   }
@@ -957,7 +962,7 @@ export class DynamicAgentsInternal extends LifecycleCapability {
     connection: Connection,
     ownerPath: ReadonlyArray<AgentPathStep>
   ): DynamicAgentConnectionMeta | null {
-    this.#host._ensureConnectionWrapped(connection);
+    ensureConnectionWrapped(connection);
     const outerUri = this.#host._unsafe_getConnectionFlag(
       connection,
       CF_SUB_AGENT_OUTER_URL_KEY
@@ -986,7 +991,7 @@ export class DynamicAgentsInternal extends LifecycleCapability {
   connectionTargetPath(
     connection: Connection
   ): ReadonlyArray<AgentPathStep> | null {
-    this.#host._ensureConnectionWrapped(connection);
+    ensureConnectionWrapped(connection);
     const outerUri = this.#host._unsafe_getConnectionFlag(
       connection,
       CF_SUB_AGENT_OUTER_URL_KEY
@@ -1034,7 +1039,7 @@ export class DynamicAgentsInternal extends LifecycleCapability {
   }
 
   connectionHasChildTarget(connection: Connection): boolean {
-    this.#host._ensureConnectionWrapped(connection);
+    ensureConnectionWrapped(connection);
     return (
       typeof this.#host._unsafe_getConnectionFlag(
         connection,
@@ -1149,7 +1154,7 @@ export class DynamicAgentsInternal extends LifecycleCapability {
     child: DynamicAgentWebSocketEndpoint;
     meta: DynamicAgentConnectionMeta;
   } | null> {
-    this.#host._ensureConnectionWrapped(connection);
+    ensureConnectionWrapped(connection);
     const outerUri = this.#host._unsafe_getConnectionFlag(
       connection,
       CF_SUB_AGENT_OUTER_URL_KEY
@@ -1236,7 +1241,7 @@ export class DynamicAgentsInternal extends LifecycleCapability {
         this.#host.setConnectionReadonly(connection, true);
       }
       if (!this.#host.shouldSendProtocolMessages(connection, { request })) {
-        this.#host._setConnectionNoProtocol(connection);
+        setConnectionProtocolEnabled(connection, false);
       }
 
       const childTags = await this.#host.getConnectionTags(connection, {
@@ -1374,7 +1379,7 @@ export class DynamicAgentsInternal extends LifecycleCapability {
     } as unknown as Connection;
 
     stored.connection = connection;
-    this.#host._ensureConnectionWrapped(connection);
+    ensureConnectionWrapped(connection);
     return connection;
   }
 
@@ -1446,8 +1451,7 @@ export class DynamicAgentsInternal extends LifecycleCapability {
   }
 
   getRawConnectionState(connection: Connection): unknown {
-    this.#host._ensureConnectionWrapped(connection);
-    return this.#host._rawStateAccessors.get(connection)?.getRaw() ?? null;
+    return getConnectionRawState(connection);
   }
 
   getForwardedState(connection: Connection): unknown {

--- a/packages/agents/src/dynamic-agents/host.ts
+++ b/packages/agents/src/dynamic-agents/host.ts
@@ -87,16 +87,12 @@ export interface DynamicAgentHostPort {
       tag?: string
     ): Iterable<Connection<TState>>;
   };
-  _ensureConnectionWrapped(connection: Connection): void;
   _unsafe_getConnectionFlag(connection: Connection, key: string): unknown;
   _unsafe_setConnectionFlag(
     connection: Connection,
     key: string,
     value: unknown
   ): void;
-  readonly _rawStateAccessors: {
-    get(connection: Connection): { getRaw(): unknown } | undefined;
-  };
   shouldConnectionBeReadonly(
     connection: Connection,
     context: { request: Request }
@@ -106,7 +102,6 @@ export interface DynamicAgentHostPort {
     connection: Connection,
     context: { request: Request }
   ): boolean;
-  _setConnectionNoProtocol(connection: Connection): void;
   getConnectionTags(
     connection: Connection,
     context: { request: Request }

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -98,6 +98,15 @@ import {
 } from "./lifecycle/current-agent";
 import { getAgentByName, type AgentOptions } from "./agent-routing";
 import { WebSockets } from "./websockets";
+import {
+  ensureConnectionWrapped,
+  getConnectionFlag,
+  isConnectionProtocolEnabled as connectionProtocolEnabled,
+  isConnectionReadonly as connectionReadonly,
+  registerInternalConnectionKeys,
+  setConnectionFlag,
+  setConnectionReadonly as markConnectionReadonly
+} from "./websockets/connection-flags";
 export {
   getAgentByName,
   routeAgentRequest,
@@ -328,16 +337,6 @@ function isRPCRequest(msg: unknown): msg is RPCRequest {
 /**
  * Type guard for state update messages
  */
-function isStateUpdateMessage(msg: unknown): msg is StateUpdateMessage {
-  return (
-    typeof msg === "object" &&
-    msg !== null &&
-    "type" in msg &&
-    msg.type === MessageType.CF_AGENT_STATE &&
-    "state" in msg
-  );
-}
-
 export {
   callable,
   unstable_callable,
@@ -765,71 +764,19 @@ const LEGACY_SCHEMA_VERSION_ROW_ID = "cf_schema_version";
 const DEFAULT_STATE = {} as unknown;
 
 /**
- * Internal key used to store the readonly flag in connection state.
- * Prefixed with _cf_ to avoid collision with user state keys.
- */
-const CF_READONLY_KEY = "_cf_readonly";
-
-/**
- * Internal key used to store the no-protocol flag in connection state.
- * When set, protocol messages (identity, state sync, MCP servers) are not
- * sent to this connection — neither on connect nor via broadcasts.
- */
-const CF_NO_PROTOCOL_KEY = "_cf_no_protocol";
-
-/**
  * Internal key used to store voice call state in connection state.
  * Used by the voice mixin to track whether a connection is in an active call.
  */
 const CF_VOICE_IN_CALL_KEY = "_cf_voiceInCall";
 
-/**
- * The set of all internal keys stored in connection state that must be
- * hidden from user code and preserved across setState calls.
- */
-const CF_INTERNAL_KEYS: ReadonlySet<string> = new Set([
-  CF_READONLY_KEY,
-  CF_NO_PROTOCOL_KEY,
+// Agent's own per-connection flags ride the WebSockets capability's
+// connection-state namespace: hidden from `connection.state`, preserved
+// across user `setState`, and carried through hibernation.
+registerInternalConnectionKeys(
   CF_VOICE_IN_CALL_KEY,
   CF_SUB_AGENT_OUTER_URL_KEY,
   CF_SUB_AGENT_TAGS_KEY
-]);
-
-/** Check if a raw connection state object contains any internal keys. */
-function rawHasInternalKeys(raw: Record<string, unknown>): boolean {
-  for (const key of Object.keys(raw)) {
-    if (CF_INTERNAL_KEYS.has(key)) return true;
-  }
-  return false;
-}
-
-/** Return a copy of `raw` with all internal keys removed, or null if no user keys remain. */
-function stripInternalKeys(
-  raw: Record<string, unknown>
-): Record<string, unknown> | null {
-  const result: Record<string, unknown> = {};
-  let hasUserKeys = false;
-  for (const key of Object.keys(raw)) {
-    if (!CF_INTERNAL_KEYS.has(key)) {
-      result[key] = raw[key];
-      hasUserKeys = true;
-    }
-  }
-  return hasUserKeys ? result : null;
-}
-
-/** Return a copy containing only the internal keys present in `raw`. */
-function extractInternalFlags(
-  raw: Record<string, unknown>
-): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
-  for (const key of Object.keys(raw)) {
-    if (CF_INTERNAL_KEYS.has(key)) {
-      result[key] = raw[key];
-    }
-  }
-  return result;
-}
+);
 
 /** Max length for error strings broadcast to clients. */
 const MAX_ERROR_STRING_LENGTH = 500;
@@ -1143,22 +1090,6 @@ export class Agent<
    * from paths that do not pass through the capability (facet bridging,
    * direct calls).
    */
-  private readonly _webSockets = new WebSockets({
-    handlers: {
-      onConnect: (connection, ctx) => this.onConnect(connection, ctx),
-      onMessage: (connection, message) => this.onMessage(connection, message),
-      onClose: (connection, code, reason, wasClean) =>
-        this.onClose(connection, code, reason, wasClean),
-      onError: (connection, error) => this.onError(connection, error)
-    },
-    // Agent answers its own rpc frames in onMessage (facet bridging,
-    // StreamingResponse) and sends identity itself under its
-    // sendIdentityOnConnect policy, so it configures neither here.
-    identity: false,
-    getConnectionTags: (connection, ctx) =>
-      this.getConnectionTags(connection, ctx)
-  });
-
   /**
    * Durable state: the `cf_agents_state` row, lazy load, validated persistence.
    * `initialState` stays on Agent (a subclass field, initialized after this
@@ -1173,6 +1104,25 @@ export class Agent<
       this.validateStateChange(nextState as TState, source),
     onChanged: (nextState, source) =>
       this._handleStateChanged(nextState as TState, source)
+  });
+
+  private readonly _webSockets = new WebSockets({
+    handlers: {
+      onConnect: (connection, ctx) => this.onConnect(connection, ctx),
+      onMessage: (connection, message) => this.onMessage(connection, message),
+      onClose: (connection, code, reason, wasClean) =>
+        this.onClose(connection, code, reason, wasClean),
+      onError: (connection, error) => this.onError(connection, error)
+    },
+    // Agent answers its own rpc frames in onMessage (facet bridging,
+    // StreamingResponse). It also drives the connect sequence itself —
+    // `sendIdentity`/`sendState` after deciding whether the connection
+    // belongs to a facet — so the capability provides the protocol but
+    // does not run it: `protocol: false`.
+    protocol: false,
+    state: this._state,
+    getConnectionTags: (connection, ctx) =>
+      this.getConnectionTags(connection, ctx)
   });
 
   /** Run user initialization after lifecycle components have started. */
@@ -1224,13 +1174,6 @@ export class Agent<
    * Used by internal flag methods (readonly, no-protocol) to read/write
    * _cf_-prefixed keys without going through the user-facing state/setState.
    */
-  private _rawStateAccessors = new WeakMap<
-    Connection,
-    {
-      getRaw: () => Record<string, unknown> | null;
-      setRaw: (state: unknown) => unknown;
-    }
-  >();
 
   /**
    * Cached persistence-hook dispatch mode, computed once in the constructor.
@@ -2138,7 +2081,7 @@ export class Agent<
       ) {
         return;
       }
-      this._ensureConnectionWrapped(connection);
+      ensureConnectionWrapped(connection);
       return runInInvocation(
         { agent: this, connection, request: undefined, email: undefined },
         async () => {
@@ -2154,31 +2097,10 @@ export class Agent<
             return this._tryCatch(() => _onMessage(connection, message));
           }
 
-          if (isStateUpdateMessage(parsed)) {
-            // Check if connection is readonly
-            if (this.isConnectionReadonly(connection)) {
-              // Send error response back to the connection
-              connection.send(
-                JSON.stringify({
-                  type: MessageType.CF_AGENT_STATE_ERROR,
-                  error: "Connection is readonly"
-                })
-              );
-              return;
-            }
-            try {
-              this._state.set(parsed.state as TState, connection);
-            } catch (e) {
-              // validateStateChange (or another sync error) rejected the update.
-              // Log the full error server-side, send a generic message to the client.
-              console.error("[Agent] State update rejected:", e);
-              connection.send(
-                JSON.stringify({
-                  type: MessageType.CF_AGENT_STATE_ERROR,
-                  error: "State update rejected"
-                })
-              );
-            }
+          // State frames: readonly check, validation, error replies — all
+          // the capability's. Root sockets never reach here with one (the
+          // capability consumed it); bridged facet connections do.
+          if (this._webSockets.applyStateFrame(connection, parsed)) {
             return;
           }
 
@@ -2275,7 +2197,7 @@ export class Agent<
 
     const _onConnect = this.onConnect.bind(this);
     this.onConnect = async (connection: Connection, ctx: ConnectionContext) => {
-      this._ensureConnectionWrapped(connection);
+      ensureConnectionWrapped(connection);
       const subAgentOuterUrl = ctx.request.headers.get(
         SUB_AGENT_OUTER_URL_HEADER
       );
@@ -2342,13 +2264,7 @@ export class Agent<
                   );
                 }
               }
-              connection.send(
-                JSON.stringify({
-                  name: this.name,
-                  agent: camelCaseToKebabCase(this._ParentClass.name),
-                  type: MessageType.CF_AGENT_IDENTITY
-                })
-              );
+              this._webSockets.sendIdentity(connection);
             }
 
             const wasExcludedFromStateInitBroadcast =
@@ -2364,12 +2280,7 @@ export class Agent<
             }
 
             if (currentState !== undefined) {
-              connection.send(
-                JSON.stringify({
-                  state: currentState,
-                  type: MessageType.CF_AGENT_STATE
-                })
-              );
+              this._webSockets.sendState(connection);
             }
 
             connection.send(
@@ -2379,7 +2290,7 @@ export class Agent<
               })
             );
           } else {
-            this._setConnectionNoProtocol(connection);
+            this._webSockets.setProtocolEnabled(connection, false);
           }
 
           this._emit("connect", { connectionId: connection.id });
@@ -2658,123 +2569,12 @@ export class Agent<
   }
 
   /**
-   * Wraps connection.state and connection.setState so that internal
-   * _cf_-prefixed flags (readonly, no-protocol) are hidden from user code
-   * and cannot be accidentally overwritten.
-   *
-   * Idempotent — safe to call multiple times on the same connection.
-   * After hibernation, the _rawStateAccessors WeakMap is empty but the
-   * connection's state getter still reads from the persisted WebSocket
-   * attachment. Calling this method re-captures the raw getter so that
-   * predicate methods (isConnectionReadonly, isConnectionProtocolEnabled)
-   * work correctly post-hibernation.
-   */
-  private _ensureConnectionWrapped(connection: Connection) {
-    if (this._rawStateAccessors.has(connection)) return;
-
-    // Hibernating lifecycle connections expose attachment-backed state as a
-    // configurable accessor. Virtual facet connections use a data property,
-    // so retain both projections below.
-    const descriptor = Object.getOwnPropertyDescriptor(connection, "state");
-
-    let getRaw: () => Record<string, unknown> | null;
-    let setRaw: (state: unknown) => unknown;
-
-    if (descriptor?.get) {
-      // Accessor property — bind the original getter directly.
-      // The getter reads from the serialized WebSocket attachment, so it
-      // always returns the latest value even after setState updates it.
-      getRaw = descriptor.get.bind(connection) as () => Record<
-        string,
-        unknown
-      > | null;
-      setRaw = connection.setState.bind(connection);
-    } else {
-      // Data property — track raw state in a closure variable.
-      // Reading `connection.state` after our override would call our filtered
-      // getter (circular), so we snapshot the value here and keep it in sync.
-      let rawState = (connection.state ?? null) as Record<
-        string,
-        unknown
-      > | null;
-      getRaw = () => rawState;
-      setRaw = (state: unknown) => {
-        rawState = state as Record<string, unknown> | null;
-        return rawState;
-      };
-    }
-
-    this._rawStateAccessors.set(connection, { getRaw, setRaw });
-
-    // Override state getter to hide all internal _cf_ flags from user code
-    Object.defineProperty(connection, "state", {
-      configurable: true,
-      enumerable: true,
-      get() {
-        const raw = getRaw();
-        if (raw != null && typeof raw === "object" && rawHasInternalKeys(raw)) {
-          return stripInternalKeys(raw);
-        }
-        return raw;
-      }
-    });
-
-    // Override setState to preserve internal flags when user sets state
-    Object.defineProperty(connection, "setState", {
-      configurable: true,
-      writable: true,
-      value(stateOrFn: unknown | ((prev: unknown) => unknown)) {
-        const raw = getRaw();
-        const flags =
-          raw != null && typeof raw === "object"
-            ? extractInternalFlags(raw as Record<string, unknown>)
-            : {};
-        const hasFlags = Object.keys(flags).length > 0;
-
-        let newUserState: unknown;
-        if (typeof stateOrFn === "function") {
-          // Pass only the user-visible state (without internal flags) to the callback
-          const userVisible = hasFlags
-            ? stripInternalKeys(raw as Record<string, unknown>)
-            : raw;
-          newUserState = (stateOrFn as (prev: unknown) => unknown)(userVisible);
-        } else {
-          newUserState = stateOrFn;
-        }
-
-        // Merge back internal flags if any were set
-        if (hasFlags) {
-          if (newUserState != null && typeof newUserState === "object") {
-            return setRaw({
-              ...(newUserState as Record<string, unknown>),
-              ...flags
-            });
-          }
-          // User set null — store just the flags
-          return setRaw(flags);
-        }
-        return setRaw(newUserState);
-      }
-    });
-  }
-
-  /**
    * Mark a connection as readonly or readwrite
    * @param connection The connection to mark
    * @param readonly Whether the connection should be readonly (default: true)
    */
   setConnectionReadonly(connection: Connection, readonly = true) {
-    this._ensureConnectionWrapped(connection);
-    const accessors = this._rawStateAccessors.get(connection)!;
-    const raw = (accessors.getRaw() as Record<string, unknown> | null) ?? {};
-    if (readonly) {
-      accessors.setRaw({ ...raw, [CF_READONLY_KEY]: true });
-    } else {
-      // Remove the key entirely instead of storing false — avoids dead keys
-      // accumulating in the connection attachment.
-      const { [CF_READONLY_KEY]: _, ...rest } = raw;
-      accessors.setRaw(Object.keys(rest).length > 0 ? rest : null);
-    }
+    markConnectionReadonly(connection, readonly);
   }
 
   /**
@@ -2786,12 +2586,7 @@ export class Agent<
    * @returns True if the connection is readonly
    */
   isConnectionReadonly(connection: Connection): boolean {
-    this._ensureConnectionWrapped(connection);
-    const raw = this._rawStateAccessors.get(connection)!.getRaw() as Record<
-      string,
-      unknown
-    > | null;
-    return !!raw?.[CF_READONLY_KEY];
+    return connectionReadonly(connection);
   }
 
   /**
@@ -2807,12 +2602,7 @@ export class Agent<
    * @internal
    */
   _unsafe_getConnectionFlag(connection: Connection, key: string): unknown {
-    this._ensureConnectionWrapped(connection);
-    const raw = this._rawStateAccessors.get(connection)!.getRaw() as Record<
-      string,
-      unknown
-    > | null;
-    return raw?.[key];
+    return getConnectionFlag(connection, key);
   }
 
   /**
@@ -2820,8 +2610,8 @@ export class Agent<
    *
    * Write an internal `_cf_`-prefixed flag to the raw connection state,
    * bypassing the user-facing state wrapper. The key must be registered
-   * in `CF_INTERNAL_KEYS` so it is preserved across user `setState` calls
-   * and hidden from `connection.state`.
+   * with `registerInternalConnectionKeys` so it is preserved across user
+   * `setState` calls and hidden from `connection.state`.
    *
    * @internal
    */
@@ -2830,15 +2620,7 @@ export class Agent<
     key: string,
     value: unknown
   ): void {
-    this._ensureConnectionWrapped(connection);
-    const accessors = this._rawStateAccessors.get(connection)!;
-    const raw = (accessors.getRaw() as Record<string, unknown> | null) ?? {};
-    if (value === undefined) {
-      const { [key]: _, ...rest } = raw;
-      accessors.setRaw(Object.keys(rest).length > 0 ? rest : null);
-    } else {
-      accessors.setRaw({ ...raw, [key]: value });
-    }
+    setConnectionFlag(connection, key, value);
   }
 
   /**
@@ -2888,23 +2670,7 @@ export class Agent<
    * @returns True if the connection receives protocol messages
    */
   isConnectionProtocolEnabled(connection: Connection): boolean {
-    this._ensureConnectionWrapped(connection);
-    const raw = this._rawStateAccessors.get(connection)!.getRaw() as Record<
-      string,
-      unknown
-    > | null;
-    return !raw?.[CF_NO_PROTOCOL_KEY];
-  }
-
-  /**
-   * Mark a connection as having protocol messages disabled.
-   * Called internally when shouldSendProtocolMessages returns false.
-   */
-  private _setConnectionNoProtocol(connection: Connection) {
-    this._ensureConnectionWrapped(connection);
-    const accessors = this._rawStateAccessors.get(connection)!;
-    const raw = (accessors.getRaw() as Record<string, unknown> | null) ?? {};
-    accessors.setRaw({ ...raw, [CF_NO_PROTOCOL_KEY]: true });
+    return connectionProtocolEnabled(connection);
   }
 
   /**

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -2264,7 +2264,12 @@ export class Agent<
                   );
                 }
               }
-              this._webSockets.sendIdentity(connection);
+              // Agent's public identity: the logical name (a facet's routed
+              // name is an internal encoding of it) and the exported class.
+              this._webSockets.sendIdentity(connection, {
+                name: this.name,
+                agent: camelCaseToKebabCase(this._ParentClass.name)
+              });
             }
 
             const wasExcludedFromStateInitBroadcast =

--- a/packages/agents/src/tests/capabilities/lifecycle.ts
+++ b/packages/agents/src/tests/capabilities/lifecycle.ts
@@ -11,6 +11,7 @@ import {
   type LifecycleJobContext,
   type LifecycleJobPushOptions
 } from "../../lifecycle";
+import { State } from "../../state";
 import { WebSockets } from "../../websockets";
 
 type StartupProps = { label: string };
@@ -689,5 +690,44 @@ export class RetryableStartObject extends DurableObject<Cloudflare.Env> {
 
   getHostStarts(): number {
     return this.hostStarts;
+  }
+}
+
+/**
+ * A plain Durable Object composed with `State` and `WebSockets`, wired so
+ * the capability syncs state over connections. Used to prove `useAgent`'s
+ * state surface works against a non-Agent host.
+ */
+export class StatefulPlainObject extends DurableObject<Cloudflare.Env> {
+  readonly #state = new State<{ count: number }>({
+    initialState: { count: 0 },
+    validateStateChange: (next) => {
+      if (next.count < 0) throw new Error("count must not be negative");
+    }
+  });
+
+  readonly #webSockets = new WebSockets({
+    state: this.#state as unknown as State<unknown>,
+    handlers: {
+      onMessage: (connection, message) => {
+        connection.send(`echo:${String(message)}`);
+      }
+    }
+  });
+
+  readonly lifecycle = Lifecycle.install(this)
+    .use(this.#state)
+    .use(this.#webSockets);
+
+  /** Host-side change, then push it to connections. */
+  async setCount(count: number): Promise<void> {
+    await this.lifecycle.start();
+    this.#state.set({ count });
+    this.#webSockets.broadcastState();
+  }
+
+  async getCount(): Promise<number | undefined> {
+    await this.lifecycle.start();
+    return this.#state.get()?.count;
   }
 }

--- a/packages/agents/src/tests/capabilities/lifecycle.ts
+++ b/packages/agents/src/tests/capabilities/lifecycle.ts
@@ -699,15 +699,26 @@ export class RetryableStartObject extends DurableObject<Cloudflare.Env> {
  * state surface works against a non-Agent host.
  */
 export class StatefulPlainObject extends DurableObject<Cloudflare.Env> {
-  readonly #state = new State<{ count: number }>({
+  readonly #state: State<{ count: number }> = new State<{ count: number }>({
     initialState: { count: 0 },
     validateStateChange: (next) => {
       if (next.count < 0) throw new Error("count must not be negative");
+    },
+    // The state owner decides who hears about a change: everyone but the
+    // connection it came from.
+    onChanged: (_next, source): void => {
+      this.#webSockets.broadcastState(source);
     }
   });
 
-  readonly #webSockets = new WebSockets({
+  readonly #webSockets: WebSockets = new WebSockets({
     state: this.#state,
+    // `?readonly=1` connections may not write; `?silent=1` connections get
+    // no protocol frames at all.
+    readonly: (_connection, { request }) =>
+      new URL(request.url).searchParams.has("readonly"),
+    protocol: (_connection, { request }) =>
+      !new URL(request.url).searchParams.has("silent"),
     handlers: {
       onMessage: (connection, message) => {
         connection.send(`echo:${String(message)}`);
@@ -719,11 +730,22 @@ export class StatefulPlainObject extends DurableObject<Cloudflare.Env> {
     .use(this.#state)
     .use(this.#webSockets);
 
-  /** Host-side change, then push it to connections. */
+  /** Host-side change; onChanged broadcasts it. */
   async setCount(count: number): Promise<void> {
     await this.lifecycle.start();
     this.#state.set({ count });
-    this.#webSockets.broadcastState();
+  }
+
+  async isReadonly(id: string): Promise<boolean | undefined> {
+    await this.lifecycle.start();
+    const connection = this.#webSockets.getConnection(id);
+    return connection ? this.#webSockets.isReadonly(connection) : undefined;
+  }
+
+  async setReadonly(id: string, readonly: boolean): Promise<void> {
+    await this.lifecycle.start();
+    const connection = this.#webSockets.getConnection(id);
+    if (connection) this.#webSockets.setReadonly(connection, readonly);
   }
 
   async getCount(): Promise<number | undefined> {

--- a/packages/agents/src/tests/capabilities/lifecycle.ts
+++ b/packages/agents/src/tests/capabilities/lifecycle.ts
@@ -701,8 +701,16 @@ export class RetryableStartObject extends DurableObject<Cloudflare.Env> {
 export class StatefulPlainObject extends DurableObject<Cloudflare.Env> {
   readonly #state: State<{ count: number }> = new State<{ count: number }>({
     initialState: { count: 0 },
-    validateStateChange: (next) => {
+    validateStateChange: (next, source) => {
       if (next.count < 0) throw new Error("count must not be negative");
+      // The ambient context names the connection the change came from,
+      // exactly as an Agent's validateStateChange sees it.
+      const ambient = getCurrentAgent().connection;
+      if (source !== "server" && ambient?.id !== source.id) {
+        throw new Error(
+          "validator ran outside the sending connection's context"
+        );
+      }
     },
     // The state owner decides who hears about a change: everyone but the
     // connection it came from.

--- a/packages/agents/src/tests/capabilities/lifecycle.ts
+++ b/packages/agents/src/tests/capabilities/lifecycle.ts
@@ -707,7 +707,7 @@ export class StatefulPlainObject extends DurableObject<Cloudflare.Env> {
   });
 
   readonly #webSockets = new WebSockets({
-    state: this.#state as unknown as State<unknown>,
+    state: this.#state,
     handlers: {
       onMessage: (connection, message) => {
         connection.send(`echo:${String(message)}`);

--- a/packages/agents/src/tests/lifecycle/websockets-capability.test.ts
+++ b/packages/agents/src/tests/lifecycle/websockets-capability.test.ts
@@ -457,6 +457,35 @@ describe("state sync over connections on a plain host", () => {
     }
   });
 
+  it("broadcasts to a second socket that shares the sender's _pk", async () => {
+    // `_pk` is client-supplied, so two live sockets can carry one id.
+    // Excluding the sender by id would starve the other socket.
+    const name = crypto.randomUUID();
+    const shared = `shared-${name}`;
+    const url = hostUrl(name);
+    url.searchParams.set("_pk", shared);
+    const alice = await upgrade(url);
+    const aliceNext = frameReader(alice);
+    await aliceNext();
+    await aliceNext();
+    const bob = await upgrade(url);
+    const bobNext = frameReader(bob);
+    await bobNext();
+    await bobNext();
+    try {
+      alice.send(
+        JSON.stringify({ type: "cf_agent_state", state: { count: 5 } })
+      );
+      expect(await bobNext()).toEqual({
+        type: "cf_agent_state",
+        state: { count: 5 }
+      });
+    } finally {
+      alice.close(1000, "done");
+      bob.close(1000, "done");
+    }
+  });
+
   it("syncs state over the Cap'n Web transport too", async () => {
     const name = crypto.randomUUID();
     const url = hostUrl(name);

--- a/packages/agents/src/tests/lifecycle/websockets-capability.test.ts
+++ b/packages/agents/src/tests/lifecycle/websockets-capability.test.ts
@@ -430,9 +430,11 @@ describe("state sync over connections on a plain host", () => {
       socket.send(
         JSON.stringify({ type: "cf_agent_state", state: { count: -1 } })
       );
-      expect(await next()).toMatchObject({
+      // The validator's reason stays server-side; the client gets the
+      // same generic answer an Agent gives.
+      expect(await next()).toEqual({
         type: "cf_agent_state_error",
-        error: "count must not be negative"
+        error: "State update rejected"
       });
       expect(await env.StatefulPlainObject.getByName(name).getCount()).toBe(0);
     } finally {
@@ -523,6 +525,72 @@ describe("state sync over connections on a plain host", () => {
       expect(await env.StatefulPlainObject.getByName(name).getCount()).toBe(3);
     } finally {
       pipe[Symbol.dispose]();
+    }
+  });
+
+  it("refuses state writes from a readonly connection", async () => {
+    const name = crypto.randomUUID();
+    const url = hostUrl(name);
+    url.searchParams.set("readonly", "1");
+    url.searchParams.set("_pk", "ro-" + name);
+    const socket = await upgrade(url);
+    const next = frameReader(socket);
+    await next();
+    await next();
+    const host = env.StatefulPlainObject.getByName(name);
+    try {
+      socket.send(
+        JSON.stringify({ type: "cf_agent_state", state: { count: 9 } })
+      );
+      expect(await next()).toEqual({
+        type: "cf_agent_state_error",
+        error: "Connection is readonly"
+      });
+      expect(await host.getCount()).toBe(0);
+      expect(await host.isReadonly("ro-" + name)).toBe(true);
+
+      // Flags never leak into the user-visible connection state, and
+      // flipping the flag later takes effect.
+      await host.setReadonly("ro-" + name, false);
+      socket.send(
+        JSON.stringify({ type: "cf_agent_state", state: { count: 9 } })
+      );
+      await new Promise((r) => setTimeout(r, 50));
+      expect(await host.getCount()).toBe(9);
+    } finally {
+      socket.close(1000, "done");
+    }
+  });
+
+  it("sends no protocol frames to a no-protocol connection, on connect or broadcast", async () => {
+    const name = crypto.randomUUID();
+    const url = hostUrl(name);
+    url.searchParams.set("silent", "1");
+    const silent = await upgrade(url);
+    const silentFrames: string[] = [];
+    silent.addEventListener("message", (e) =>
+      silentFrames.push(String(e.data))
+    );
+    const loud = await upgrade(hostUrl(name));
+    const loudNext = frameReader(loud);
+    await loudNext();
+    await loudNext();
+    try {
+      // The silent socket still works for the host's own frames.
+      silent.send("hello");
+      await new Promise((r) => setTimeout(r, 50));
+      expect(silentFrames).toEqual(["echo:hello"]);
+
+      await env.StatefulPlainObject.getByName(name).setCount(4);
+      expect(await loudNext()).toEqual({
+        type: "cf_agent_state",
+        state: { count: 4 }
+      });
+      await new Promise((r) => setTimeout(r, 50));
+      expect(silentFrames).toEqual(["echo:hello"]);
+    } finally {
+      silent.close(1000, "done");
+      loud.close(1000, "done");
     }
   });
 });

--- a/packages/agents/src/tests/lifecycle/websockets-capability.test.ts
+++ b/packages/agents/src/tests/lifecycle/websockets-capability.test.ts
@@ -369,3 +369,131 @@ describe("plain host Agent protocol on the Cap'n Web wire", () => {
     }
   });
 });
+
+/**
+ * A plain host that composes `State` with `WebSockets` gets the hook's
+ * whole state surface: pushed on connect, updated from the client,
+ * broadcast to everyone else, and validated by the host.
+ */
+describe("state sync over connections on a plain host", () => {
+  const hostUrl = (name: string) =>
+    new URL(`/agents/stateful-plain-object/${name}`, "https://example.com");
+
+  it("pushes state on connect, after identity", async () => {
+    const name = crypto.randomUUID();
+    const socket = await upgrade(hostUrl(name));
+    const next = frameReader(socket);
+    try {
+      expect(await next()).toMatchObject({ type: "cf_agent_identity", name });
+      expect(await next()).toEqual({
+        type: "cf_agent_state",
+        state: { count: 0 }
+      });
+    } finally {
+      socket.close(1000, "done");
+    }
+  });
+
+  it("applies a client update and broadcasts it to the others", async () => {
+    const name = crypto.randomUUID();
+    const alice = await upgrade(hostUrl(name));
+    const aliceNext = frameReader(alice);
+    await aliceNext();
+    await aliceNext();
+    const bob = await upgrade(hostUrl(name));
+    const bobNext = frameReader(bob);
+    await bobNext();
+    await bobNext();
+    try {
+      alice.send(
+        JSON.stringify({ type: "cf_agent_state", state: { count: 7 } })
+      );
+      // Bob sees it; the sender is excluded since it already has the value.
+      expect(await bobNext()).toEqual({
+        type: "cf_agent_state",
+        state: { count: 7 }
+      });
+      expect(await env.StatefulPlainObject.getByName(name).getCount()).toBe(7);
+    } finally {
+      alice.close(1000, "done");
+      bob.close(1000, "done");
+    }
+  });
+
+  it("answers a rejected update with cf_agent_state_error and changes nothing", async () => {
+    const name = crypto.randomUUID();
+    const socket = await upgrade(hostUrl(name));
+    const next = frameReader(socket);
+    await next();
+    await next();
+    try {
+      socket.send(
+        JSON.stringify({ type: "cf_agent_state", state: { count: -1 } })
+      );
+      expect(await next()).toMatchObject({
+        type: "cf_agent_state_error",
+        error: "count must not be negative"
+      });
+      expect(await env.StatefulPlainObject.getByName(name).getCount()).toBe(0);
+    } finally {
+      socket.close(1000, "done");
+    }
+  });
+
+  it("broadcasts a host-side change", async () => {
+    const name = crypto.randomUUID();
+    const socket = await upgrade(hostUrl(name));
+    const next = frameReader(socket);
+    await next();
+    await next();
+    try {
+      await env.StatefulPlainObject.getByName(name).setCount(42);
+      expect(await next()).toEqual({
+        type: "cf_agent_state",
+        state: { count: 42 }
+      });
+    } finally {
+      socket.close(1000, "done");
+    }
+  });
+
+  it("syncs state over the Cap'n Web transport too", async () => {
+    const name = crypto.randomUUID();
+    const url = hostUrl(name);
+    url.searchParams.set(CAPNWEB_TRANSPORT_QUERY, CAPNWEB_TRANSPORT_VALUE);
+    const socket = await upgrade(url);
+    const frames: Frame[] = [];
+    const waiters: Array<(frame: Frame) => void> = [];
+    class Inbox extends RpcTarget {
+      message(value: string) {
+        let frame: Frame;
+        try {
+          frame = JSON.parse(value) as Frame;
+        } catch {
+          return;
+        }
+        const waiter = waiters.shift();
+        if (waiter) waiter(frame);
+        else frames.push(frame);
+      }
+    }
+    const next = () =>
+      frames.length > 0
+        ? Promise.resolve(frames.shift() as Frame)
+        : new Promise<Frame>((resolve) => waiters.push(resolve));
+    const pipe = newWebSocketRpcSession<TransportHostPipe>(socket, new Inbox());
+    try {
+      expect(await next()).toMatchObject({ type: "cf_agent_identity" });
+      expect(await next()).toEqual({
+        type: "cf_agent_state",
+        state: { count: 0 }
+      });
+      await pipe[CAPNWEB_TRANSPORT_SEND](
+        JSON.stringify({ type: "cf_agent_state", state: { count: 3 } })
+      );
+      expect(await env.StatefulPlainObject.getByName(name).getCount()).toBe(3);
+    } finally {
+      pipe[Symbol.dispose]();
+    }
+  });
+});

--- a/packages/agents/src/tests/spike-sub-agent-routing.test.ts
+++ b/packages/agents/src/tests/spike-sub-agent-routing.test.ts
@@ -113,6 +113,28 @@ describe("Spike: sub-agent routing via facet Fetcher", () => {
     ws.close();
   });
 
+  it("a facet's identity frame carries its logical name, not the routed DO name", async () => {
+    // The identity frame is built by the WebSockets capability from what
+    // Agent hands it: `this.name` decodes a path-scoped facet's internal
+    // `cf-agents:v2:` routed name back to the child name the client used.
+    const parent = uniqueName();
+    const child = uniqueName();
+
+    const ws = await openWS(parent, "spike-sub-child", child);
+    const [identity] = await collectMessages(
+      ws,
+      1,
+      (data) => typeof data === "string" && data.includes("cf_agent_identity")
+    );
+    expect(JSON.parse(identity)).toEqual({
+      type: "cf_agent_identity",
+      name: child,
+      agent: "spike-sub-child"
+    });
+
+    ws.close();
+  });
+
   it("establishes a WebSocket through the parent → facet chain", async () => {
     const parent = uniqueName();
     const child = uniqueName();

--- a/packages/agents/src/tests/worker.ts
+++ b/packages/agents/src/tests/worker.ts
@@ -11,11 +11,13 @@ export { CapabilityHarnessObject } from "./capabilities/harness.ts";
 import type { CapabilityHarnessObject } from "./capabilities/harness.ts";
 export {
   PlainLifecycleObject,
-  RetryableStartObject
+  RetryableStartObject,
+  StatefulPlainObject
 } from "./capabilities/lifecycle.ts";
 import type {
   PlainLifecycleObject,
-  RetryableStartObject
+  RetryableStartObject,
+  StatefulPlainObject
 } from "./capabilities/lifecycle.ts";
 export {
   ScheduledLifecycleObject,
@@ -213,6 +215,7 @@ export type Env = {
   CapabilityHarnessObject: DurableObjectNamespace<CapabilityHarnessObject>;
   PlainLifecycleObject: DurableObjectNamespace<PlainLifecycleObject>;
   RetryableStartObject: DurableObjectNamespace<RetryableStartObject>;
+  StatefulPlainObject: DurableObjectNamespace<StatefulPlainObject>;
   ScheduledLifecycleObject: DurableObjectNamespace<ScheduledLifecycleObject>;
   SchedulerHarnessObject: DurableObjectNamespace<SchedulerHarnessObject>;
   SchedulerStartupWarnObject: DurableObjectNamespace<SchedulerStartupWarnObject>;

--- a/packages/agents/src/tests/wrangler.jsonc
+++ b/packages/agents/src/tests/wrangler.jsonc
@@ -21,6 +21,10 @@
         "name": "PlainLifecycleObject"
       },
       {
+        "class_name": "StatefulPlainObject",
+        "name": "StatefulPlainObject"
+      },
+      {
         "class_name": "RetryableStartObject",
         "name": "RetryableStartObject"
       },
@@ -409,6 +413,7 @@
       "new_sqlite_classes": [
         "CapabilityHarnessObject",
         "PlainLifecycleObject",
+        "StatefulPlainObject",
         "RetryableStartObject",
         "ScheduledLifecycleObject",
         "SchedulerHarnessObject",

--- a/packages/agents/src/websockets/connection-flags.ts
+++ b/packages/agents/src/websockets/connection-flags.ts
@@ -1,0 +1,221 @@
+import type { Connection } from "../lifecycle";
+
+/**
+ * Internal per-connection flags, stored inside the connection's own state
+ * under `_cf_`-prefixed keys so they ride the hibernation attachment (or a
+ * bridged connection's synced state) and survive a wake. The state wrapper
+ * installed by {@link ensureConnectionWrapped} hides them from
+ * `connection.state` and preserves them across user `setState` calls.
+ *
+ * Owned by the WebSockets capability; `Agent` and framework mixins reach it
+ * through the capability or, for their own keys, through
+ * {@link registerInternalConnectionKeys}.
+ */
+
+/** A readonly connection may not update host state. */
+export const CF_READONLY_KEY = "_cf_readonly";
+
+/**
+ * A no-protocol connection receives no protocol text frames (identity,
+ * state sync, MCP servers) — neither on connect nor via broadcasts.
+ */
+export const CF_NO_PROTOCOL_KEY = "_cf_no_protocol";
+
+const internalKeys = new Set<string>([CF_READONLY_KEY, CF_NO_PROTOCOL_KEY]);
+
+/**
+ * Register additional `_cf_`-prefixed keys a host or mixin stores in
+ * connection state, so they are hidden from `connection.state` and kept
+ * across user `setState` calls like the capability's own flags.
+ */
+export function registerInternalConnectionKeys(...keys: string[]): void {
+  for (const key of keys) internalKeys.add(key);
+}
+
+function rawHasInternalKeys(raw: Record<string, unknown>): boolean {
+  for (const key of Object.keys(raw)) {
+    if (internalKeys.has(key)) return true;
+  }
+  return false;
+}
+
+/** A copy of `raw` without internal keys, or null when no user keys remain. */
+function stripInternalKeys(
+  raw: Record<string, unknown>
+): Record<string, unknown> | null {
+  const result: Record<string, unknown> = {};
+  let hasUserKeys = false;
+  for (const key of Object.keys(raw)) {
+    if (!internalKeys.has(key)) {
+      result[key] = raw[key];
+      hasUserKeys = true;
+    }
+  }
+  return hasUserKeys ? result : null;
+}
+
+/** A copy containing only the internal keys present in `raw`. */
+function extractInternalFlags(
+  raw: Record<string, unknown>
+): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(raw)) {
+    if (internalKeys.has(key)) result[key] = raw[key];
+  }
+  return result;
+}
+
+type RawAccessors = {
+  getRaw: () => Record<string, unknown> | null;
+  setRaw: (state: unknown) => unknown;
+};
+
+/**
+ * Per-connection raw accessors, keyed by the live connection object. The
+ * map is in-memory: after hibernation it is empty, and every entry point
+ * re-wraps the connection on first use.
+ */
+const rawStateAccessors = new WeakMap<Connection, RawAccessors>();
+
+/**
+ * Wrap `connection.state` / `connection.setState` so internal flags are
+ * hidden from user code and preserved when user code sets state.
+ * Idempotent, and safe to call after hibernation.
+ */
+export function ensureConnectionWrapped(connection: Connection): void {
+  if (rawStateAccessors.has(connection)) return;
+
+  // Hibernating connections expose attachment-backed state as a
+  // configurable accessor. Virtual (bridged) connections use a data
+  // property, so both projections are retained below.
+  const descriptor = Object.getOwnPropertyDescriptor(connection, "state");
+
+  let getRaw: RawAccessors["getRaw"];
+  let setRaw: RawAccessors["setRaw"];
+
+  if (descriptor?.get) {
+    // Accessor property: bind the original getter. It reads the serialized
+    // attachment, so it always returns the latest value after setState.
+    getRaw = descriptor.get.bind(connection) as RawAccessors["getRaw"];
+    setRaw = connection.setState.bind(connection);
+  } else {
+    // Data property: track the raw value in a closure. Reading
+    // `connection.state` after the override would hit the filtered getter.
+    let rawState = (connection.state ?? null) as Record<string, unknown> | null;
+    getRaw = () => rawState;
+    setRaw = (state: unknown) => {
+      rawState = state as Record<string, unknown> | null;
+      return rawState;
+    };
+  }
+
+  rawStateAccessors.set(connection, { getRaw, setRaw });
+
+  Object.defineProperty(connection, "state", {
+    configurable: true,
+    enumerable: true,
+    get() {
+      const raw = getRaw();
+      if (raw != null && typeof raw === "object" && rawHasInternalKeys(raw)) {
+        return stripInternalKeys(raw);
+      }
+      return raw;
+    }
+  });
+
+  Object.defineProperty(connection, "setState", {
+    configurable: true,
+    writable: true,
+    value(stateOrFn: unknown | ((prev: unknown) => unknown)) {
+      const raw = getRaw();
+      const flags =
+        raw != null && typeof raw === "object"
+          ? extractInternalFlags(raw as Record<string, unknown>)
+          : {};
+      const hasFlags = Object.keys(flags).length > 0;
+
+      let newUserState: unknown;
+      if (typeof stateOrFn === "function") {
+        // The callback sees only user-visible state.
+        const userVisible = hasFlags
+          ? stripInternalKeys(raw as Record<string, unknown>)
+          : raw;
+        newUserState = (stateOrFn as (prev: unknown) => unknown)(userVisible);
+      } else {
+        newUserState = stateOrFn;
+      }
+
+      if (hasFlags) {
+        if (newUserState != null && typeof newUserState === "object") {
+          return setRaw({
+            ...(newUserState as Record<string, unknown>),
+            ...flags
+          });
+        }
+        // User set null: keep just the flags.
+        return setRaw(flags);
+      }
+      return setRaw(newUserState);
+    }
+  });
+}
+
+/** The raw connection state, internal flags included. */
+export function getConnectionRawState(
+  connection: Connection
+): Record<string, unknown> | null {
+  ensureConnectionWrapped(connection);
+  return rawStateAccessors.get(connection)!.getRaw();
+}
+
+/** Read an internal flag from the raw connection state. */
+export function getConnectionFlag(
+  connection: Connection,
+  key: string
+): unknown {
+  ensureConnectionWrapped(connection);
+  return rawStateAccessors.get(connection)!.getRaw()?.[key];
+}
+
+/**
+ * Write an internal flag to the raw connection state. `undefined` removes
+ * the key rather than storing a dead value; the last key removed leaves
+ * `null`.
+ */
+export function setConnectionFlag(
+  connection: Connection,
+  key: string,
+  value: unknown
+): void {
+  ensureConnectionWrapped(connection);
+  const accessors = rawStateAccessors.get(connection)!;
+  const raw = accessors.getRaw() ?? {};
+  if (value === undefined) {
+    const { [key]: _, ...rest } = raw;
+    accessors.setRaw(Object.keys(rest).length > 0 ? rest : null);
+  } else {
+    accessors.setRaw({ ...raw, [key]: value });
+  }
+}
+
+export function isConnectionReadonly(connection: Connection): boolean {
+  return !!getConnectionFlag(connection, CF_READONLY_KEY);
+}
+
+export function setConnectionReadonly(
+  connection: Connection,
+  readonly: boolean
+): void {
+  setConnectionFlag(connection, CF_READONLY_KEY, readonly ? true : undefined);
+}
+
+export function isConnectionProtocolEnabled(connection: Connection): boolean {
+  return !getConnectionFlag(connection, CF_NO_PROTOCOL_KEY);
+}
+
+export function setConnectionProtocolEnabled(
+  connection: Connection,
+  enabled: boolean
+): void {
+  setConnectionFlag(connection, CF_NO_PROTOCOL_KEY, enabled ? undefined : true);
+}

--- a/packages/agents/src/websockets/index.ts
+++ b/packages/agents/src/websockets/index.ts
@@ -7,6 +7,7 @@
  */
 export { WebSockets } from "./websockets";
 export type {
+  SyncedState,
   WebSocketHandlers,
   WebSocketMessage,
   WebSocketsOptions

--- a/packages/agents/src/websockets/index.ts
+++ b/packages/agents/src/websockets/index.ts
@@ -6,6 +6,11 @@
  * @experimental The WebSockets surface may change before stabilizing.
  */
 export { WebSockets } from "./websockets";
+export {
+  CF_NO_PROTOCOL_KEY,
+  CF_READONLY_KEY,
+  registerInternalConnectionKeys
+} from "./connection-flags";
 export type {
   SyncedState,
   WebSocketHandlers,

--- a/packages/agents/src/websockets/options.ts
+++ b/packages/agents/src/websockets/options.ts
@@ -1,4 +1,5 @@
 import type { RpcTarget } from "cloudflare:workers";
+import type { State } from "../state";
 import type { Connection, ConnectionContext, WSMessage } from "../lifecycle";
 
 /** A frame delivered on a capability-owned WebSocket connection. */
@@ -64,6 +65,17 @@ export interface WebSocketsOptions {
    * Defaults to `true`. `Agent` sends its own identity and passes `false`.
    */
   readonly identity?: boolean;
+
+  /**
+   * A {@link State} capability to sync over connections. The WebSockets
+   * capability then pushes the current state to each new connection,
+   * applies `cf_agent_state` frames a client sends (answering
+   * `cf_agent_state_error` when the host rejects one), and broadcasts
+   * every change to the other connections. Install the same instance on
+   * the lifecycle so it owns storage and validation; without this option
+   * state is never sent or accepted over connections.
+   */
+  readonly state?: State<unknown>;
 
   /**
    * Tags attached to each accepted connection, queryable through

--- a/packages/agents/src/websockets/options.ts
+++ b/packages/agents/src/websockets/options.ts
@@ -1,6 +1,17 @@
 import type { RpcTarget } from "cloudflare:workers";
-import type { State } from "../state";
 import type { Connection, ConnectionContext, WSMessage } from "../lifecycle";
+
+/**
+ * The part of a `State` capability the WebSockets capability uses. A
+ * structural port, so any `State<T>` fits without a cast and the
+ * capability never depends on the class itself.
+ */
+export type SyncedState = {
+  /** Current state, or `undefined` when nothing is stored. */
+  get(): unknown;
+  /** Validate and persist a change; throws when the host rejects it. */
+  set(nextState: never, source: Connection): void;
+};
 
 /** A frame delivered on a capability-owned WebSocket connection. */
 export type WebSocketMessage = WSMessage;
@@ -67,7 +78,8 @@ export interface WebSocketsOptions {
   readonly identity?: boolean;
 
   /**
-   * A {@link State} capability to sync over connections. The WebSockets
+   * A {@link SyncedState} — normally a `State` capability — to sync over
+   * connections. The WebSockets
    * capability then pushes the current state to each new connection,
    * applies `cf_agent_state` frames a client sends (answering
    * `cf_agent_state_error` when the host rejects one), and broadcasts
@@ -75,7 +87,7 @@ export interface WebSocketsOptions {
    * the lifecycle so it owns storage and validation; without this option
    * state is never sent or accepted over connections.
    */
-  readonly state?: State<unknown>;
+  readonly state?: SyncedState;
 
   /**
    * Tags attached to each accepted connection, queryable through

--- a/packages/agents/src/websockets/options.ts
+++ b/packages/agents/src/websockets/options.ts
@@ -71,19 +71,43 @@ export interface WebSocketsOptions {
   readonly callables?: RpcTarget;
 
   /**
-   * Send the identity frame (`cf_agent_identity`) to each new connection,
-   * so `useAgent` and `AgentClient` resolve `ready` against this host.
-   * Defaults to `true`. `Agent` sends its own identity and passes `false`.
+   * Whether a new connection gets the connect-time protocol frames —
+   * identity (`cf_agent_identity`), then the current state when `state`
+   * is set — and whether protocol frames reach it at all.
+   *
+   * - `true` (default): every connection.
+   * - a function: decided per connection at accept time. `false` marks
+   *   the connection no-protocol: it gets no protocol text frames, on
+   *   connect or via `broadcastState()`, but can still send and receive
+   *   ordinary messages and use callables. For binary-only clients.
+   * - `false`: the host drives the connect sequence itself with
+   *   `sendIdentity()` and `sendState()`, and applies client state frames
+   *   with `applyStateFrame()` — `Agent` does this, since it must decide
+   *   whether a connection belongs to a facet before any frame is sent.
    */
-  readonly identity?: boolean;
+  readonly protocol?:
+    | boolean
+    | ((connection: Connection, ctx: ConnectionContext) => boolean);
+
+  /**
+   * Decide at accept time whether a connection is readonly. A readonly
+   * connection's `cf_agent_state` frames are refused with
+   * `cf_agent_state_error`; everything else works. Also settable later
+   * with `setReadonly()`.
+   */
+  readonly readonly?: (
+    connection: Connection,
+    ctx: ConnectionContext
+  ) => boolean;
 
   /**
    * A {@link SyncedState} — normally a `State` capability — to sync over
-   * connections. The WebSockets
-   * capability then pushes the current state to each new connection,
-   * applies `cf_agent_state` frames a client sends (answering
-   * `cf_agent_state_error` when the host rejects one), and broadcasts
-   * every change to the other connections. Install the same instance on
+   * connections. The capability pushes the current value to each new
+   * connection after identity and applies `cf_agent_state` frames a
+   * client sends: a readonly connection is refused, and a change the
+   * host's validator rejects is answered with `cf_agent_state_error`.
+   * Broadcasting a change is the state owner's call — wire the `State`'s
+   * `onChanged` to `broadcastState(source)`. Install the same instance on
    * the lifecycle so it owns storage and validation; without this option
    * state is never sent or accepted over connections.
    */

--- a/packages/agents/src/websockets/websockets.ts
+++ b/packages/agents/src/websockets/websockets.ts
@@ -311,10 +311,18 @@ export class WebSockets extends LifecycleCapability {
     if (
       this.#state &&
       this.#protocol !== false &&
-      typeof message === "string" &&
-      this.applyStateFrame(connection, parseJson(message))
+      typeof message === "string"
     ) {
-      return;
+      const frame = parseJson(message);
+      if (isStateFrame(frame)) {
+        // Inside the host boundary, so the host's validator and change
+        // hook see the sending connection through the ambient context.
+        await this.lifecycle.runInHostContext(
+          () => this.applyStateFrame(connection, frame),
+          { connection }
+        );
+        return;
+      }
     }
     if (
       this.#callables.size > 0 &&
@@ -423,13 +431,24 @@ export class WebSockets extends LifecycleCapability {
   // connect sequence and consumes state frames itself; with
   // `protocol: false` the host calls these at the moments it chooses.
 
-  /** Send the identity frame, unless the connection is no-protocol. */
-  sendIdentity(connection: Connection): void {
+  /**
+   * Send the identity frame, unless the connection is no-protocol. The
+   * defaults are the Durable Object's routed name and host class; a host
+   * whose public identity differs — an `Agent` facet, whose routed name
+   * is an internal encoding of its logical name — passes its own.
+   */
+  sendIdentity(
+    connection: Connection,
+    identity: { name: string; agent: string } = {
+      name: this.lifecycle.name,
+      agent: camelCaseToKebabCase(this.lifecycle.className)
+    }
+  ): void {
     if (!isConnectionProtocolEnabled(connection)) return;
     this.#sendFrame(connection, {
       type: MessageType.CF_AGENT_IDENTITY,
-      name: this.lifecycle.name,
-      agent: camelCaseToKebabCase(this.lifecycle.className)
+      name: identity.name,
+      agent: identity.agent
     });
   }
 
@@ -453,7 +472,9 @@ export class WebSockets extends LifecycleCapability {
    * connection is refused; a change the host's validator rejects is
    * logged in full server-side and answered with a generic
    * `cf_agent_state_error`. Broadcasting the accepted change is the state
-   * owner's call, through its `onChanged` hook.
+   * owner's call, through its `onChanged` hook. Callers that drive the
+   * protocol themselves call this inside their own invocation context;
+   * the capability's automatic path does so via `runInHostContext`.
    *
    * @returns Whether the frame was a state frame (handled either way).
    */

--- a/packages/agents/src/websockets/websockets.ts
+++ b/packages/agents/src/websockets/websockets.ts
@@ -426,15 +426,28 @@ export class WebSockets extends LifecycleCapability {
     if (current === undefined) return;
     const frame = { type: MessageType.CF_AGENT_STATE, state: current };
     for (const connection of this.getConnections()) {
-      if (connection.id === except?.id) continue;
+      // Object identity, not id: `_pk` is client-supplied, so two live
+      // sockets can share an id and excluding by id would starve the
+      // other one. `createConnection` returns the same wrapper for a
+      // socket, so the sender compares equal here.
+      if (connection === except) continue;
       this.#sendFrame(connection, frame);
     }
   }
 
-  /** Send one protocol frame, tolerating a peer that just disconnected. */
+  /**
+   * Send one protocol frame. Serialization is the caller's contract — every
+   * frame built here is plain JSON — while a send failure is tolerated: the
+   * peer may have disconnected between the wake and the send.
+   */
   #sendFrame(connection: Connection, frame: Record<string, unknown>): void {
+    this.#send(connection, JSON.stringify(frame));
+  }
+
+  /** Write one already-serialized frame, tolerating a closed peer. */
+  #send(connection: Connection, text: string): void {
     try {
-      connection.send(JSON.stringify(frame));
+      connection.send(text);
     } catch {
       // The socket closed between the wake and the send.
     }
@@ -558,11 +571,7 @@ export class WebSockets extends LifecycleCapability {
         }`
       } satisfies RpcResponse);
     }
-    try {
-      connection.send(text);
-    } catch {
-      // The peer disconnected while the callable was running.
-    }
+    this.#send(connection, text);
   }
 
   async #dispatchCallable(

--- a/packages/agents/src/websockets/websockets.ts
+++ b/packages/agents/src/websockets/websockets.ts
@@ -8,6 +8,7 @@ import {
   type ConnectionSetStateFn,
   type ConnectionState
 } from "../lifecycle";
+import type { State } from "../state";
 import { MessageType } from "../types";
 import { camelCaseToKebabCase } from "../utils";
 import {
@@ -62,6 +63,15 @@ type RpcResponse =
   | { type: "rpc"; id: string; success: true; done: boolean; result: unknown }
   | { type: "rpc"; id: string; success: false; error: string };
 
+/** The `cf_agent_state` frame a client sends to update host state. */
+type StateFrame = { readonly type: "cf_agent_state"; readonly state: unknown };
+
+function isStateFrame(value: unknown): value is StateFrame {
+  if (typeof value !== "object" || value === null) return false;
+  const frame = value as Record<string, unknown>;
+  return frame.type === MessageType.CF_AGENT_STATE && "state" in frame;
+}
+
 function isRpcRequest(value: unknown): value is RpcRequest {
   if (typeof value !== "object" || value === null) return false;
   const frame = value as Record<string, unknown>;
@@ -111,7 +121,9 @@ function isRpcRequest(value: unknown): value is RpcRequest {
  * WebSocket wire, and natively on the Cap'n Web session root, where an
  * `RpcTarget` result becomes a live stub and calls pipeline. `call()`
  * and `stub` work against a plain Durable Object exactly as against an
- * `Agent`.
+ * `Agent`. Pass a `State` capability as `state` and the hook's
+ * `state`/`setState` work too: the current value is pushed on connect,
+ * client updates are validated and applied, and changes broadcast.
  *
  * @experimental The API surface may change before stabilizing.
  */
@@ -122,6 +134,7 @@ export class WebSockets extends LifecycleCapability {
   readonly #handlers: WebSocketHandlers | undefined;
   readonly #getConnectionTags: WebSocketsOptions["getConnectionTags"];
   readonly #identity: boolean;
+  readonly #state: State<unknown> | undefined;
   readonly #callables: ReadonlyMap<string, CallableInvoker>;
   readonly #sessions = new Map<string, CapnWebSession>();
   #manager: ConnectionManager | undefined;
@@ -131,6 +144,7 @@ export class WebSockets extends LifecycleCapability {
     this.#handlers = options.handlers;
     this.#getConnectionTags = options.getConnectionTags;
     this.#identity = options.identity ?? true;
+    this.#state = options.state;
     this.#callables = options.callables
       ? exposableMethods(options.callables)
       : new Map();
@@ -236,13 +250,23 @@ export class WebSockets extends LifecycleCapability {
     ctx: ConnectionContext
   ): Promise<void> {
     if (this.#identity) {
-      connection.send(
-        JSON.stringify({
-          type: MessageType.CF_AGENT_IDENTITY,
-          name: this.lifecycle.name,
-          agent: camelCaseToKebabCase(this.lifecycle.className)
-        })
-      );
+      this.#sendFrame(connection, {
+        type: MessageType.CF_AGENT_IDENTITY,
+        name: this.lifecycle.name,
+        agent: camelCaseToKebabCase(this.lifecycle.className)
+      });
+    }
+    if (this.#state) {
+      // After identity, so a client that resolves `ready` on identity has
+      // the state by the time it renders. Absent state sends nothing; the
+      // client keeps whatever default it started with.
+      const current = this.#state.get();
+      if (current !== undefined) {
+        this.#sendFrame(connection, {
+          type: MessageType.CF_AGENT_STATE,
+          state: current
+        });
+      }
     }
     await this.lifecycle.runInHostContext(
       () => this.#handlers?.onConnect?.(connection, ctx),
@@ -254,6 +278,7 @@ export class WebSockets extends LifecycleCapability {
     connection: Connection,
     message: WebSocketMessage
   ): Promise<void> {
+    if (this.#state && this.#applyStateFrame(connection, message)) return;
     if (
       this.#callables.size > 0 &&
       (await this.#answerRpc(connection, message))
@@ -352,6 +377,67 @@ export class WebSockets extends LifecycleCapability {
       }
     });
     return response;
+  }
+
+  // ── State ──────────────────────────────────────────────────────────────
+
+  /**
+   * Apply a client's `cf_agent_state` frame to the State capability and
+   * broadcast the result to the other connections. The host's own
+   * `validateStateChange` decides whether the change is allowed; a throw
+   * answers the sender with `cf_agent_state_error` and changes nothing.
+   *
+   * @returns Whether the message was a state frame.
+   */
+  #applyStateFrame(connection: Connection, raw: WebSocketMessage): boolean {
+    if (typeof raw !== "string") return false;
+    let frame: unknown;
+    try {
+      frame = JSON.parse(raw);
+    } catch {
+      return false;
+    }
+    if (!isStateFrame(frame)) return false;
+    try {
+      // `set()` runs the host's validation and persists; the source is this
+      // connection, so the broadcast below excludes it — it already has
+      // the value it sent.
+      this.#state?.set(frame.state, connection);
+    } catch (error) {
+      this.#sendFrame(connection, {
+        type: MessageType.CF_AGENT_STATE_ERROR,
+        error: error instanceof Error ? error.message : String(error)
+      });
+      return true;
+    }
+    this.broadcastState(connection);
+    return true;
+  }
+
+  /**
+   * Push the current state to every connection, optionally excluding the
+   * one a change came from. Hosts call this after their own `setState`
+   * when they want connections to see it; a change arriving from a client
+   * is broadcast automatically.
+   */
+  broadcastState(except?: Connection): void {
+    if (!this.#state) return;
+    const current = this.#state.get();
+    if (current === undefined) return;
+    const frame = { type: MessageType.CF_AGENT_STATE, state: current };
+    for (const connection of this.getConnections()) {
+      if (connection.id === except?.id) continue;
+      this.#sendFrame(connection, frame);
+    }
+  }
+
+  /** Send one protocol frame, tolerating a peer that just disconnected. */
+  #sendFrame(connection: Connection, frame: Record<string, unknown>): void {
+    try {
+      connection.send(JSON.stringify(frame));
+    } catch {
+      // The socket closed between the wake and the send.
+    }
   }
 
   // ── Callables ──────────────────────────────────────────────────────────

--- a/packages/agents/src/websockets/websockets.ts
+++ b/packages/agents/src/websockets/websockets.ts
@@ -15,6 +15,13 @@ import {
   createConnection,
   isManagedWebSocket
 } from "./connection";
+import {
+  ensureConnectionWrapped,
+  isConnectionProtocolEnabled,
+  isConnectionReadonly,
+  setConnectionProtocolEnabled,
+  setConnectionReadonly
+} from "./connection-flags";
 import { exposableMethods, type CallableInvoker } from "./callables-target";
 import type {
   SyncedState,
@@ -72,6 +79,15 @@ function isStateFrame(value: unknown): value is StateFrame {
   return frame.type === MessageType.CF_AGENT_STATE && "state" in frame;
 }
 
+/** Parse a text frame; anything that is not JSON is `undefined`. */
+function parseJson(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
 function isRpcRequest(value: unknown): value is RpcRequest {
   if (typeof value !== "object" || value === null) return false;
   const frame = value as Record<string, unknown>;
@@ -122,8 +138,10 @@ function isRpcRequest(value: unknown): value is RpcRequest {
  * `RpcTarget` result becomes a live stub and calls pipeline. `call()`
  * and `stub` work against a plain Durable Object exactly as against an
  * `Agent`. Pass a `State` capability as `state` and the hook's
- * `state`/`setState` work too: the current value is pushed on connect,
- * client updates are validated and applied, and changes broadcast.
+ * `state`/`setState` work too: the current value is pushed on connect
+ * and client updates are validated and applied; the state owner
+ * broadcasts changes with `broadcastState()`. Per-connection readonly
+ * and no-protocol flags live here as well, for every host.
  *
  * @experimental The API surface may change before stabilizing.
  */
@@ -133,8 +151,16 @@ export class WebSockets extends LifecycleCapability {
 
   readonly #handlers: WebSocketHandlers | undefined;
   readonly #getConnectionTags: WebSocketsOptions["getConnectionTags"];
-  readonly #identity: boolean;
+  readonly #protocol: WebSocketsOptions["protocol"];
+  readonly #readonly: WebSocketsOptions["readonly"];
   readonly #state: SyncedState | undefined;
+  /**
+   * Connections inside their connect sequence, before the state push.
+   * `broadcastState()` skips them: reading state for the push can seed the
+   * initial value, whose change broadcast would otherwise reach a
+   * connection that is about to receive the same value directly.
+   */
+  readonly #connecting = new Set<Connection>();
   readonly #callables: ReadonlyMap<string, CallableInvoker>;
   readonly #sessions = new Map<string, CapnWebSession>();
   #manager: ConnectionManager | undefined;
@@ -143,7 +169,8 @@ export class WebSockets extends LifecycleCapability {
     super("websockets");
     this.#handlers = options.handlers;
     this.#getConnectionTags = options.getConnectionTags;
-    this.#identity = options.identity ?? true;
+    this.#protocol = options.protocol ?? true;
+    this.#readonly = options.readonly;
     this.#state = options.state;
     this.#callables = options.callables
       ? exposableMethods(options.callables)
@@ -249,23 +276,26 @@ export class WebSockets extends LifecycleCapability {
     connection: Connection,
     ctx: ConnectionContext
   ): Promise<void> {
-    if (this.#identity) {
-      this.#sendFrame(connection, {
-        type: MessageType.CF_AGENT_IDENTITY,
-        name: this.lifecycle.name,
-        agent: camelCaseToKebabCase(this.lifecycle.className)
-      });
+    ensureConnectionWrapped(connection);
+    // Flags first, so they are set before the client can respond.
+    if (this.#readonly?.(connection, ctx)) {
+      setConnectionReadonly(connection, true);
     }
-    if (this.#state) {
-      // After identity, so a client that resolves `ready` on identity has
-      // the state by the time it renders. Absent state sends nothing; the
-      // client keeps whatever default it started with.
-      const current = this.#state.get();
-      if (current !== undefined) {
-        this.#sendFrame(connection, {
-          type: MessageType.CF_AGENT_STATE,
-          state: current
-        });
+    if (this.#protocol !== false) {
+      const enabled =
+        typeof this.#protocol === "function"
+          ? this.#protocol(connection, ctx)
+          : true;
+      if (enabled) {
+        this.#connecting.add(connection);
+        try {
+          this.sendIdentity(connection);
+          this.sendState(connection);
+        } finally {
+          this.#connecting.delete(connection);
+        }
+      } else {
+        setConnectionProtocolEnabled(connection, false);
       }
     }
     await this.lifecycle.runInHostContext(
@@ -278,7 +308,14 @@ export class WebSockets extends LifecycleCapability {
     connection: Connection,
     message: WebSocketMessage
   ): Promise<void> {
-    if (this.#state && this.#applyStateFrame(connection, message)) return;
+    if (
+      this.#state &&
+      this.#protocol !== false &&
+      typeof message === "string" &&
+      this.applyStateFrame(connection, parseJson(message))
+    ) {
+      return;
+    }
     if (
       this.#callables.size > 0 &&
       (await this.#answerRpc(connection, message))
@@ -379,62 +416,111 @@ export class WebSockets extends LifecycleCapability {
     return response;
   }
 
-  // ── State ──────────────────────────────────────────────────────────────
+  // ── Protocol frames ────────────────────────────────────────────────────
+  //
+  // The Agent protocol a client (`useAgent`, `AgentClient`) speaks, owned
+  // here for every host. With `protocol: true` the capability drives the
+  // connect sequence and consumes state frames itself; with
+  // `protocol: false` the host calls these at the moments it chooses.
+
+  /** Send the identity frame, unless the connection is no-protocol. */
+  sendIdentity(connection: Connection): void {
+    if (!isConnectionProtocolEnabled(connection)) return;
+    this.#sendFrame(connection, {
+      type: MessageType.CF_AGENT_IDENTITY,
+      name: this.lifecycle.name,
+      agent: camelCaseToKebabCase(this.lifecycle.className)
+    });
+  }
 
   /**
-   * Apply a client's `cf_agent_state` frame to the State capability and
-   * broadcast the result to the other connections. The host's own
-   * `validateStateChange` decides whether the change is allowed; a throw
-   * answers the sender with `cf_agent_state_error` and changes nothing.
-   *
-   * @returns Whether the message was a state frame.
+   * Send the current state to one connection, unless nothing is stored
+   * or the connection is no-protocol. Reading the state may seed the
+   * initial value; see `#connecting`.
    */
-  #applyStateFrame(connection: Connection, raw: WebSocketMessage): boolean {
-    if (typeof raw !== "string") return false;
-    let frame: unknown;
-    try {
-      frame = JSON.parse(raw);
-    } catch {
-      return false;
-    }
-    if (!isStateFrame(frame)) return false;
-    try {
-      // `set()` runs the host's validation and persists; the source is this
-      // connection, so the broadcast below excludes it — it already has
-      // the value it sent.
-      // `never` on the port keeps any `State<T>` assignable; the value
-      // came off the wire, so the host's validator is what checks it.
-      this.#state?.set(frame.state as never, connection);
-    } catch (error) {
+  sendState(connection: Connection): void {
+    if (!this.#state || !isConnectionProtocolEnabled(connection)) return;
+    const current = this.#state.get();
+    if (current === undefined) return;
+    this.#sendFrame(connection, {
+      type: MessageType.CF_AGENT_STATE,
+      state: current
+    });
+  }
+
+  /**
+   * Apply a parsed `cf_agent_state` frame from a client. A readonly
+   * connection is refused; a change the host's validator rejects is
+   * logged in full server-side and answered with a generic
+   * `cf_agent_state_error`. Broadcasting the accepted change is the state
+   * owner's call, through its `onChanged` hook.
+   *
+   * @returns Whether the frame was a state frame (handled either way).
+   */
+  applyStateFrame(connection: Connection, frame: unknown): boolean {
+    if (!this.#state || !isStateFrame(frame)) return false;
+    if (isConnectionReadonly(connection)) {
       this.#sendFrame(connection, {
         type: MessageType.CF_AGENT_STATE_ERROR,
-        error: error instanceof Error ? error.message : String(error)
+        error: "Connection is readonly"
       });
       return true;
     }
-    this.broadcastState(connection);
+    try {
+      // `never` on the port keeps any `State<T>` assignable; the value
+      // came off the wire, so the host's validator is what checks it.
+      this.#state.set(frame.state as never, connection);
+    } catch (error) {
+      console.error("[WebSockets] State update rejected:", error);
+      this.#sendFrame(connection, {
+        type: MessageType.CF_AGENT_STATE_ERROR,
+        error: "State update rejected"
+      });
+    }
     return true;
   }
 
   /**
-   * Push the current state to every connection, optionally excluding the
-   * one a change came from. Hosts call this after their own `setState`
-   * when they want connections to see it; a change arriving from a client
-   * is broadcast automatically.
+   * Push the current state to every protocol-enabled connection except
+   * the one a change came from, which already has the value it sent.
+   * Wire a `State`'s `onChanged` to this.
    */
-  broadcastState(except?: Connection): void {
+  broadcastState(except?: Connection | "server"): void {
     if (!this.#state) return;
     const current = this.#state.get();
     if (current === undefined) return;
     const frame = { type: MessageType.CF_AGENT_STATE, state: current };
     for (const connection of this.getConnections()) {
       // Object identity, not id: `_pk` is client-supplied, so two live
-      // sockets can share an id and excluding by id would starve the
-      // other one. `createConnection` returns the same wrapper for a
-      // socket, so the sender compares equal here.
+      // sockets can share an id, and excluding by id would starve the
+      // other one. `createConnection` returns one wrapper per socket.
       if (connection === except) continue;
+      if (this.#connecting.has(connection)) continue;
+      if (!isConnectionProtocolEnabled(connection)) continue;
       this.#sendFrame(connection, frame);
     }
+  }
+
+  // ── Connection flags ───────────────────────────────────────────────────
+
+  /** Whether the connection may update host state over the wire. */
+  isReadonly(connection: Connection): boolean {
+    return isConnectionReadonly(connection);
+  }
+
+  /** Mark a connection readonly, or writable again. */
+  setReadonly(connection: Connection, readonly = true): void {
+    setConnectionReadonly(connection, readonly);
+  }
+
+  /** Whether protocol text frames reach the connection. */
+  isProtocolEnabled(connection: Connection): boolean {
+    return isConnectionProtocolEnabled(connection);
+  }
+
+  /** Enable or suppress protocol text frames for a connection. */
+  setProtocolEnabled(connection: Connection, enabled: boolean): void {
+    setConnectionProtocolEnabled(connection, enabled);
   }
 
   /**

--- a/packages/agents/src/websockets/websockets.ts
+++ b/packages/agents/src/websockets/websockets.ts
@@ -8,7 +8,6 @@ import {
   type ConnectionSetStateFn,
   type ConnectionState
 } from "../lifecycle";
-import type { State } from "../state";
 import { MessageType } from "../types";
 import { camelCaseToKebabCase } from "../utils";
 import {
@@ -18,6 +17,7 @@ import {
 } from "./connection";
 import { exposableMethods, type CallableInvoker } from "./callables-target";
 import type {
+  SyncedState,
   WebSocketHandlers,
   WebSocketMessage,
   WebSocketsOptions
@@ -134,7 +134,7 @@ export class WebSockets extends LifecycleCapability {
   readonly #handlers: WebSocketHandlers | undefined;
   readonly #getConnectionTags: WebSocketsOptions["getConnectionTags"];
   readonly #identity: boolean;
-  readonly #state: State<unknown> | undefined;
+  readonly #state: SyncedState | undefined;
   readonly #callables: ReadonlyMap<string, CallableInvoker>;
   readonly #sessions = new Map<string, CapnWebSession>();
   #manager: ConnectionManager | undefined;
@@ -402,7 +402,9 @@ export class WebSockets extends LifecycleCapability {
       // `set()` runs the host's validation and persists; the source is this
       // connection, so the broadcast below excludes it — it already has
       // the value it sent.
-      this.#state?.set(frame.state, connection);
+      // `never` on the port keeps any `State<T>` assignable; the value
+      // came off the wire, so the host's validator is what checks it.
+      this.#state?.set(frame.state as never, connection);
     } catch (error) {
       this.#sendFrame(connection, {
         type: MessageType.CF_AGENT_STATE_ERROR,


### PR DESCRIPTION
## What

Completes the plain-host story from #2249 by **moving** the Agent protocol's state sync and per-connection flags out of `Agent` and into the `WebSockets` capability, so a plain `DurableObject` gets `useAgent().state` / `setState()` and `Agent` keeps its exact behaviour by delegating.

```ts
export class Counter extends DurableObject<Env> {
  readonly state = new State({
    initialState: { count: 0 },
    onChanged: (_state, source) => this.webSockets.broadcastState(source)
  });
  readonly webSockets = new WebSockets({ state: this.state });
  readonly lifecycle = Lifecycle.install(this).use(this.state).use(this.webSockets);
}
```

**Moved into `agents/websockets`, unchanged in behaviour**

- The readonly and no-protocol flags, their `_cf_` storage inside connection state, and the wrapper that hides them from `connection.state` and preserves them across `setState` (`websockets/connection-flags.ts`). Hosts and mixins register their own keys with `registerInternalConnectionKeys`.
- The connect-time identity and state frames (`sendIdentity()`, `sendState()`).
- A client's `cf_agent_state` frame: readonly refusal with `"Connection is readonly"`, the host's `validateStateChange` as the gate, full error logged server-side, generic `"State update rejected"` to the client (`applyStateFrame()`).
- Protocol-aware broadcast: `broadcastState(source)` reaches every protocol-enabled connection except the source, and skips a connection whose connect sequence is mid-flight so the initial-state seed cannot double-deliver.

**`Agent`**: `isConnectionReadonly`, `setConnectionReadonly`, `isConnectionProtocolEnabled`, `_unsafe_get/setConnectionFlag` delegate to the module. It passes `protocol: false` and calls `sendIdentity()`/`sendState()` at the same point in its `onConnect` wrapper as before, after the facet routing decision; `shouldConnectionBeReadonly` and `shouldSendProtocolMessages` are unchanged. `dynamic-agents` uses the module instead of host internals. No public method, override point, or wire frame changes for Agent or Think users.

**Plain hosts**: `protocol` (`true` | per-connection function | `false`) and `readonly` (per-connection function) are the accept-time policies; `isReadonly`/`setReadonly`, `isProtocolEnabled`/`setProtocolEnabled` flip them later. The `identity` option from #2249's changeset is replaced by `protocol`. `state` is a structural port, so any `State<T>` fits without a cast.

## Test plan

- [x] Workers project: 125 files, 1941 tests. The suites that pin Agent's wire behaviour — `readonly-connections`, `protocol-messages`, `state`, `spike-sub-agent-routing`, `dynamic-agents`, `capnweb-transport` — are untouched and pass.
- [x] New plain-host coverage on `StatefulPlainObject`: push after identity, client update with broadcast exclusion by object identity (including two sockets sharing a `_pk`), generic rejection reply, host-side broadcast via `onChanged`, readonly refusal and later flip, no-protocol connections receiving nothing on connect or broadcast, and the Cap'n Web wire.
- [x] React suites (71), Think workers suite, websockets example (6).
- [x] `sherif`, `oxlint`, `oxfmt --check .`, root typecheck (122 projects) clean.
